### PR TITLE
select package from bin on monorepo build command

### DIFF
--- a/build/lgn-monorepo/src/build.rs
+++ b/build/lgn-monorepo/src/build.rs
@@ -49,6 +49,10 @@ pub fn run(mut args: Args, ctx: &Context) -> Result<()> {
         .exclude
         .push(env!("CARGO_PKG_NAME").into());
 
-    let packages = args.package_args.to_selected_packages(ctx)?;
+    let mut packages = args.package_args.to_selected_packages(ctx)?;
+    let bin = args.build_args.bin.first();
+    if let Some(bin) = bin {
+        packages.select_package_from_bin(bin.as_str(), ctx)?;
+    }
     cmd.run_on_packages(ctx, &packages)
 }


### PR DESCRIPTION
When running a "build" sub-command on lgn-monorepo, default to the package associated with the binary argument if one is provided.
Same behavior as in the "run" sub-command.

To repro the issue:
1) add an invalid statement (ex: "use lgn_scripting::ScriptingPlugin;" in body of update_rotation (generic-data/src/plugin.rs)
2) cargo mbuild --bin lgn-graphics-sandbox
should not build successfully, but does without this fix