### PR TITLE
Allow Zlib license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,7 @@ allow = [
   "Apache-2.0 WITH LLVM-exception",
   "BSD-3-Clause",
   "ISC",
+  "Zlib",
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
Required by [slotmap](https://docs.rs/slotmap/1.0.5/slotmap/) crate.