### PR TITLE
use winrust self-hosted runner to execute windows's tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: [self-hosted, winrust]
             container: ghcr.io/legion-labs/build-env-win-rust:0.1.0
             workdir: C:\github\workspace
           - os: [self-hosted, ubuntu]
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: [self-hosted, winrust]
             container: ghcr.io/legion-labs/build-env-win-rust:0.1.0
             workdir: C:\github\workspace
           - os: [self-hosted, ubuntu]


### PR DESCRIPTION
Replacing the github managed windows-2019 runner by legion-labs self-hosted windows runner.