### PR TITLE
optional sparse binding

### DIFF
--- a/lib/graphics-api/src/backends/vulkan/memory_allocation.rs
+++ b/lib/graphics-api/src/backends/vulkan/memory_allocation.rs
@@ -146,6 +146,12 @@ impl VulkanMemoryPagesAllocation {
         }
     }
 
+    pub fn empty_allocation() -> Self {
+        Self {
+            vk_allocated_pages: Vec::new(),
+        }
+    }
+
     pub fn destroy(&mut self, device_context: &DeviceContext) {
         let mut allocations = Vec::with_capacity(self.vk_allocated_pages.len());
         for allocation in &self.vk_allocated_pages {

--- a/lib/graphics-api/src/types/memory_allocation.rs
+++ b/lib/graphics-api/src/types/memory_allocation.rs
@@ -148,6 +148,20 @@ impl MemoryPagesAllocation {
                 }),
         }
     }
+
+    pub fn empty_allocation(device_context: &DeviceContext) -> Self {
+        #[cfg(feature = "vulkan")]
+        let platform_allocation = VulkanMemoryPagesAllocation::empty_allocation();
+        Self {
+            inner: device_context
+                .deferred_dropper()
+                .new_drc(MemoryPagesAllocationInner {
+                    device_context: device_context.clone(),
+                    #[cfg(any(feature = "vulkan"))]
+                    platform_allocation,
+                }),
+        }
+    }
 }
 
 pub type BufferAllocation = BufferSubAllocation<MemoryAllocation>;

--- a/plugin/renderer/src/renderer.rs
+++ b/plugin/renderer/src/renderer.rs
@@ -50,7 +50,7 @@ impl Renderer {
         let api = unsafe { GfxApi::new(&ApiDef::default()).unwrap() };
         let device_context = api.device_context();
 
-        let static_buffer = UnifiedStaticBuffer::new(device_context, 64 * 1024 * 1024);
+        let static_buffer = UnifiedStaticBuffer::new(device_context, 64 * 1024 * 1024, true);
         let test_transform_data = TestStaticBuffer::new(UniformGPUData::<EntityTransforms>::new(
             &static_buffer,
             64 * 1024,


### PR DESCRIPTION
Make sparse binding optional (on by default)

Render doc fails most times when sparse binding is enabled, so allow to easily disable when captures are needed.