### PR TITLE
Editor client: Improve video player stream code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-web",
 ]
@@ -4292,8 +4293,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tonic",
  "webrtc",
+ "webrtc-media",
 ]
 
 [[package]]

--- a/client/editor/frontend/package.json
+++ b/client/editor/frontend/package.json
@@ -58,6 +58,7 @@
     "grpc-web": "^1.3.0",
     "long": "^5.1.0",
     "protobufjs": "^6.11.2",
+    "rxjs": "6.6.7",
     "uuid-random": "^1.3.2"
   }
 }

--- a/client/editor/frontend/src/actions/videoPlayer.ts
+++ b/client/editor/frontend/src/actions/videoPlayer.ts
@@ -21,10 +21,15 @@ export default function videoPlayer(
   videoElement: HTMLVideoElement,
   options?: { onFatal?: () => void }
 ) {
+  videoElement.muted = true;
+  videoElement.autoplay = true;
+  videoElement.playsInline = true;
+
   let videoSource: SourceBuffer | null = null;
   let mediaSource: MediaSource | null = null;
   let waitingForKeyFrame = true;
   let listeners: Listener[] = [];
+
   const queue: Uint8Array[] = [];
 
   const addListener = (source: Source, name: string, f: () => void) => {
@@ -50,8 +55,6 @@ export default function videoPlayer(
       if (videoSource) {
         addListener(videoSource, "update", submit);
       }
-
-      videoElement.play();
     });
   };
 
