### PR TITLE
minor determinism fix in codegen

### DIFF
--- a/lib/data-codegen/src/lib.rs
+++ b/lib/data-codegen/src/lib.rs
@@ -102,8 +102,13 @@ pub fn generate_for_directory(directory: &std::path::Path) -> Result<(), Box<dyn
             let mut processed_types = Vec::<DataContainerMetaInfo>::new();
 
             // Process all the .rs inside the directory
-            for entry in std::fs::read_dir(directory)? {
-                let path = entry?.path();
+            let mut paths = std::fs::read_dir(directory)?
+                .map(|result| result.map(|entry| entry.path()))
+                .collect::<Result<Vec<_>, std::io::Error>>()?;
+            // Since the order in which read_dir returns entries is platform+filesystem dependent,
+            // sort to guarantee determinism
+            paths.sort();
+            for path in paths {
                 let filename = path.file_name().unwrap().to_ascii_lowercase();
 
                 if let Some(ext) = path.extension() {


### PR DESCRIPTION
Workaround for std::fs::read_dir entry order being different on WSL.
See https://doc.rust-lang.org/std/fs/fn.read_dir.html
Repro for issue (using WSL):
* cargo clean
* cargo cg -p generic-data
will modify test/generic-data/codegen content (mod.rs files)