### PR TITLE
Remove tracing dependency from legion-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,6 +3528,7 @@ version = "0.1.0"
 dependencies = [
  "legion-derive",
  "legion-ecs",
+ "legion-telemetry",
  "legion-transform",
  "legion-utils",
  "ron",
@@ -3771,6 +3772,7 @@ dependencies = [
  "fxhash",
  "legion-ecs-macros",
  "legion-tasks",
+ "legion-telemetry",
  "legion-utils",
  "parking_lot 0.11.2",
  "rand 0.8.4",
@@ -4215,7 +4217,6 @@ dependencies = [
  "serde",
  "siphasher",
  "toml",
- "tracing",
  "uuid",
 ]
 

--- a/lib/app/Cargo.toml
+++ b/lib/app/Cargo.toml
@@ -9,13 +9,13 @@ license = "MIT OR Apache-2.0"
 keywords = ["legion"]
 
 [features]
-trace = []
 legion_ci_testing = ["serde", "ron"]
 
 [dependencies]
 # legion
 legion-derive = { path = "../derive", version = "0.1.0" }
 legion-ecs = { path = "../ecs", version = "0.1.0" }
+legion-telemetry = { path = "../telemetry", version = "0.1.0" }
 legion-utils = { path = "../utils", version = "0.1.0" }
 
 # other

--- a/lib/app/src/app.rs
+++ b/lib/app/src/app.rs
@@ -9,9 +9,8 @@ use legion_ecs::{
     system::Resource,
     world::World,
 };
-use legion_utils::tracing::debug;
-#[cfg(feature = "trace")]
-use legion_utils::tracing::info_span;
+use legion_telemetry::trace_scope;
+use legion_utils::log::debug;
 
 use crate::{CoreStage, Events, Plugin, PluginGroup, PluginGroupBuilder, StartupStage};
 
@@ -78,10 +77,9 @@ impl App {
     ///
     /// See [`Schedule::run_once`] for more details.
     pub fn update(&mut self) {
-        #[cfg(feature = "trace")]
-        let legion_frame_update_span = info_span!("frame");
-        #[cfg(feature = "trace")]
-        let _legion_frame_update_guard = legion_frame_update_span.enter();
+        trace_scope!();
+        // let legion_frame_update_span = info_span!("frame");
+        // let _legion_frame_update_guard = legion_frame_update_span.enter();
         self.schedule.run(&mut self.world);
     }
 
@@ -90,10 +88,9 @@ impl App {
     /// Finalizes the [`App`] configuration. For general usage, see the example on the item
     /// level documentation.
     pub fn run(&mut self) {
-        #[cfg(feature = "trace")]
-        let legion_app_run_span = info_span!("legion_app");
-        #[cfg(feature = "trace")]
-        let _legion_app_run_guard = legion_app_run_span.enter();
+        trace_scope!();
+        // let legion_app_run_span = info_span!("legion_app");
+        // let _legion_app_run_guard = legion_app_run_span.enter();
 
         let mut app = std::mem::replace(self, Self::empty());
         let runner = std::mem::replace(&mut app.runner, Box::new(run_once));

--- a/lib/app/src/plugin_group.rs
+++ b/lib/app/src/plugin_group.rs
@@ -1,6 +1,6 @@
 use std::any::TypeId;
 
-use legion_utils::{tracing::debug, HashMap};
+use legion_utils::{log::debug, HashMap};
 
 use crate::{App, Plugin};
 

--- a/lib/ecs/Cargo.toml
+++ b/lib/ecs/Cargo.toml
@@ -9,13 +9,11 @@ license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "legion"]
 categories = ["game-engines", "data-structures"]
 
-[features]
-trace = []
-
 [dependencies]
-legion-tasks = { path = "../tasks", version = "0.1.0" }
-legion-utils = { path = "../utils", version = "0.1.0" }
 legion-ecs-macros = { path = "macros", version = "0.1.0" }
+legion-tasks = { path = "../tasks", version = "0.1.0" }
+legion-telemetry = { path = "../telemetry", version = "0.1.0" }
+legion-utils = { path = "../utils", version = "0.1.0" }
 
 async-channel = "1.6"
 fixedbitset = "0.4"

--- a/lib/ecs/src/event.rs
+++ b/lib/ecs/src/event.rs
@@ -6,7 +6,7 @@ use std::{
     marker::PhantomData,
 };
 
-use legion_utils::tracing::trace;
+use legion_utils::log::trace;
 
 use crate::system::{Local, Res, ResMut, SystemParam};
 use crate::{self as legion_ecs, system::Resource};

--- a/lib/ecs/src/schedule/executor.rs
+++ b/lib/ecs/src/schedule/executor.rs
@@ -1,4 +1,5 @@
 use downcast_rs::{impl_downcast, Downcast};
+use legion_telemetry::trace_scope;
 
 use crate::{archetype::ArchetypeGeneration, schedule::ParallelSystemContainer, world::World};
 
@@ -31,11 +32,10 @@ impl ParallelSystemExecutor for SingleThreadedExecutor {
 
         for system in systems {
             if system.should_run() {
-                #[cfg(feature = "trace")]
-                let system_span =
-                    legion_utils::tracing::info_span!("system", name = &*system.name());
-                #[cfg(feature = "trace")]
-                let _system_guard = system_span.enter();
+                // TODO: add system name to trace scope
+                trace_scope!();
+                // let system_span = info_span!("system", name = &*system.name());
+                // let _system_guard = system_span.enter();
                 system.system_mut().run((), world);
             }
         }

--- a/lib/ecs/src/schedule/executor_parallel.rs
+++ b/lib/ecs/src/schedule/executor_parallel.rs
@@ -1,6 +1,7 @@
 use async_channel::{Receiver, Sender};
 use fixedbitset::FixedBitSet;
 use legion_tasks::{ComputeTaskPool, Scope, TaskPool};
+use legion_telemetry::trace_scope;
 #[cfg(test)]
 use SchedulingEvent::StartedSystems;
 
@@ -187,16 +188,14 @@ impl ParallelExecutor {
                         .recv()
                         .await
                         .unwrap_or_else(|error| unreachable!(error));
-                    #[cfg(feature = "trace")]
-                    let system_span =
-                        legion_utils::tracing::info_span!("system", name = &*system.name());
-                    #[cfg(feature = "trace")]
-                    let system_guard = system_span.enter();
+                    // TODO: add system name to trace scope
+                    trace_scope!();
+                    // let system_span = info_span!("system", name = &*system.name());
+                    // let system_guard = system_span.enter();
                     unsafe {
                         system.run_unsafe((), world);
                     };
-                    #[cfg(feature = "trace")]
-                    drop(system_guard);
+                    // drop(system_guard);
                     finish_sender
                         .send(index)
                         .await

--- a/lib/ecs/src/schedule/graph_utils.rs
+++ b/lib/ecs/src/schedule/graph_utils.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt::Debug, hash::Hash};
 
 use fixedbitset::FixedBitSet;
-use legion_utils::{tracing::warn, AHashExt, HashMap, HashSet};
+use legion_utils::{log::warn, AHashExt, HashMap, HashSet};
 
 pub enum DependencyGraphError<Labels> {
     GraphCycles(Vec<(usize, Labels)>),

--- a/lib/ecs/src/schedule/mod.rs
+++ b/lib/ecs/src/schedule/mod.rs
@@ -9,13 +9,14 @@ mod system_container;
 mod system_descriptor;
 mod system_set;
 
+use legion_telemetry::trace_scope;
+use legion_utils::HashMap;
 use std::fmt::Debug;
 
 pub use executor::*;
 pub use executor_parallel::*;
 pub use graph_utils::GraphNode;
 pub use label::*;
-use legion_utils::HashMap;
 pub use run_criteria::*;
 pub use stage::*;
 pub use state::*;
@@ -332,11 +333,10 @@ impl Schedule {
     /// Executes each [`Stage`] contained in the schedule, one at a time.
     pub fn run_once(&mut self, world: &mut World) {
         for label in &self.stage_order {
-            #[cfg(feature = "trace")]
-            let stage_span =
-                legion_utils::tracing::info_span!("stage", name = &format!("{:?}", label) as &str);
-            #[cfg(feature = "trace")]
-            let _stage_guard = stage_span.enter();
+            // TODO: add stage name to trace scope
+            trace_scope!();
+            // let stage_span = info_span!("stage", name = &format!("{:?}", label) as &str);
+            // let _stage_guard = stage_span.enter();
             let stage = self.stages.get_mut(label).unwrap();
             stage.run(world);
         }

--- a/lib/ecs/src/schedule/stage.rs
+++ b/lib/ecs/src/schedule/stage.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use downcast_rs::{impl_downcast, Downcast};
 use fixedbitset::FixedBitSet;
-use legion_utils::{tracing::info, HashMap, HashSet};
+use legion_utils::{log::info, HashMap, HashSet};
 
 use super::IntoSystemDescriptor;
 use crate::{

--- a/lib/ecs/src/system/commands/mod.rs
+++ b/lib/ecs/src/system/commands/mod.rs
@@ -3,7 +3,7 @@ mod command_queue;
 use std::marker::PhantomData;
 
 pub use command_queue::CommandQueue;
-use legion_utils::tracing::{error, warn};
+use legion_utils::log::{error, warn};
 
 use super::Resource;
 use crate::{

--- a/lib/ecs/src/system/system.rs
+++ b/lib/ecs/src/system/system.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use legion_utils::tracing::warn;
+use legion_utils::log::warn;
 
 use crate::{
     archetype::{Archetype, ArchetypeComponentId},

--- a/lib/utils/Cargo.toml
+++ b/lib/utils/Cargo.toml
@@ -10,7 +10,6 @@ legion-derive = { path = "../derive", version = "0.1.0" }
 ahash = "0.7"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 siphasher = "0.3.7"
-tracing = { version = "0.1", features = ["release_max_level_info"] }
 toml = "0.5.8"
 lazy_static = "1.4"
 log = "0.4"

--- a/lib/utils/src/lib.rs
+++ b/lib/utils/src/lib.rs
@@ -71,7 +71,7 @@ mod hash;
 pub use hash::*;
 // republish types
 pub use instant::{Duration, Instant};
-pub use tracing;
+pub use log;
 pub use uuid::Uuid;
 
 mod settings;

--- a/plugin/core/src/task_pool_options.rs
+++ b/plugin/core/src/task_pool_options.rs
@@ -1,6 +1,6 @@
 use legion_ecs::world::World;
 use legion_tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder};
-use legion_utils::tracing::trace;
+use legion_utils::log::trace;
 
 /// Defines a simple way to determine how many threads to use given the number of remaining cores
 /// and number of total cores

--- a/plugin/transform/src/hierarchy/hierarchy.rs
+++ b/plugin/transform/src/hierarchy/hierarchy.rs
@@ -3,7 +3,7 @@ use legion_ecs::{
     system::{Command, EntityCommands},
     world::{EntityMut, World},
 };
-use legion_utils::tracing::debug;
+use legion_utils::log::debug;
 
 use crate::components::{Children, Parent};
 

--- a/plugin/window/src/window.rs
+++ b/plugin/window/src/window.rs
@@ -1,5 +1,5 @@
 use legion_math::{IVec2, Vec2};
-use legion_utils::{tracing::warn, Uuid};
+use legion_utils::{log::warn, Uuid};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WindowId(Uuid);

--- a/plugin/winit/src/lib.rs
+++ b/plugin/winit/src/lib.rs
@@ -72,7 +72,7 @@ pub use winit_windows::*;
 use legion_app::{App, AppExit, CoreStage, Events, ManualEventReader, Plugin};
 use legion_ecs::{system::IntoExclusiveSystem, world::World};
 use legion_math::{ivec2, Vec2};
-use legion_utils::tracing::{error, trace, warn};
+use legion_utils::log::{error, trace, warn};
 use legion_window::{
     CreateWindow, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, ReceivedCharacter,
     WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated, WindowFocused,


### PR DESCRIPTION
* Remove "trace", "tracing-*" features from integrated Bevy plugins/libraries
* Remove tracing crate from legion-utils dependencies
* Re-publish log crate through legion-utils, so that code that previously used legion_utils::tracing::* (log, info, etc) can now use legion_utils::log::*, without adding any new dependency to the log crate