@@ -75,7 +78,6 @@ export default function videoPlayer(
     onVideoClose();
 
     waitingForKeyFrame = true;
-    videoElement.pause();
 
     for (const { source, name, f } of listeners) {
       source.removeEventListener(name, f);

--- a/client/editor/frontend/src/components/StatusBar.svelte
+++ b/client/editor/frontend/src/components/StatusBar.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { statusStore } from "@/stores/statusBarData";
+  import statusBar from "@/stores/statusBar";
 </script>
 
 <div class="root">
   <div class="status-bar">
     <span class="status">
-      {#if $statusStore}
-        {$statusStore}
+      {#if $statusBar}
+        {$statusBar}
       {/if}
     </span>
   </div>

--- a/client/editor/frontend/src/lib/promises.ts
+++ b/client/editor/frontend/src/lib/promises.ts
@@ -45,8 +45,6 @@ export async function retry<T>(
       throw error;
     }
 
-    n--;
-
-    return retry(f, n);
+    return retry(f, n - 1);
   }
 }

--- a/client/editor/frontend/src/stores/statusBar.ts
+++ b/client/editor/frontend/src/stores/statusBar.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export default writable<string | null>(null);

--- a/client/editor/frontend/src/stores/statusBarData.ts
+++ b/client/editor/frontend/src/stores/statusBarData.ts
@@ -1,3 +1,0 @@
-import { writable, Writable } from "svelte/store";
-
-export const statusStore: Writable<string | null> = writable(null);

--- a/plugin/streamer/Cargo.toml
+++ b/plugin/streamer/Cargo.toml
@@ -32,8 +32,10 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.13", features = ["full"] }
+tokio-stream = "0.1.8"
 tonic = "0.6"
 webrtc = "0.2"
+webrtc-media = "0.4.3"
 
 [features]
 default = []

--- a/plugin/streamer/src/grpc.rs
+++ b/plugin/streamer/src/grpc.rs
@@ -1,11 +1,17 @@
 use std::sync::Arc;
 
 use lgn_streaming_proto::{
+    initialize_stream_response,
     streamer_server::{Streamer, StreamerServer},
+    AddIceCandidatesRequest, AddIceCandidatesResponse, IceCandidateRequest, IceCandidateResponse,
     InitializeStreamRequest, InitializeStreamResponse,
 };
+use lgn_utils::StableHashMap;
 use log::{debug, info, warn};
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
+use webrtc::peer::{ice::ice_candidate::RTCIceCandidate, peer_connection::RTCPeerConnection};
 
 use crate::{streamer::StreamEvent, webrtc::WebRTCServer};
 
@@ -13,6 +19,12 @@ use crate::{streamer::StreamEvent, webrtc::WebRTCServer};
 pub(crate) struct GRPCServer {
     webrtc_server: WebRTCServer,
     stream_events_sender: Arc<crossbeam::channel::Sender<StreamEvent>>,
+    // TODO: Peer connection doesn't have to be an Arc
+    rtc_peer_connnections: Arc<Mutex<StableHashMap<String, Arc<RTCPeerConnection>>>>,
+    stream_ice_candidates_senders:
+        Arc<Mutex<StableHashMap<String, Arc<crossbeam::channel::Sender<RTCIceCandidate>>>>>,
+    stream_ice_candidates_receivers:
+        Arc<Mutex<StableHashMap<String, Arc<crossbeam::channel::Receiver<RTCIceCandidate>>>>>,
 }
 
 /// Stream represents an established stream.
@@ -25,6 +37,13 @@ impl GRPCServer {
         Self {
             webrtc_server,
             stream_events_sender: Arc::new(stream_events_sender),
+            rtc_peer_connnections: Arc::new(Mutex::new(StableHashMap::from_iter(Vec::new()))),
+            stream_ice_candidates_senders: Arc::new(Mutex::new(StableHashMap::from_iter(
+                Vec::new(),
+            ))),
+            stream_ice_candidates_receivers: Arc::new(Mutex::new(StableHashMap::from_iter(
+                Vec::new(),
+            ))),
         }
     }
 
@@ -41,31 +60,137 @@ impl Streamer for GRPCServer {
     ) -> Result<Response<InitializeStreamResponse>, Status> {
         debug!("Initializing a new WebRTC stream connection...");
 
+        // This channel is in charge to push the new ice candidates to the clients and vice versa
+        let (stream_ice_candidates_sender, stream_ice_candidates_receiver) =
+            crossbeam::channel::unbounded();
+
+        let stream_ice_candidates_sender = Arc::new(stream_ice_candidates_sender);
+
         let remote_description = self
             .webrtc_server
             .initialize_stream_connection(
                 request.into_inner().rtc_session_description,
                 Arc::clone(&self.stream_events_sender),
+                Arc::clone(&stream_ice_candidates_sender),
             )
             .await;
 
         Ok(Response::new(match remote_description {
-            Ok(rtc_session_description) => {
+            Ok((stream_id, peer_connection, rtc_session_description)) => {
                 info!("New WebRTC stream connection initialized.");
 
-                InitializeStreamResponse {
-                    rtc_session_description,
-                    error: String::default(),
-                }
-            }
-            Err(e) => {
-                warn!("Failed to initialize new WebRTC stream connection: {}.", e);
+                self.stream_ice_candidates_senders
+                    .lock()
+                    .await
+                    .insert(stream_id.to_string(), stream_ice_candidates_sender);
+
+                self.stream_ice_candidates_receivers.lock().await.insert(
+                    stream_id.to_string(),
+                    Arc::new(stream_ice_candidates_receiver),
+                );
+
+                self.rtc_peer_connnections
+                    .lock()
+                    .await
+                    .insert(stream_id.to_string(), peer_connection);
 
                 InitializeStreamResponse {
-                    rtc_session_description: vec![],
-                    error: e.to_string(),
+                    response: Some(initialize_stream_response::Response::Ok(
+                        initialize_stream_response::Ok {
+                            rtc_session_description,
+                            stream_id: stream_id.to_string(),
+                        },
+                    )),
+                }
+            }
+            Err(error) => {
+                warn!(
+                    "Failed to initialize new WebRTC stream connection: {}.",
+                    error
+                );
+
+                InitializeStreamResponse {
+                    response: Some(initialize_stream_response::Response::Error(
+                        error.to_string(),
+                    )),
                 }
             }
         }))
+    }
+
+    async fn add_ice_candidates(
+        &self,
+        request: Request<AddIceCandidatesRequest>,
+    ) -> Result<Response<AddIceCandidatesResponse>, Status> {
+        let AddIceCandidatesRequest {
+            stream_id,
+            ice_candidates,
+        } = request.into_inner();
+
+        let rtc_peer_connections = self.rtc_peer_connnections.lock().await;
+
+        let peer_connection = rtc_peer_connections.get(&stream_id);
+
+        let ok = if let Some(peer_connection) = peer_connection {
+            for ice_candidate in ice_candidates {
+                let ice_candidate = serde_json::from_slice(&ice_candidate)
+                    .map_err(|error| Status::invalid_argument(error.to_string()))?;
+
+                peer_connection
+                    .add_ice_candidate(ice_candidate)
+                    .await
+                    .map_err(|error| {
+                        Status::internal(format!(
+                            "Couldn't add ice candidate to peer connection: {}",
+                            error.to_string(),
+                        ))
+                    })?;
+            }
+
+            true
+        } else {
+            false
+        };
+
+        Ok(Response::new(AddIceCandidatesResponse { ok }))
+    }
+
+    #[doc = "Server streaming response type for the IceCandidates method."]
+    type IceCandidatesStream = ReceiverStream<Result<IceCandidateResponse, Status>>;
+
+    async fn ice_candidates(
+        &self,
+        request: Request<IceCandidateRequest>,
+    ) -> Result<Response<Self::IceCandidatesStream>, Status> {
+        let ice_candidate_request = request.into_inner();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+        // TODO: Super ugly code below: cleanup
+        let stream_ice_candidates_receivers = &self.stream_ice_candidates_receivers.lock().await;
+
+        let stream_ice_candidates_receiver =
+            stream_ice_candidates_receivers.get(&ice_candidate_request.stream_id);
+
+        if let Some(stream_ice_candidates_receiver) = stream_ice_candidates_receiver {
+            let stream_ice_candidates_receiver = Arc::clone(stream_ice_candidates_receiver);
+
+            tokio::spawn(async move {
+                for ice_candidate in stream_ice_candidates_receiver
+                    .iter()
+                    .collect::<Vec<RTCIceCandidate>>()
+                {
+                    tx.send(Ok(IceCandidateResponse {
+                        ice_candidate: serde_json::to_vec(&ice_candidate).unwrap(),
+                    }))
+                    .await
+                    .unwrap();
+                }
+            });
+
+            return Ok(Response::new(ReceiverStream::new(rx)));
+        }
+
+        Err(Status::failed_precondition("Stream id not found"))
     }
 }

--- a/plugin/streamer/src/lib.rs
+++ b/plugin/streamer/src/lib.rs
@@ -74,7 +74,7 @@ pub struct StreamerPlugin;
 
 impl Plugin for StreamerPlugin {
     fn build(&self, app: &mut App) {
-        // This channel is used a communication mechanism between the async server threads and the game-loop.
+        // This channel is used as a communication mechanism between the async server threads and the game-loop.
         let (stream_events_sender, stream_events_receiver) = crossbeam::channel::unbounded();
 
         // The streamer is the game-loop representative of the whole streaming system.
@@ -82,6 +82,7 @@ impl Plugin for StreamerPlugin {
 
         let time = Time::default();
 
+        // TODO: Add the other streamer? What for?
         app.insert_resource(streamer)
             .insert_resource(time)
             .add_event::<streamer::VideoStreamEvent>()
@@ -89,7 +90,7 @@ impl Plugin for StreamerPlugin {
             .add_system(streamer::update_streams);
 
         let webrtc_server =
-            webrtc::WebRTCServer::new().expect("failed to instanciate a WebRTC server");
+            webrtc::WebRTCServer::new().expect("failed to instantiate a WebRTC server");
         let grpc_server = grpc::GRPCServer::new(webrtc_server, stream_events_sender);
 
         app.world

--- a/plugin/streamer/src/webrtc.rs
+++ b/plugin/streamer/src/webrtc.rs
@@ -2,16 +2,25 @@ use std::sync::Arc;
 
 use interceptor::registry::Registry;
 use log::{debug, info, warn};
+use tokio::sync::Notify;
 use webrtc::{
     api::{
-        interceptor_registry::register_default_interceptors, media_engine::MediaEngine, APIBuilder,
-        API,
+        interceptor_registry::register_default_interceptors,
+        media_engine::{MediaEngine, MIME_TYPE_H264},
+        APIBuilder, API,
     },
     data::data_channel::{data_channel_message::DataChannelMessage, RTCDataChannel},
+    media::{
+        rtp::rtp_codec::{RTCRtpCodecCapability, RTCRtpCodecParameters, RTPCodecType},
+        track::track_local::{track_local_static_sample::TrackLocalStaticSample, TrackLocal},
+    },
     peer::{
-        configuration::RTCConfiguration, ice::ice_server::RTCIceServer,
-        peer_connection::RTCPeerConnection, peer_connection_state::RTCPeerConnectionState,
-        sdp::session_description::RTCSessionDescription, signaling_state::RTCSignalingState,
+        configuration::RTCConfiguration,
+        ice::{ice_candidate::RTCIceCandidate, ice_server::RTCIceServer},
+        peer_connection::RTCPeerConnection,
+        peer_connection_state::RTCPeerConnectionState,
+        sdp::session_description::RTCSessionDescription,
+        signaling_state::RTCSignalingState,
     },
 };
 
@@ -36,6 +45,17 @@ impl WebRTCServer {
         // Register default codecs
         media_engine.register_default_codecs()?;
 
+        media_engine.register_codec(
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: "video/mp4; codecs=\"avc1.640C34\"".to_owned(),
+                    ..RTCRtpCodecCapability::default()
+                },
+                ..RTCRtpCodecParameters::default()
+            },
+            RTPCodecType::Video,
+        )?;
+
         // Create a InterceptorRegistry. This is the user configurable RTP/RTCP Pipeline.
         // This provides NACKs, RTCP Reports and other features. If you use `webrtc.NewPeerConnection`
         // this is enabled by default. If you are manually managing You MUST create a InterceptorRegistry
@@ -58,11 +78,14 @@ impl WebRTCServer {
         &self,
         remote_rtc_session_description: Vec<u8>,
         stream_events_sender: Arc<crossbeam::channel::Sender<StreamEvent>>,
-    ) -> Result<Vec<u8>, anyhow::Error> {
+        stream_ice_candidates_sender: Arc<crossbeam::channel::Sender<RTCIceCandidate>>,
+    ) -> Result<(StreamID, Arc<RTCPeerConnection>, Vec<u8>), anyhow::Error> {
         let offer =
             serde_json::from_slice::<RTCSessionDescription>(&remote_rtc_session_description)?;
 
-        let peer_connection = self.new_peer_connection(stream_events_sender).await?;
+        let (stream_id, peer_connection) = self
+            .new_peer_connection(stream_events_sender, stream_ice_candidates_sender)
+            .await?;
 
         // Set the remote SessionDescription
         peer_connection.set_remote_description(offer).await?;
@@ -84,13 +107,18 @@ impl WebRTCServer {
         // Output the answer in base64 so we can paste it in browser
         let rtc_session_description = peer_connection.local_description().await.unwrap();
 
-        Ok(serde_json::to_vec(&rtc_session_description)?)
+        Ok((
+            stream_id,
+            peer_connection,
+            serde_json::to_vec(&rtc_session_description)?,
+        ))
     }
 
     async fn new_peer_connection(
         &self,
         stream_events_sender: Arc<crossbeam::channel::Sender<StreamEvent>>,
-    ) -> anyhow::Result<Arc<RTCPeerConnection>> {
+        stream_ice_candidates_sender: Arc<crossbeam::channel::Sender<RTCIceCandidate>>,
+    ) -> anyhow::Result<(StreamID, Arc<RTCPeerConnection>)> {
         // Prepare the configuration
         let config = RTCConfiguration {
             ice_servers: vec![RTCIceServer {
@@ -99,6 +127,9 @@ impl WebRTCServer {
             }],
             ..RTCConfiguration::default()
         };
+
+        // Will notify video streamer when the peer connection is ready
+        let notify_video = Arc::new(Notify::new());
 
         let peer_connection = Arc::new(self.api.new_peer_connection(config).await?);
 
@@ -121,43 +152,47 @@ impl WebRTCServer {
 
         let on_state_change_peer_connection = Arc::clone(&peer_connection);
         let on_state_change_stream_events_sender = Arc::clone(&stream_events_sender);
+        let on_state_change_notify_video = Arc::clone(&notify_video);
 
         peer_connection
-            .on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
-                info!("Peer connection state has changed: {}", s);
+            .on_peer_connection_state_change(Box::new(
+                move |connection_state: RTCPeerConnectionState| {
+                    info!("Peer connection state has changed: {}", connection_state);
 
-                if s == RTCPeerConnectionState::Disconnected {
-                    let _ =
-                        on_state_change_stream_events_sender.send(StreamEvent::ConnectionClosed(
-                            stream_id,
-                            Arc::clone(&on_state_change_peer_connection),
-                        ));
-                };
+                    match connection_state {
+                        RTCPeerConnectionState::Connected => {
+                            on_state_change_notify_video.notify_waiters();
+                        }
+                        RTCPeerConnectionState::Disconnected => {
+                            let _ = on_state_change_stream_events_sender.send(
+                                StreamEvent::ConnectionClosed(
+                                    stream_id,
+                                    Arc::clone(&on_state_change_peer_connection),
+                                ),
+                            );
+                        }
+                        _ => {}
+                    }
 
-                Box::pin(async {})
-            }))
+                    Box::pin(async {})
+                },
+            ))
             .await;
+
+        let on_data_channel_stream_events_sender = Arc::clone(&stream_events_sender);
 
         // Register data channel creation handling
         peer_connection
             .on_data_channel(Box::new(move |data_channel: Arc<RTCDataChannel>| {
-                let stream_events_sender = Arc::clone(&stream_events_sender);
+                let on_data_channel_stream_events_sender =
+                    Arc::clone(&on_data_channel_stream_events_sender);
 
                 match data_channel.label() {
                     "control" => Box::pin(async move {
                         Self::handle_control_data_channel(
                             data_channel,
                             stream_id,
-                            stream_events_sender,
-                        )
-                        .await
-                        .unwrap();
-                    }),
-                    "video" => Box::pin(async move {
-                        Self::handle_video_data_channel(
-                            data_channel,
-                            stream_id,
-                            stream_events_sender,
+                            on_data_channel_stream_events_sender,
                         )
                         .await
                         .unwrap();
@@ -169,7 +204,64 @@ impl WebRTCServer {
             }))
             .await;
 
-        Ok(peer_connection)
+        let on_ice_candidate_stream_ice_candidates_sender =
+            Arc::clone(&stream_ice_candidates_sender);
+
+        // Send ice candidates to a client
+        peer_connection
+            .on_ice_candidate(Box::new(move |ice_candidate| {
+                let on_ice_candidate_stream_ice_candidates_sender =
+                    Arc::clone(&on_ice_candidate_stream_ice_candidates_sender);
+
+                Box::pin(async move {
+                    if let Some(ice_candidate) = ice_candidate {
+                        on_ice_candidate_stream_ice_candidates_sender
+                            .send(ice_candidate)
+                            .unwrap();
+                    }
+                })
+            }))
+            .await;
+
+        let video_track = Arc::new(TrackLocalStaticSample::new(
+            RTCRtpCodecCapability {
+                mime_type: MIME_TYPE_H264.to_string(),
+                // mime_type: "video/mp4; codecs=\"avc1.640C34\"".to_string(),
+                ..RTCRtpCodecCapability::default()
+            },
+            "video".to_string(),
+            stream_id.to_string(),
+        ));
+
+        let rtp_sender = peer_connection
+            .add_track(Arc::clone(&video_track) as Arc<dyn TrackLocal + Send + Sync>)
+            .await?;
+
+        tokio::spawn(async move {
+            let mut rtcp_buf = vec![0u8; 1500];
+
+            while let Ok((i, hmap)) = rtp_sender.read(&mut rtcp_buf).await {
+                debug!("Rtp index: {} - map: {:?}", i, hmap);
+            }
+        });
+
+        let notify_video = Arc::clone(&notify_video);
+
+        tokio::spawn(async move {
+            notify_video.notified().await;
+
+            // stream_events_sender
+            //     .send(StreamEvent::VideoChannelOpened(stream_id, video_track))
+            //     .unwrap();
+            crate::streamer::video_stream::VideoStream::write_video_to_track(
+                "../../plugin/streamer/sample.h264",
+                video_track,
+            )
+            .await
+            .unwrap();
+        });
+
+        Ok((stream_id, peer_connection))
     }
 
     async fn ignore_data_channel(data_channel: Arc<RTCDataChannel>) -> Result<(), webrtc::Error> {
@@ -234,77 +326,6 @@ impl WebRTCServer {
                         msg,
                     ),
                 );
-
-                Box::pin(async {})
-            }))
-            .await;
-
-        Ok(())
-    }
-
-    async fn handle_video_data_channel(
-        data_channel: Arc<RTCDataChannel>,
-        stream_id: StreamID,
-        stream_events_sender: Arc<crossbeam::channel::Sender<StreamEvent>>,
-    ) -> anyhow::Result<()> {
-        let on_error_name = data_channel.name();
-
-        data_channel
-            .on_error(Box::new(move |err| {
-                warn!("Video data channel {} error: {}.", on_error_name, err);
-
-                Box::pin(async {})
-            }))
-            .await;
-
-        let on_open_stream_events_sender = Arc::clone(&stream_events_sender);
-        let on_open_data_channel = Arc::clone(&data_channel);
-
-        data_channel
-            .on_open(Box::new(move || {
-                info!("Video data channel opened.");
-
-                let _ = on_open_stream_events_sender.send(StreamEvent::VideoChannelOpened(
-                    stream_id,
-                    on_open_data_channel,
-                ));
-
-                Box::pin(async move {})
-            }))
-            .await;
-
-        let on_close_stream_events_sender = Arc::clone(&stream_events_sender);
-        let on_close_data_channel = Arc::clone(&data_channel);
-
-        data_channel
-            .on_close(Box::new(move || {
-                info!("Video data channel closed.");
-
-                let _ = on_close_stream_events_sender.send(StreamEvent::VideoChannelClosed(
-                    stream_id,
-                    Arc::clone(&on_close_data_channel),
-                ));
-
-                Box::pin(async {})
-            }))
-            .await;
-
-        let on_message_name = data_channel.name();
-        let on_message_stream_events_sender = Arc::clone(&stream_events_sender);
-        let on_message_data_channel = Arc::clone(&data_channel);
-
-        // Register text message handling
-        data_channel
-            .on_message(Box::new(move |msg: DataChannelMessage| {
-                let msg_str = String::from_utf8(msg.data.to_vec()).unwrap();
-                debug!("{}: {}", on_message_name, msg_str);
-
-                let _ =
-                    on_message_stream_events_sender.send(StreamEvent::VideoChannelMessageReceived(
-                        stream_id,
-                        Arc::clone(&on_message_data_channel),
-                        msg,
-                    ));
 
                 Box::pin(async {})
             }))

--- a/proto/streaming/codegen/streaming.rs
+++ b/proto/streaming/codegen/streaming.rs
@@ -5,10 +5,47 @@ pub struct InitializeStreamRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitializeStreamResponse {
+    #[prost(oneof = "initialize_stream_response::Response", tags = "3, 4")]
+    pub response: ::core::option::Option<initialize_stream_response::Response>,
+}
+/// Nested message and enum types in `InitializeStreamResponse`.
+pub mod initialize_stream_response {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Ok {
+        #[prost(bytes = "vec", tag = "1")]
+        pub rtc_session_description: ::prost::alloc::vec::Vec<u8>,
+        #[prost(string, tag = "2")]
+        pub stream_id: ::prost::alloc::string::String,
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Response {
+        #[prost(message, tag = "3")]
+        Ok(Ok),
+        #[prost(string, tag = "4")]
+        Error(::prost::alloc::string::String),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AddIceCandidatesRequest {
+    #[prost(string, tag = "1")]
+    pub stream_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub ice_candidates: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AddIceCandidatesResponse {
+    #[prost(bool, tag = "1")]
+    pub ok: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IceCandidateRequest {
+    #[prost(string, tag = "1")]
+    pub stream_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct IceCandidateResponse {
     #[prost(bytes = "vec", tag = "1")]
-    pub rtc_session_description: ::prost::alloc::vec::Vec<u8>,
-    #[prost(string, tag = "2")]
-    pub error: ::prost::alloc::string::String,
+    pub ice_candidate: ::prost::alloc::vec::Vec<u8>,
 }
 #[doc = r" Generated client implementations."]
 pub mod streamer_client {
@@ -84,6 +121,39 @@ pub mod streamer_client {
             let path = http::uri::PathAndQuery::from_static("/streaming.Streamer/InitializeStream");
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn add_ice_candidates(
+            &mut self,
+            request: impl tonic::IntoRequest<super::AddIceCandidatesRequest>,
+        ) -> Result<tonic::Response<super::AddIceCandidatesResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/streaming.Streamer/AddIceCandidates");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn ice_candidates(
+            &mut self,
+            request: impl tonic::IntoRequest<super::IceCandidateRequest>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::IceCandidateResponse>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/streaming.Streamer/IceCandidates");
+            self.inner
+                .server_streaming(request.into_request(), path, codec)
+                .await
+        }
     }
 }
 #[doc = r" Generated server implementations."]
@@ -97,6 +167,18 @@ pub mod streamer_server {
             &self,
             request: tonic::Request<super::InitializeStreamRequest>,
         ) -> Result<tonic::Response<super::InitializeStreamResponse>, tonic::Status>;
+        async fn add_ice_candidates(
+            &self,
+            request: tonic::Request<super::AddIceCandidatesRequest>,
+        ) -> Result<tonic::Response<super::AddIceCandidatesResponse>, tonic::Status>;
+        #[doc = "Server streaming response type for the IceCandidates method."]
+        type IceCandidatesStream: futures_core::Stream<Item = Result<super::IceCandidateResponse, tonic::Status>>
+            + Send
+            + 'static;
+        async fn ice_candidates(
+            &self,
+            request: tonic::Request<super::IceCandidateRequest>,
+        ) -> Result<tonic::Response<Self::IceCandidatesStream>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct StreamerServer<T: Streamer> {
@@ -166,6 +248,75 @@ pub mod streamer_server {
                             send_compression_encodings,
                         );
                         let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/streaming.Streamer/AddIceCandidates" => {
+                    #[allow(non_camel_case_types)]
+                    struct AddIceCandidatesSvc<T: Streamer>(pub Arc<T>);
+                    impl<T: Streamer> tonic::server::UnaryService<super::AddIceCandidatesRequest>
+                        for AddIceCandidatesSvc<T>
+                    {
+                        type Response = super::AddIceCandidatesResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::AddIceCandidatesRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).add_ice_candidates(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = AddIceCandidatesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/streaming.Streamer/IceCandidates" => {
+                    #[allow(non_camel_case_types)]
+                    struct IceCandidatesSvc<T: Streamer>(pub Arc<T>);
+                    impl<T: Streamer>
+                        tonic::server::ServerStreamingService<super::IceCandidateRequest>
+                        for IceCandidatesSvc<T>
+                    {
+                        type Response = super::IceCandidateResponse;
+                        type ResponseStream = T::IceCandidatesStream;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::IceCandidateRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).ice_candidates(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = IceCandidatesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/proto/streaming/codegen/streaming.ts
+++ b/proto/streaming/codegen/streaming.ts
@@ -2,7 +2,9 @@
 import Long from "long";
 import { grpc } from "@improbable-eng/grpc-web";
 import _m0 from "protobufjs/minimal";
+import { Observable } from "rxjs";
 import { BrowserHeaders } from "browser-headers";
+import { share } from "rxjs/operators";
 
 export const protobufPackage = "streaming";
 
@@ -11,8 +13,30 @@ export interface InitializeStreamRequest {
 }
 
 export interface InitializeStreamResponse {
+  ok: InitializeStreamResponse_Ok | undefined;
+  error: string | undefined;
+}
+
+export interface InitializeStreamResponse_Ok {
   rtcSessionDescription: Uint8Array;
-  error: string;
+  streamId: string;
+}
+
+export interface AddIceCandidatesRequest {
+  streamId: string;
+  iceCandidates: Uint8Array[];
+}
+
+export interface AddIceCandidatesResponse {
+  ok: boolean;
+}
+
+export interface IceCandidateRequest {
+  streamId: string;
+}
+
+export interface IceCandidateResponse {
+  iceCandidate: Uint8Array;
 }
 
 const baseInitializeStreamRequest: object = {};
@@ -87,18 +111,21 @@ export const InitializeStreamRequest = {
   },
 };
 
-const baseInitializeStreamResponse: object = { error: "" };
+const baseInitializeStreamResponse: object = {};
 
 export const InitializeStreamResponse = {
   encode(
     message: InitializeStreamResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.rtcSessionDescription.length !== 0) {
-      writer.uint32(10).bytes(message.rtcSessionDescription);
+    if (message.ok !== undefined) {
+      InitializeStreamResponse_Ok.encode(
+        message.ok,
+        writer.uint32(26).fork()
+      ).ldelim();
     }
-    if (message.error !== "") {
-      writer.uint32(18).string(message.error);
+    if (message.error !== undefined) {
+      writer.uint32(34).string(message.error);
     }
     return writer;
   },
@@ -112,14 +139,16 @@ export const InitializeStreamResponse = {
     const message = {
       ...baseInitializeStreamResponse,
     } as InitializeStreamResponse;
-    message.rtcSessionDescription = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        case 1:
-          message.rtcSessionDescription = reader.bytes();
+        case 3:
+          message.ok = InitializeStreamResponse_Ok.decode(
+            reader,
+            reader.uint32()
+          );
           break;
-        case 2:
+        case 4:
           message.error = reader.string();
           break;
         default:
@@ -134,26 +163,23 @@ export const InitializeStreamResponse = {
     const message = {
       ...baseInitializeStreamResponse,
     } as InitializeStreamResponse;
-    message.rtcSessionDescription =
-      object.rtcSessionDescription !== undefined &&
-      object.rtcSessionDescription !== null
-        ? bytesFromBase64(object.rtcSessionDescription)
-        : new Uint8Array();
+    message.ok =
+      object.ok !== undefined && object.ok !== null
+        ? InitializeStreamResponse_Ok.fromJSON(object.ok)
+        : undefined;
     message.error =
       object.error !== undefined && object.error !== null
         ? String(object.error)
-        : "";
+        : undefined;
     return message;
   },
 
   toJSON(message: InitializeStreamResponse): unknown {
     const obj: any = {};
-    message.rtcSessionDescription !== undefined &&
-      (obj.rtcSessionDescription = base64FromBytes(
-        message.rtcSessionDescription !== undefined
-          ? message.rtcSessionDescription
-          : new Uint8Array()
-      ));
+    message.ok !== undefined &&
+      (obj.ok = message.ok
+        ? InitializeStreamResponse_Ok.toJSON(message.ok)
+        : undefined);
     message.error !== undefined && (obj.error = message.error);
     return obj;
   },
@@ -164,9 +190,360 @@ export const InitializeStreamResponse = {
     const message = {
       ...baseInitializeStreamResponse,
     } as InitializeStreamResponse;
+    message.ok =
+      object.ok !== undefined && object.ok !== null
+        ? InitializeStreamResponse_Ok.fromPartial(object.ok)
+        : undefined;
+    message.error = object.error ?? undefined;
+    return message;
+  },
+};
+
+const baseInitializeStreamResponse_Ok: object = { streamId: "" };
+
+export const InitializeStreamResponse_Ok = {
+  encode(
+    message: InitializeStreamResponse_Ok,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.rtcSessionDescription.length !== 0) {
+      writer.uint32(10).bytes(message.rtcSessionDescription);
+    }
+    if (message.streamId !== "") {
+      writer.uint32(18).string(message.streamId);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): InitializeStreamResponse_Ok {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseInitializeStreamResponse_Ok,
+    } as InitializeStreamResponse_Ok;
+    message.rtcSessionDescription = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.rtcSessionDescription = reader.bytes();
+          break;
+        case 2:
+          message.streamId = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): InitializeStreamResponse_Ok {
+    const message = {
+      ...baseInitializeStreamResponse_Ok,
+    } as InitializeStreamResponse_Ok;
+    message.rtcSessionDescription =
+      object.rtcSessionDescription !== undefined &&
+      object.rtcSessionDescription !== null
+        ? bytesFromBase64(object.rtcSessionDescription)
+        : new Uint8Array();
+    message.streamId =
+      object.streamId !== undefined && object.streamId !== null
+        ? String(object.streamId)
+        : "";
+    return message;
+  },
+
+  toJSON(message: InitializeStreamResponse_Ok): unknown {
+    const obj: any = {};
+    message.rtcSessionDescription !== undefined &&
+      (obj.rtcSessionDescription = base64FromBytes(
+        message.rtcSessionDescription !== undefined
+          ? message.rtcSessionDescription
+          : new Uint8Array()
+      ));
+    message.streamId !== undefined && (obj.streamId = message.streamId);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<InitializeStreamResponse_Ok>, I>>(
+    object: I
+  ): InitializeStreamResponse_Ok {
+    const message = {
+      ...baseInitializeStreamResponse_Ok,
+    } as InitializeStreamResponse_Ok;
     message.rtcSessionDescription =
       object.rtcSessionDescription ?? new Uint8Array();
-    message.error = object.error ?? "";
+    message.streamId = object.streamId ?? "";
+    return message;
+  },
+};
+
+const baseAddIceCandidatesRequest: object = { streamId: "" };
+
+export const AddIceCandidatesRequest = {
+  encode(
+    message: AddIceCandidatesRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.streamId !== "") {
+      writer.uint32(10).string(message.streamId);
+    }
+    for (const v of message.iceCandidates) {
+      writer.uint32(18).bytes(v!);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): AddIceCandidatesRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseAddIceCandidatesRequest,
+    } as AddIceCandidatesRequest;
+    message.iceCandidates = [];
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.streamId = reader.string();
+          break;
+        case 2:
+          message.iceCandidates.push(reader.bytes());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AddIceCandidatesRequest {
+    const message = {
+      ...baseAddIceCandidatesRequest,
+    } as AddIceCandidatesRequest;
+    message.streamId =
+      object.streamId !== undefined && object.streamId !== null
+        ? String(object.streamId)
+        : "";
+    message.iceCandidates = (object.iceCandidates ?? []).map((e: any) =>
+      bytesFromBase64(e)
+    );
+    return message;
+  },
+
+  toJSON(message: AddIceCandidatesRequest): unknown {
+    const obj: any = {};
+    message.streamId !== undefined && (obj.streamId = message.streamId);
+    if (message.iceCandidates) {
+      obj.iceCandidates = message.iceCandidates.map((e) =>
+        base64FromBytes(e !== undefined ? e : new Uint8Array())
+      );
+    } else {
+      obj.iceCandidates = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AddIceCandidatesRequest>, I>>(
+    object: I
+  ): AddIceCandidatesRequest {
+    const message = {
+      ...baseAddIceCandidatesRequest,
+    } as AddIceCandidatesRequest;
+    message.streamId = object.streamId ?? "";
+    message.iceCandidates = object.iceCandidates?.map((e) => e) || [];
+    return message;
+  },
+};
+
+const baseAddIceCandidatesResponse: object = { ok: false };
+
+export const AddIceCandidatesResponse = {
+  encode(
+    message: AddIceCandidatesResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.ok === true) {
+      writer.uint32(8).bool(message.ok);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): AddIceCandidatesResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = {
+      ...baseAddIceCandidatesResponse,
+    } as AddIceCandidatesResponse;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.ok = reader.bool();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AddIceCandidatesResponse {
+    const message = {
+      ...baseAddIceCandidatesResponse,
+    } as AddIceCandidatesResponse;
+    message.ok =
+      object.ok !== undefined && object.ok !== null
+        ? Boolean(object.ok)
+        : false;
+    return message;
+  },
+
+  toJSON(message: AddIceCandidatesResponse): unknown {
+    const obj: any = {};
+    message.ok !== undefined && (obj.ok = message.ok);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AddIceCandidatesResponse>, I>>(
+    object: I
+  ): AddIceCandidatesResponse {
+    const message = {
+      ...baseAddIceCandidatesResponse,
+    } as AddIceCandidatesResponse;
+    message.ok = object.ok ?? false;
+    return message;
+  },
+};
+
+const baseIceCandidateRequest: object = { streamId: "" };
+
+export const IceCandidateRequest = {
+  encode(
+    message: IceCandidateRequest,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.streamId !== "") {
+      writer.uint32(10).string(message.streamId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): IceCandidateRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseIceCandidateRequest } as IceCandidateRequest;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.streamId = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): IceCandidateRequest {
+    const message = { ...baseIceCandidateRequest } as IceCandidateRequest;
+    message.streamId =
+      object.streamId !== undefined && object.streamId !== null
+        ? String(object.streamId)
+        : "";
+    return message;
+  },
+
+  toJSON(message: IceCandidateRequest): unknown {
+    const obj: any = {};
+    message.streamId !== undefined && (obj.streamId = message.streamId);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<IceCandidateRequest>, I>>(
+    object: I
+  ): IceCandidateRequest {
+    const message = { ...baseIceCandidateRequest } as IceCandidateRequest;
+    message.streamId = object.streamId ?? "";
+    return message;
+  },
+};
+
+const baseIceCandidateResponse: object = {};
+
+export const IceCandidateResponse = {
+  encode(
+    message: IceCandidateResponse,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.iceCandidate.length !== 0) {
+      writer.uint32(10).bytes(message.iceCandidate);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): IceCandidateResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseIceCandidateResponse } as IceCandidateResponse;
+    message.iceCandidate = new Uint8Array();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.iceCandidate = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): IceCandidateResponse {
+    const message = { ...baseIceCandidateResponse } as IceCandidateResponse;
+    message.iceCandidate =
+      object.iceCandidate !== undefined && object.iceCandidate !== null
+        ? bytesFromBase64(object.iceCandidate)
+        : new Uint8Array();
+    return message;
+  },
+
+  toJSON(message: IceCandidateResponse): unknown {
+    const obj: any = {};
+    message.iceCandidate !== undefined &&
+      (obj.iceCandidate = base64FromBytes(
+        message.iceCandidate !== undefined
+          ? message.iceCandidate
+          : new Uint8Array()
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<IceCandidateResponse>, I>>(
+    object: I
+  ): IceCandidateResponse {
+    const message = { ...baseIceCandidateResponse } as IceCandidateResponse;
+    message.iceCandidate = object.iceCandidate ?? new Uint8Array();
     return message;
   },
 };
@@ -176,6 +553,14 @@ export interface Streamer {
     request: DeepPartial<InitializeStreamRequest>,
     metadata?: grpc.Metadata
   ): Promise<InitializeStreamResponse>;
+  addIceCandidates(
+    request: DeepPartial<AddIceCandidatesRequest>,
+    metadata?: grpc.Metadata
+  ): Promise<AddIceCandidatesResponse>;
+  iceCandidates(
+    request: DeepPartial<IceCandidateRequest>,
+    metadata?: grpc.Metadata
+  ): Observable<IceCandidateResponse>;
 }
 
 export class StreamerClientImpl implements Streamer {
@@ -184,6 +569,8 @@ export class StreamerClientImpl implements Streamer {
   constructor(rpc: Rpc) {
     this.rpc = rpc;
     this.initializeStream = this.initializeStream.bind(this);
+    this.addIceCandidates = this.addIceCandidates.bind(this);
+    this.iceCandidates = this.iceCandidates.bind(this);
   }
 
   initializeStream(
@@ -193,6 +580,28 @@ export class StreamerClientImpl implements Streamer {
     return this.rpc.unary(
       StreamerInitializeStreamDesc,
       InitializeStreamRequest.fromPartial(request),
+      metadata
+    );
+  }
+
+  addIceCandidates(
+    request: DeepPartial<AddIceCandidatesRequest>,
+    metadata?: grpc.Metadata
+  ): Promise<AddIceCandidatesResponse> {
+    return this.rpc.unary(
+      StreamerAddIceCandidatesDesc,
+      AddIceCandidatesRequest.fromPartial(request),
+      metadata
+    );
+  }
+
+  iceCandidates(
+    request: DeepPartial<IceCandidateRequest>,
+    metadata?: grpc.Metadata
+  ): Observable<IceCandidateResponse> {
+    return this.rpc.invoke(
+      StreamerIceCandidatesDesc,
+      IceCandidateRequest.fromPartial(request),
       metadata
     );
   }
@@ -224,6 +633,50 @@ export const StreamerInitializeStreamDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
+export const StreamerAddIceCandidatesDesc: UnaryMethodDefinitionish = {
+  methodName: "AddIceCandidates",
+  service: StreamerDesc,
+  requestStream: false,
+  responseStream: false,
+  requestType: {
+    serializeBinary() {
+      return AddIceCandidatesRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      return {
+        ...AddIceCandidatesResponse.decode(data),
+        toObject() {
+          return this;
+        },
+      };
+    },
+  } as any,
+};
+
+export const StreamerIceCandidatesDesc: UnaryMethodDefinitionish = {
+  methodName: "IceCandidates",
+  service: StreamerDesc,
+  requestStream: false,
+  responseStream: true,
+  requestType: {
+    serializeBinary() {
+      return IceCandidateRequest.encode(this).finish();
+    },
+  } as any,
+  responseType: {
+    deserializeBinary(data: Uint8Array) {
+      return {
+        ...IceCandidateResponse.decode(data),
+        toObject() {
+          return this;
+        },
+      };
+    },
+  } as any,
+};
+
 interface UnaryMethodDefinitionishR
   extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
@@ -238,13 +691,18 @@ interface Rpc {
     request: any,
     metadata: grpc.Metadata | undefined
   ): Promise<any>;
+  invoke<T extends UnaryMethodDefinitionish>(
+    methodDesc: T,
+    request: any,
+    metadata: grpc.Metadata | undefined
+  ): Observable<any>;
 }
 
 export class GrpcWebImpl {
   private host: string;
   private options: {
     transport?: grpc.TransportFactory;
-
+    streamingTransport?: grpc.TransportFactory;
     debug?: boolean;
     metadata?: grpc.Metadata;
   };
@@ -253,7 +711,7 @@ export class GrpcWebImpl {
     host: string,
     options: {
       transport?: grpc.TransportFactory;
-
+      streamingTransport?: grpc.TransportFactory;
       debug?: boolean;
       metadata?: grpc.Metadata;
     }
@@ -294,6 +752,47 @@ export class GrpcWebImpl {
         },
       });
     });
+  }
+
+  invoke<T extends UnaryMethodDefinitionish>(
+    methodDesc: T,
+    _request: any,
+    metadata: grpc.Metadata | undefined
+  ): Observable<any> {
+    // Status Response Codes (https://developers.google.com/maps-booking/reference/grpc-api/status_codes)
+    const upStreamCodes = [2, 4, 8, 9, 10, 13, 14, 15];
+    const DEFAULT_TIMEOUT_TIME: number = 3_000;
+    const request = { ..._request, ...methodDesc.requestType };
+    const maybeCombinedMetadata =
+      metadata && this.options.metadata
+        ? new BrowserHeaders({
+            ...this.options?.metadata.headersMap,
+            ...metadata?.headersMap,
+          })
+        : metadata || this.options.metadata;
+    return new Observable((observer) => {
+      const upStream = () => {
+        const client = grpc.invoke(methodDesc, {
+          host: this.host,
+          request,
+          transport: this.options.streamingTransport || this.options.transport,
+          metadata: maybeCombinedMetadata,
+          debug: this.options.debug,
+          onMessage: (next) => observer.next(next),
+          onEnd: (code: grpc.Code, message: string) => {
+            if (code === 0) {
+              observer.complete();
+            } else if (upStreamCodes.includes(code)) {
+              setTimeout(upStream, DEFAULT_TIMEOUT_TIME);
+            } else {
+              observer.error(new Error(`Error ${code} ${message}`));
+            }
+          },
+        });
+        observer.add(() => client.close());
+      };
+      upStream();
+    }).pipe(share());
   }
 }
 

--- a/proto/streaming/streaming.proto
+++ b/proto/streaming/streaming.proto
@@ -4,11 +4,34 @@ package streaming;
 service Streamer {
   rpc InitializeStream(InitializeStreamRequest)
       returns (InitializeStreamResponse);
+
+  rpc AddIceCandidates(AddIceCandidatesRequest)
+      returns (AddIceCandidatesResponse);
+
+  rpc IceCandidates(IceCandidateRequest) returns (stream IceCandidateResponse);
 }
 
 message InitializeStreamRequest { bytes rtcSessionDescription = 1; }
 
 message InitializeStreamResponse {
-  bytes rtcSessionDescription = 1;
-  string error = 2;
+  message Ok {
+    bytes rtcSessionDescription = 1;
+    string stream_id = 2;
+  }
+
+  oneof Response {
+    Ok ok = 3;
+    string error = 4;
+  }
 }
+
+message AddIceCandidatesRequest {
+  string stream_id = 1;
+  repeated bytes iceCandidates = 2;
+}
+
+message AddIceCandidatesResponse { bool ok = 1; }
+
+message IceCandidateRequest { string stream_id = 1; }
+
+message IceCandidateResponse { bytes iceCandidate = 1; }

--- a/test/aws-lambda-grpc-test/Cargo.toml
+++ b/test/aws-lambda-grpc-test/Cargo.toml
@@ -19,6 +19,7 @@ lambda_runtime = "0.4"
 lambda_http = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio-stream = "0.1.8"
 log = "0.4"
 simple_logger = "1.13"
 lgn-streaming-proto = { path = "../../proto/streaming", version = "0.1.0" }

--- a/test/aws-lambda-grpc-test/src/handler.rs
+++ b/test/aws-lambda-grpc-test/src/handler.rs
@@ -1,7 +1,10 @@
 use lgn_streaming_proto::{
-    streamer_server::Streamer, InitializeStreamRequest, InitializeStreamResponse,
+    initialize_stream_response, streamer_server::Streamer, AddIceCandidatesRequest,
+    AddIceCandidatesResponse, IceCandidateRequest, IceCandidateResponse, InitializeStreamRequest,
+    InitializeStreamResponse,
 };
 use log::info;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
 pub struct MyStreamer;
@@ -13,11 +16,37 @@ impl Streamer for MyStreamer {
         request: Request<InitializeStreamRequest>,
     ) -> Result<Response<InitializeStreamResponse>, Status> {
         let request = request.into_inner();
+
         info!("gRPC request received: {:?}", request);
+
         let response = InitializeStreamResponse {
-            rtc_session_description: request.rtc_session_description,
-            error: "".to_string(),
+            response: Some(initialize_stream_response::Response::Ok(
+                initialize_stream_response::Ok {
+                    rtc_session_description: request.rtc_session_description,
+                    stream_id: "stream-id".to_string(),
+                },
+            )),
         };
+
         Ok(Response::new(response))
+    }
+
+    // TODO: Implement test
+    async fn add_ice_candidates(
+        &self,
+        _request: Request<AddIceCandidatesRequest>,
+    ) -> Result<Response<AddIceCandidatesResponse>, Status> {
+        unimplemented!()
+    }
+
+    #[doc = "Server streaming response type for the IceCandidates method."]
+    type IceCandidatesStream = ReceiverStream<Result<IceCandidateResponse, Status>>;
+
+    // TODO: Implement test
+    async fn ice_candidates(
+        &self,
+        _request: Request<IceCandidateRequest>,
+    ) -> Result<Response<Self::IceCandidatesStream>, Status> {
+        unimplemented!()
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3986,6 +3986,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@6.6.7:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
+
 sade@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/sade/-/sade-1.7.4.tgz#ea681e0c65d248d2095c90578c03ca0bb1b54691"
@@ -4473,7 +4480,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
Or die tryin'

- [x] Cleanup `video.svelte` and `videoPlayer.ts` code (basically drop most of the code)
- [ ] Use tracks and direct stream instead of using a temporary URL (mostly done)

So far everything works well when streaming an h264 file, but it doesn't work with the frames which is (very likely) related to the encoding. I might need a hand tomorrow morning to check the encoding and maybe change it if needed 😕 