### PR TITLE
Ignore sample-data eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 *.js text eol=lf
 *.svelte text eol=lf
 *.lock text eol=lf
+test/sample-data/**/* text eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf


### PR DESCRIPTION
Currently when sample data is regenerated git marks most (if not all) data as 'not staged' and when diffing shows `warning: CRLF will be replaced by LF in '_filename_'`

I am not sure if there is a better way of doing this. Any suggestions?