### PR TITLE
Fix editor-srv crash

### DIFF
--- a/crates/lgn-renderer/src/lib.rs
+++ b/crates/lgn-renderer/src/lib.rs
@@ -472,6 +472,8 @@ fn render_update(
 
         render_surface.present(&render_context);
     }
+
+    debug_display.clear_display_lists();
 }
 
 fn render_post_update(mut renderer: ResMut<'_, Renderer>) {

--- a/crates/lgn-renderer/src/render_pass/debug_render_pass.rs
+++ b/crates/lgn-renderer/src/render_pass/debug_render_pass.rs
@@ -219,8 +219,6 @@ impl DebugRenderPass {
                 default_meshes,
             );
         });
-
-        debug_display.clear_display_lists();
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Unblocking quick fix for server crash when we keep adding display lists to the debug display but there's no surface to render them