### PR TITLE
Fixed deadlock in the authentication library

### DIFF
--- a/client/analytics-web/src/main.rs
+++ b/client/analytics-web/src/main.rs
@@ -80,6 +80,7 @@ async fn authenticate(token_cache: tauri::State<'_, Arc<TokenCache>>) -> anyhow:
 
     token_cache
         .authenticator()
+        .await
         .get_user_info(&access_token)
         .await
         .map_err(Into::into)

--- a/client/editor/src/main.rs
+++ b/client/editor/src/main.rs
@@ -80,6 +80,7 @@ async fn authenticate(token_cache: tauri::State<'_, Arc<TokenCache>>) -> anyhow:
 
     let user_info = token_cache
         .authenticator()
+        .await
         .get_user_info(&access_token)
         .await
         .map_err::<anyhow::Error, _>(Into::into)?;


### PR DESCRIPTION
This fixes a problem reported by @kevin-legion where a refresh of the authentication token set would deadlock cause the semaphore is tentatively consumed twice, which can never succeed.