### PR TITLE
lgn-graphics-api compiles if track-device-contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13739d7177fbd22bb0ed28badfff9f372f8bef46c863db4e1c6248f6b223b6e"
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +729,21 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.4",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide 0.4.4",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -2647,6 +2671,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
 name = "gio"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,6 +4059,7 @@ name = "lgn-graphics-api"
 version = "0.1.0"
 dependencies = [
  "ash",
+ "backtrace",
  "bitflags",
  "bumpalo",
  "crossbeam-channel 0.5.1",
@@ -5480,6 +5511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6580,6 +6620,12 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils 0.8.5",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"

--- a/lib/graphics-api/Cargo.toml
+++ b/lib/graphics-api/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
+track-device-contexts = ["backtrace"]
 vulkan = ["ash", "vk-mem"]
 
 [dependencies]
@@ -16,6 +17,7 @@ bumpalo = "3.8"
 lgn-utils = { path = "../../lib/utils", version = "0.1.0" }
 lgn-telemetry = { path = "../telemetry", version = "0.1.0" }
 raw-window-handle = "0.4"
+backtrace = { version = "0.3", optional = true }
 bitflags = "1.3"
 fnv = "1.0"
 serde = { version = "1.0", features = ["serde_derive"] }

--- a/lib/graphics-api/src/backends/vulkan/device_context.rs
+++ b/lib/graphics-api/src/backends/vulkan/device_context.rs
@@ -1,4 +1,7 @@
 use std::ffi::CStr;
+#[cfg(debug_assertions)]
+#[cfg(feature = "track-device-contexts")]
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 
 use ash::extensions::khr;
@@ -64,10 +67,12 @@ pub(crate) struct VulkanDeviceContext {
 
     #[cfg(debug_assertions)]
     #[cfg(feature = "track-device-contexts")]
+    #[allow(dead_code)]
     next_create_index: AtomicU64,
 
     #[cfg(debug_assertions)]
     #[cfg(feature = "track-device-contexts")]
+    #[allow(dead_code)]
     all_contexts: Mutex<fnv::FnvHashMap<u64, backtrace::Backtrace>>,
 }
 

--- a/lib/graphics-api/src/types/device_context.rs
+++ b/lib/graphics-api/src/types/device_context.rs
@@ -1,5 +1,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+#[cfg(debug_assertions)]
+#[cfg(feature = "track-device-contexts")]
+use std::{sync::atomic::AtomicU64, sync::Mutex};
 
 use raw_window_handle::HasRawWindowHandle;
 
@@ -52,7 +55,7 @@ pub(crate) struct DeviceContextInner {
 
     #[cfg(debug_assertions)]
     #[cfg(feature = "track-device-contexts")]
-    all_contexts: Mutex<fnv::FnvHashMap<u64, backtrace::Backtrace>>,
+    pub(crate) all_contexts: Mutex<fnv::FnvHashMap<u64, backtrace::Backtrace>>,
 
     #[cfg(feature = "vulkan")]
     pub(crate) platform_device_context: VulkanDeviceContext,
@@ -156,7 +159,7 @@ impl Clone for DeviceContext {
                     .insert(create_index, create_backtrace);
             }
 
-            log::trace!("Cloned VulkanDeviceContext create_index {}", create_index);
+            trace!("Cloned VulkanDeviceContext create_index {}", create_index);
             create_index
         };
         Self {


### PR DESCRIPTION
Noticed remaining occurrence of log::trace in "dead" code within graphics-api.
Fixed compilation of lgn-graphics-api if "track-device-contexts" feature is enabled