### PR TITLE
res-reg: use tasks crate directly vs async-plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ dependencies = [
  "legion-asset-registry",
  "legion-async",
  "legion-codec-api",
+ "legion-core",
  "legion-data-offline",
  "legion-data-runtime",
  "legion-data-transaction",
@@ -4052,12 +4053,12 @@ version = "0.1.0"
 dependencies = [
  "generic_data_offline",
  "legion-app",
- "legion-async",
  "legion-data-offline",
  "legion-data-runtime",
  "legion-data-transaction",
  "legion-ecs",
  "legion-graphics-offline",
+ "legion-tasks",
  "sample-data-offline",
  "tokio",
 ]

--- a/plugin/resource-registry/Cargo.toml
+++ b/plugin/resource-registry/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["legion"]
 [dependencies]
 # Legion engine
 legion-app = { path = "../../lib/app", version = "0.1.0" }
-legion-async = { path = "../async", version = "0.1.0" }
 legion-data-offline = { path = "../../lib/data-offline", version = "0.1.0" }
 legion-data-transaction = { path = "../../lib/data-transaction", version = "0.1.0" }
 legion-data-runtime = { path = "../../lib/data-runtime", version = "0.1.0" }
 legion-ecs = { path = "../../lib/ecs", version = "0.1.0" }
 legion-graphics-offline = { path = "../../lib/graphics-offline", version = "0.1.0" }
+legion-tasks = { path = "../../lib/tasks", version = "0.1.0" }
 
 # temp dependency on sample-data, until offline data moved to plugins
 sample-data-offline = { path = "../../test/sample-data-offline", version = "0.1.0" }

--- a/server/editor-srv/Cargo.toml
+++ b/server/editor-srv/Cargo.toml
@@ -9,18 +9,19 @@ license = "MIT OR Apache-2.0"
 legion-app = { path = "../../lib/app", version = "0.1.0" }
 legion-asset-registry = { path = "../../plugin/asset-registry", version = "0.1.0" }
 legion-async = { path = "../../plugin/async", version = "0.1.0" }
-legion-grpc = { path = "../../plugin/grpc", version = "0.1.0" }
 legion-codec-api = { path = "../../lib/codec-api", version = "0.1.0" }
-legion-data-runtime = { path = "../../lib/data-runtime", version = "0.1.0" }
+legion-core = { path = "../../plugin/core", version = "0.1.0" }
 legion-data-offline = { path = "../../lib/data-offline", version = "0.1.0" }
-legion-renderer = { path = "../../plugin/renderer", version = "0.1.0" }
+legion-data-runtime = { path = "../../lib/data-runtime", version = "0.1.0" }
 legion-data-transaction = { path = "../../lib/data-transaction", version = "0.1.0" }
+legion-editor-proto = { path = "../../proto/editor", version = "0.1.0" }
+legion-grpc = { path = "../../plugin/grpc", version = "0.1.0" }
 legion-mp4 = { path = "../../lib/mp4", version = "0.1.0" }
+legion-renderer = { path = "../../plugin/renderer", version = "0.1.0" }
 legion-resource-registry = { path = "../../plugin/resource-registry", version = "0.1.0" }
 legion-streamer = { path = "../../plugin/streamer", version = "0.1.0" }
-legion-transform = { path = "../../plugin/transform", version = "0.1.0" }
-legion-editor-proto = { path = "../../proto/editor", version = "0.1.0" }
 legion-telemetry = { path = "../../lib/telemetry" }
+legion-transform = { path = "../../plugin/transform", version = "0.1.0" }
 legion-utils = { path = "../../lib/utils" }
 tokio = { version = "1.13", features = ["full"] }
 tonic = "0.6"

--- a/server/editor-srv/src/main.rs
+++ b/server/editor-srv/src/main.rs
@@ -4,6 +4,7 @@ use clap::Arg;
 use legion_app::{prelude::*, ScheduleRunnerPlugin, ScheduleRunnerSettings};
 use legion_asset_registry::{AssetRegistryPlugin, AssetRegistrySettings, DataBuildSettings};
 use legion_async::AsyncPlugin;
+use legion_core::CorePlugin;
 use legion_data_runtime::ResourceId;
 use legion_grpc::{GRPCPlugin, GRPCPluginSettings};
 use legion_renderer::RendererPlugin;
@@ -133,6 +134,7 @@ fn main() {
         .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
+        .add_plugin(CorePlugin::default())
         .add_plugin(ScheduleRunnerPlugin::default())
         .add_plugin(AsyncPlugin::default())
         .insert_resource(AssetRegistrySettings::new(


### PR DESCRIPTION
As a simple use-case, in the resource-registry plugin, use the legion-tasks crate (task pools, tasks, etc) directly instead of relying on the async plugin.