### PR TITLE
Editor client: Initialize render surface with the resolution provided by the client

### DIFF
--- a/lib/browser/frontend/src/components/RemoteWindow.svelte
+++ b/lib/browser/frontend/src/components/RemoteWindow.svelte
@@ -174,6 +174,31 @@
         return;
       }
 
+      const normalizedDesiredResolution =
+        normalizeDesiredResolution(desiredResolution);
+
+      if (
+        !normalizedDesiredResolution ||
+        normalizedDesiredResolution.width == 0 ||
+        normalizedDesiredResolution.height == 0
+      ) {
+        return;
+      }
+
+      log.debug(
+        "video",
+        `Resolution is: ${normalizedDesiredResolution.width}x${normalizedDesiredResolution.height}`
+      );
+
+      videoChannel.send(
+        JSON.stringify({
+          event: "initialize",
+          color: backgroundColors[serverType],
+          width: normalizedDesiredResolution.width,
+          height: normalizedDesiredResolution.height,
+        })
+      );
+
       log.debug("video", "Video channel is now open.");
     };
 
@@ -184,53 +209,6 @@
     videoChannel.onmessage = async (message: MessageEvent<ArrayBuffer>) => {
       if (!videoElement) {
         return;
-      }
-
-      // If the message is very small it's unlikely to be a frame
-      if (message.data.byteLength < 100) {
-        try {
-          const jsonMessage = JSON.parse(
-            new TextDecoder().decode(message.data)
-          );
-
-          if (
-            videoChannel &&
-            desiredResolution &&
-            jsonMessage.type === "initialized"
-          ) {
-            const normalizedDesiredResolution =
-              normalizeDesiredResolution(desiredResolution);
-
-            if (
-              !normalizedDesiredResolution ||
-              normalizedDesiredResolution.width == 0 ||
-              normalizedDesiredResolution.height == 0
-            ) {
-              return;
-            }
-
-            log.debug(
-              "video",
-              `Resolution is: ${normalizedDesiredResolution.width}x${normalizedDesiredResolution.height}`
-            );
-
-            videoChannel.send(
-              JSON.stringify({
-                event: "initialize",
-                color: backgroundColors[serverType],
-                width: normalizedDesiredResolution.width,
-                height: normalizedDesiredResolution.height,
-              })
-            );
-          }
-        } catch {
-          log.error(
-            "Couldn't JSON parse what seemed to be a message coming from the server"
-          );
-        } finally {
-          // Block the message and don't push it into the player
-          return;
-        }
       }
 
       // videoElement is augmented with the `videoPlayer` action and will

--- a/plugin/streamer/src/streamer/events.rs
+++ b/plugin/streamer/src/streamer/events.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::bail;
 use lgn_input::{
     keyboard::KeyboardInput,
@@ -7,20 +9,26 @@ use lgn_input::{
 };
 use lgn_math::Vec2;
 use serde::Deserialize;
+use webrtc::data_channel::RTCDataChannel;
 
 use super::StreamID;
 
-#[derive(Debug)]
 pub(crate) struct VideoStreamEvent {
     pub(crate) stream_id: StreamID,
     pub(crate) info: VideoStreamEventInfo,
+    pub(crate) video_data_channel: Arc<RTCDataChannel>,
 }
 
 impl VideoStreamEvent {
-    pub(crate) fn parse(stream_id: StreamID, data: &[u8]) -> anyhow::Result<Self> {
+    pub(crate) fn parse(
+        stream_id: StreamID,
+        video_data_channel: Arc<RTCDataChannel>,
+        data: &[u8],
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             stream_id,
             info: serde_json::from_slice(data)?,
+            video_data_channel,
         })
     }
 }

--- a/plugin/streamer/src/streamer/mod.rs
+++ b/plugin/streamer/src/streamer/mod.rs
@@ -77,7 +77,6 @@ impl Streamer {
 pub(crate) fn handle_stream_events(
     task_pool: Res<'_, RenderTaskPool>,
     streamer: Res<'_, Streamer>,
-    renderer: Res<'_, Renderer>,
     mut commands: Commands<'_, '_>,
     mut video_stream_events: EventWriter<'_, '_, VideoStreamEvent>,
 ) {
@@ -104,28 +103,7 @@ pub(crate) fn handle_stream_events(
                     stream_id,
                 );
             }
-            StreamEvent::VideoChannelOpened(stream_id, data_channel) => {
-                let resolution = Resolution::new(1024, 768);
-
-                let video_player_data_channel = Arc::clone(&data_channel);
-
-                let video_stream =
-                    VideoStream::new(&renderer, resolution, video_player_data_channel).unwrap();
-
-                let mut render_surface = RenderSurface::new(
-                    &renderer,
-                    RenderSurfaceExtents::new(resolution.width(), resolution.height()),
-                );
-                render_surface.register_presenter(|| video_stream);
-                commands.entity(stream_id.entity).insert(render_surface);
-
-                task_pool.spawn(async move {
-                    data_channel
-                        .send(&Bytes::from(r#"{"type": "initialized"}"#))
-                        .await
-                        .unwrap();
-                });
-
+            StreamEvent::VideoChannelOpened(stream_id, _data_channel) => {
                 info!(
                     "Video channel is now opened for stream {}: adding a video-stream component",
                     stream_id,
@@ -139,8 +117,8 @@ pub(crate) fn handle_stream_events(
                     stream_id,
                 );
             }
-            StreamEvent::VideoChannelMessageReceived(stream_id, _, msg) => {
-                match VideoStreamEvent::parse(stream_id, &msg.data) {
+            StreamEvent::VideoChannelMessageReceived(stream_id, data_channel, msg) => {
+                match VideoStreamEvent::parse(stream_id, data_channel, &msg.data) {
                     Ok(event) => {
                         video_stream_events.send(event);
                     }
@@ -188,6 +166,7 @@ pub(crate) fn handle_stream_events(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn update_streams(
     renderer: Res<'_, Renderer>,
+    mut commands: Commands<'_, '_>,
     mut query: Query<'_, '_, &mut RenderSurface>,
     mut video_stream_events: EventReader<'_, '_, VideoStreamEvent>,
     mut input_mouse_motion: EventWriter<'_, '_, MouseMotion>,
@@ -197,70 +176,98 @@ pub(crate) fn update_streams(
     mut input_keyboard_input: EventWriter<'_, '_, KeyboardInput>,
 ) {
     for event in video_stream_events.iter() {
-        match query.get_mut(event.stream_id.entity) {
-            Ok(mut render_surface) => {
+        match &event.info {
+            VideoStreamEventInfo::Initialize {
+                color,
+                width,
+                height,
+            } => {
+                info!("received initialize command");
+
+                let resolution = Resolution::new(*width, *height);
+
+                let video_data_channel = Arc::clone(&event.video_data_channel);
+
+                let video_stream =
+                    VideoStream::new(&renderer, resolution, video_data_channel).unwrap();
+
+                let mut render_surface = RenderSurface::new(
+                    &renderer,
+                    RenderSurfaceExtents::new(resolution.width(), resolution.height()),
+                );
+
+                render_surface.register_presenter(|| video_stream);
+
                 let render_pass = render_surface.test_renderpass();
 
-                match &event.info {
-                    VideoStreamEventInfo::Initialize {
-                        color,
-                        width,
-                        height,
-                    } => {
-                        info!("received initialize command");
+                commands
+                    .entity(event.stream_id.entity)
+                    .insert(render_surface);
 
+                render_pass.write().set_color(color.0);
+
+                let video_data_channel = Arc::clone(&event.video_data_channel);
+
+                let _ = video_data_channel.send(&Bytes::from(r#"{"type": "initialized"}"#));
+            }
+            VideoStreamEventInfo::Resize { width, height } => {
+                match query.get_mut(event.stream_id.entity) {
+                    Ok(mut render_surface) => {
                         let resolution = Resolution::new(*width, *height);
 
                         render_surface.resize(
                             &renderer,
                             RenderSurfaceExtents::new(resolution.width(), resolution.height()),
                         );
-
-                        render_pass.write().set_color(color.0);
                     }
-                    VideoStreamEventInfo::Resize { width, height } => {
-                        let resolution = Resolution::new(*width, *height);
-
-                        render_surface.resize(
-                            &renderer,
-                            RenderSurfaceExtents::new(resolution.width(), resolution.height()),
-                        );
-                    }
-                    VideoStreamEventInfo::Speed { speed } => {
-                        info!("received speed command {}", speed);
-                        render_pass.write().set_speed(*speed);
-                    }
-                    VideoStreamEventInfo::Input { input } => {
-                        info!("received input: {:?}", input);
-
-                        match input {
-                            Input::MouseButtonInput(mouse_button_input) => {
-                                input_mouse_button_input.send(mouse_button_input.clone());
-                            }
-                            Input::MouseMotion(mouse_motion) => {
-                                input_mouse_motion.send(mouse_motion.clone());
-                            }
-                            Input::MouseWheel(mouse_wheel) => {
-                                input_mouse_wheel.send(mouse_wheel.clone());
-                            }
-                            Input::TouchInput(touch_input) => {
-                                // A bit unsure why, but unlike other events
-                                // [`legion_input::touch:TouchInput`]
-                                // derives Copy (_and_ `Clone`).
-                                input_touch_input.send(*touch_input);
-                            }
-                            Input::KeyboardInput(keyboard_input) => {
-                                input_keyboard_input.send(keyboard_input.clone());
-                            }
-                        }
+                    Err(query_err) => {
+                        // TODO
+                        // Most likely: "The given entity does not have the requested component"
+                        // i.e. the entity associated with the stream-id does not have a RenderSurface
+                        error!("{}", query_err);
                     }
                 }
             }
-            Err(query_err) => {
-                // TODO
-                // Most likely: "The given entity does not have the requested component"
-                // i.e. the entity associated with the stream-id does not have a RenderSurface
-                error!("{}", query_err);
+            VideoStreamEventInfo::Speed { speed } => {
+                info!("received speed command {}", speed);
+
+                match query.get_mut(event.stream_id.entity) {
+                    Ok(render_surface) => {
+                        let render_pass = render_surface.test_renderpass();
+
+                        render_pass.write().set_speed(*speed);
+                    }
+                    Err(query_err) => {
+                        // TODO
+                        // Most likely: "The given entity does not have the requested component"
+                        // i.e. the entity associated with the stream-id does not have a RenderSurface
+                        error!("{}", query_err);
+                    }
+                }
+            }
+            VideoStreamEventInfo::Input { input } => {
+                info!("received input: {:?}", input);
+
+                match input {
+                    Input::MouseButtonInput(mouse_button_input) => {
+                        input_mouse_button_input.send(mouse_button_input.clone());
+                    }
+                    Input::MouseMotion(mouse_motion) => {
+                        input_mouse_motion.send(mouse_motion.clone());
+                    }
+                    Input::MouseWheel(mouse_wheel) => {
+                        input_mouse_wheel.send(mouse_wheel.clone());
+                    }
+                    Input::TouchInput(touch_input) => {
+                        // A bit unsure why, but unlike other events
+                        // [`legion_input::touch:TouchInput`]
+                        // derives Copy (_and_ `Clone`).
+                        input_touch_input.send(*touch_input);
+                    }
+                    Input::KeyboardInput(keyboard_input) => {
+                        input_keyboard_input.send(keyboard_input.clone());
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
~Send the resolution as soon as possible. I'm working on a version that initialize the render surface with the proper resolution, but just in case we can maybe start with this pr?~

Render surface is initialized with the resolution sent by the client.

@anthony-de-rochefort does it help?