### PR TITLE
Banning the use of crc32 in our codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,6 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "chrono",
- "crc",
  "lgn-analytics",
  "lgn-source-control",
  "lgn-telemetry",
@@ -175,6 +174,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tonic-web",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,7 @@
 # This will change once we become more stable
 avoid-breaking-exported-api = false
-# disallowed-types = [{ path = "rustc_hash::FxHashMap", reason = "use this instead" }]
+disallowed-types = [
+    "crc::Crc", # "use xxHash familiy of hashes, ideally XXH3"
+]
 # disallowed-methods = [{ path = "std::vec::Vec::leak", reason = "no leaking memory" }]
 # enforced-import-renames = [ { path = "serde_json::Value", rename = "JsonValue" }]

--- a/server/analytics-srv/Cargo.toml
+++ b/server/analytics-srv/Cargo.toml
@@ -15,6 +15,7 @@ lgn-telemetry-sink = { path = "../../lib/telemetry-sink", version = "0.1.0" }
 lgn-transit = { path = "../../lib/transit", version = "0.1.0" }
 anyhow = "1.0"
 async-recursion = "1"
+chrono = "0.4"
 tonic = "0.6"
 tonic-web = "0.2"
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
@@ -25,8 +26,7 @@ sqlx = { version = "0.5", features = [
     "runtime-tokio-native-tls",
 ] }
 prost = "0.9"
-crc = "2.1.0"
-chrono = "0.4"
+xxhash-rust = { version = "0.8.2", features = ["xxh32", "const_xxh32"] }
 
 [build-dependencies]
 tonic-build = "0.6"

--- a/server/analytics-srv/src/call_tree.rs
+++ b/server/analytics-srv/src/call_tree.rs
@@ -186,11 +186,11 @@ pub(crate) async fn compute_block_call_tree(
 }
 
 pub(crate) type ScopeHashMap = std::collections::HashMap<u32, ScopeDesc>;
-const CRC32: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
+use xxhash_rust::const_xxh32::xxh32 as const_xxh32;
 
 fn compute_scope_hash(name: &str) -> u32 {
     //todo: add filename
-    CRC32.checksum(name.as_bytes())
+    const_xxh32(name.as_bytes(), 0)
 }
 
 fn make_spans_from_tree(tree: &CallTreeNode, depth: u32, lod: &mut SpanBlockLod) {


### PR DESCRIPTION
Rationale: xxHash is far better in all regards, spead, collision rate,
it's a not brainer to use, as it can reduce a headeach later on.