### PR TITLE
Editor client deactivate wasm example for now as it seems to block the cargo run commands

### DIFF
--- a/client/editor/frontend/package.json
+++ b/client/editor/frontend/package.json
@@ -56,7 +56,6 @@
     "@lgn/frontend": "^0.1.0",
     "@lgn/proto-editor": "^0.1.0",
     "@lgn/proto-streaming": "^0.1.0",
-    "@lgn/simple-wasm-logger": "workspace:^0.1.0",
     "@tauri-apps/api": "^1.0.0-beta.8",
     "browser-headers": "^0.4.1",
     "color-convert": "^2.0.1",

--- a/client/editor/frontend/src/index.ts
+++ b/client/editor/frontend/src/index.ts
@@ -3,17 +3,17 @@ import "./assets/index.css";
 import { defaultAuthUserConfig, run } from "@lgn/frontend";
 import App from "@/App.svelte";
 import "@/workers/editorWorker";
-import initWasmLogger, { debug } from "@lgn/simple-wasm-logger";
+// import initWasmLogger, { debug } from "@lgn/simple-wasm-logger";
 
 run({
   appComponent: App,
   auth: defaultAuthUserConfig(),
   rootQuerySelector: "#root",
   logLevel: "warn",
-  async onPreInit() {
-    await initWasmLogger();
-    debug("Hello from the Legion editor");
-  },
+  // async onPreInit() {
+  //   await initWasmLogger();
+  //   debug("Hello from the Legion editor");
+  // },
 })
   // eslint-disable-next-line no-console
   .catch((error) => console.error("Application couldn't start", error));

--- a/client/editor/frontend/vite.config.js
+++ b/client/editor/frontend/vite.config.js
@@ -4,7 +4,7 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import viteTsProto from "vite-plugin-ts-proto";
-import viteWasmPack from "vite-plugin-wasm";
+// import viteWasmPack from "vite-plugin-wasm";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -19,15 +19,15 @@ export default defineConfig({
         { name: "@lgn/proto-streaming", glob: "*.proto" },
       ],
     }),
-    viteWasmPack({
-      crates: [
-        {
-          path: "../../../lib/simple-wasm-logger",
-          packageName: "@lgn/simple-wasm-logger",
-        },
-      ],
-      outDir: "frontend",
-      quiet: true,
-    }),
+    // viteWasmPack({
+    //   crates: [
+    //     {
+    //       path: "../../../lib/simple-wasm-logger",
+    //       packageName: "@lgn/simple-wasm-logger",
+    //     },
+    //   ],
+    //   outDir: "frontend",
+    //   quiet: true,
+    // }),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,6 @@ importers:
       '@lgn/frontend': ^0.1.0
       '@lgn/proto-editor': ^0.1.0
       '@lgn/proto-streaming': ^0.1.0
-      '@lgn/simple-wasm-logger': workspace:^0.1.0
       '@sveltejs/vite-plugin-svelte': ^1.0.0-next.34
       '@swc/core': ^1.2.127
       '@swc/jest': ^0.2.15
@@ -144,7 +143,6 @@ importers:
       '@lgn/frontend': link:../../../lib/browser/frontend
       '@lgn/proto-editor': link:../../../proto/editor
       '@lgn/proto-streaming': link:../../../proto/streaming
-      '@lgn/simple-wasm-logger': link:../../../lib/simple-wasm-logger/frontend
       '@tauri-apps/api': 1.0.0-beta.8
       browser-headers: 0.4.1
       color-convert: 2.0.1


### PR DESCRIPTION
If wasm-pack is indeed blocking `cargo run --bin editor-client --release` this pr disables it for now.

I think it'll be better to use `wasm-bindgen` (that doesn't run `cargo build`) anyway, so after the CI uses `monorepo` I can use `wasm-bindgen` and add this example back 👍 