### PR TITLE
Editor client: Simple logging system (#599)

### DIFF
--- a/client/editor-svelte/frontend/.eslintrc.js
+++ b/client/editor-svelte/frontend/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     "svelte3/ignore-styles": () => true,
   },
   rules: {
-    "no-console": "off",
+    "no-console": "error",
     "@typescript-eslint/no-unused-vars": "off",
   },
 };

--- a/client/editor-svelte/frontend/src/actions/videoPlayer.ts
+++ b/client/editor-svelte/frontend/src/actions/videoPlayer.ts
@@ -1,4 +1,5 @@
 import { onVideoChunkReceived, onVideoClose } from "@/api";
+import log from "@/lib/log";
 
 type Source = MediaSource | SourceBuffer | HTMLVideoElement;
 
@@ -38,7 +39,7 @@ export default function videoPlayer(
     videoElement.load();
 
     addListener(videoElement, "error", () => {
-      console.error(videoElement.error?.message);
+      log.error("video", videoElement.error?.message);
     });
 
     addListener(mediaSource, "sourceopen", () => {
@@ -63,7 +64,7 @@ export default function videoPlayer(
           videoSource.appendBuffer(frame);
         }
       } catch (error) {
-        console.warn(error);
+        log.error("video", error);
         destroy();
         options?.onFatal && options.onFatal();
       }

--- a/client/editor-svelte/frontend/src/components/TopBar.svelte
+++ b/client/editor-svelte/frontend/src/components/TopBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import clickOutside from "@/actions/clickOutside";
+  import log from "@/lib/log";
   import {
     default as topBarMenu,
     Id as TopBarMenuId,
@@ -19,10 +20,10 @@
     $topBarMenu ? topBarMenu.close() : topBarMenu.set(id);
   };
 
-  const onMenuItemClick = () => {
+  const onMenuItemClick = (title: string) => {
+    log.debug("layout:topbar", `Clicked on item ${title}`);
     // When a user clicks on a menu dropdown item, we just close the menu
     topBarMenu.close();
-    console.log("Executed");
   };
 
   const closeMenu = () => {
@@ -53,7 +54,10 @@
         >
           <div class="menu-dropdown-items">
             {#each [`Foo ${menu.title}`, `Bar ${menu.title}`, `Baz ${menu.title}`] as menuItemTitle}
-              <div class="menu-dropdown-item" on:click={onMenuItemClick}>
+              <div
+                class="menu-dropdown-item"
+                on:click={() => onMenuItemClick(menu.title)}
+              >
                 {menuItemTitle}
               </div>
             {/each}

--- a/client/editor-svelte/frontend/src/index.ts
+++ b/client/editor-svelte/frontend/src/index.ts
@@ -1,6 +1,15 @@
 import "./assets/index.css";
 
+import log, { Level } from "@/lib/log";
 import App from "./App.svelte";
+
+// TODO: Set level from configuration file
+const logLevel: Level = "debug";
+
+if (logLevel) {
+  log.init();
+  log.set(logLevel);
+}
 
 const target = document.querySelector("#root");
 

--- a/client/editor-svelte/frontend/src/lib/log.ts
+++ b/client/editor-svelte/frontend/src/lib/log.ts
@@ -1,0 +1,140 @@
+/**
+ * Poor man, dead simple, log module.
+ * Exposes functions to set the log level and to log to the browser console.
+ *
+ * The logger easily allows for log filtering by level and namespace(s).
+ *
+ * Doesn't sync with any API.
+ */
+
+export type Level = "error" | "warn" | "info" | "debug" | "trace";
+
+const levels: Level[] = ["error", "warn", "info", "debug", "trace"];
+
+function levelColor(level: Level) {
+  switch (level) {
+    case "error":
+      return "red";
+    case "warn":
+      return "orange";
+    case "info":
+      return "skyblue";
+    case "debug":
+      return "gray";
+    case "trace":
+      return "black";
+  }
+}
+
+function levelPriority(level: Level) {
+  switch (level) {
+    case "error":
+      return 0;
+    case "warn":
+      return 1;
+    case "info":
+      return 2;
+    case "debug":
+      return 3;
+    case "trace":
+      return 4;
+  }
+}
+
+// TODO: Sync with local storage
+declare global {
+  interface Window {
+    __LOG__: { level: Level; namespace: RegExp } | null;
+  }
+}
+
+const localStorageKey = "__LOG__";
+
+/** Inits the log system, should be called in the `index` */
+function init() {
+  try {
+    const log = localStorage.getItem(localStorageKey);
+    window.__LOG__ = log ? JSON.parse(log) : null;
+  } catch {
+    window.__LOG__ = null;
+  }
+}
+
+/** Set the log level and namespace to listen to */
+function set(level: Level, namespace = /.*/) {
+  const log = { level, namespace };
+
+  localStorage.setItem(localStorageKey, JSON.stringify(log));
+
+  window.__LOG__ = log;
+}
+
+/** Basically stop displaying any log */
+function hush() {
+  window.__LOG__ = null;
+
+  localStorage.removeItem(localStorageKey);
+}
+
+/** Log function that accepts a level, a message, and optionally a namespace to log into */
+function log(
+  level: Level,
+  ...args: [namespace: string, message: unknown] | [message: unknown]
+) {
+  if (!window.__LOG__) {
+    return;
+  }
+
+  const { level: requestedLevel, namespace: requestedNamespace } =
+    window.__LOG__;
+
+  const namespace = args.length === 2 ? args[0] : "";
+
+  const message = args.length === 2 ? args[1] : args[0];
+
+  if (
+    levelPriority(level) <= levelPriority(requestedLevel) &&
+    requestedNamespace?.test(namespace)
+  ) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[%c${new Date().toISOString()} %c${level.toUpperCase()}${
+        namespace === undefined ? "" : ` %c${namespace}`
+      }%c]`,
+      "color: purple",
+      `color: ${levelColor(level)}`,
+      "color: purple",
+      "color: black",
+      message
+    );
+  }
+}
+
+/** Automatically serializes templates' expressions using `JSON.stringify` */
+function json(stringParts: TemplateStringsArray, ...expressions: unknown[]) {
+  return stringParts.reduce(
+    (acc, part, index) =>
+      `${acc}${part}${
+        index === stringParts.length - 1
+          ? ""
+          : JSON.stringify(expressions[index])
+      }`,
+    ""
+  );
+}
+
+const loggers = levels.reduce(
+  (loggers, level) => ({
+    ...loggers,
+    [level]: (
+      ...args: [namespace: string, message: unknown] | [message: unknown]
+    ) => log(level, ...args),
+  }),
+  {} as {
+    [Key in Level]: (
+      ...args: [namespace: string, message: unknown] | [message: unknown]
+    ) => void;
+  }
+);
+
+export default { init, log, set, hush, json, ...loggers };


### PR DESCRIPTION
Very simple and rudimentary logging library. I couldn't find anything really simple that allows for filtering by level _and_ namespace/keywords so I made a really simple one.

The only inconvenience is the fact that we lose the call stack, but it's not really meant to be used when developing a feature. Also we can switch from `console.log` to `console.trace` to display the stack but it makes the logs rather hard to read.