### PR TITLE
Editor client: Rename resource via the context menu

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -4,3 +4,9 @@
 
 - rafx-api (https://github.com/aclysma/rafx) helped us bootstrap the low level rendering code
 - bevy_app, bevy_ecs, bevy_tasks, bevy_input, bevy_winit, bevy_window, as the basis of the engine runtime core
+
+## Icons used
+
+- A first draft of the application contained some raw SVG (copy pasted for technical purpose) from the [Boostrap icons set](https://icons.getbootstrap.com/) v1.7.2 with [this License](https://github.com/twbs/icons/blob/main/LICENSE.md).
+- A second draft included some icons from the ["Material Design Icons" set](https://icon-sets.iconify.design/mdi/) with [this license](https://raw.githubusercontent.com/Templarian/MaterialDesign/master/LICENSE).
+- All icons used currently belongs to the ["Google Material Icons" set](https://icon-sets.iconify.design/ic/) with [this license](https://github.com/material-icons/material-icons/blob/master/LICENSE).

--- a/crates/lgn-analytics-gui/frontend/.eslintrc.js
+++ b/crates/lgn-analytics-gui/frontend/.eslintrc.js
@@ -19,8 +19,8 @@ module.exports = {
     "svelte3/ignore-styles": () => true,
   },
   rules: {
-    "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
+    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
     "@typescript-eslint/no-unused-vars": "off",
   },
 };

--- a/crates/lgn-browser/frontend/.eslintrc.cjs
+++ b/crates/lgn-browser/frontend/.eslintrc.cjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 module.exports = {
   env: {
     browser: true,
@@ -17,7 +19,8 @@ module.exports = {
     "svelte3/ignore-styles": () => true,
   },
   rules: {
-    "no-console": "error",
+    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
     "@typescript-eslint/no-unused-vars": "off",
   },
 };

--- a/crates/lgn-browser/frontend/src/actions/clickOutside.ts
+++ b/crates/lgn-browser/frontend/src/actions/clickOutside.ts
@@ -1,7 +1,11 @@
 // Taken from https://svelte.dev/repl/0ace7a508bd843b798ae599940a91783?version=3.16.7
 /**
  * When the user clicks outside the provided `node` (that is, on an element on the page
- * that isn't contained by the `node`) the `listener` function is callled.
+ * that isn't contained by the `node`) the `listener` function is called.
+ *
+ * To click inside the context menu (if it's present in the page) will _not_ trigger
+ * the click outside function.
+ *
  * @param node The `node`
  * @param listener The function called when the user clicks outside the `ref node`
  */
@@ -10,14 +14,22 @@ export default function clickOutside(
   listener: (event: MouseEvent) => void
 ) {
   const handleClick = (event: MouseEvent) => {
+    const contextMenu = document.getElementById("context-menu");
+
     if (
-      node &&
-      event.target instanceof Node &&
-      !node.contains(event.target) &&
-      !event.defaultPrevented
+      // Target is not a valid Node
+      !(event.target instanceof Node) ||
+      // The context menu is in the page and contains the event target
+      (contextMenu && contextMenu.contains(event.target)) ||
+      // The node contains the event target
+      node.contains(event.target) ||
+      // The event has been "prevented"
+      event.defaultPrevented
     ) {
-      listener(event);
+      return;
     }
+
+    listener(event);
   };
 
   window.addEventListener("click", handleClick, true);

--- a/crates/lgn-browser/frontend/src/actions/contextMenu.ts
+++ b/crates/lgn-browser/frontend/src/actions/contextMenu.ts
@@ -7,16 +7,44 @@ import { Store as ContextMenuStore } from "../stores/contextMenu";
  * The provided context menu name must have been registered using
  * the `contextMenuStore.register` function.
  */
-
 export default function buildContextMenu<
   EntryRecord extends Record<string, unknown>
 >(contextMenuStore: ContextMenuStore<EntryRecord>) {
   return function contextMenu<Name extends keyof EntryRecord>(
     element: HTMLElement,
-    { name, payload }: { name: Name; payload: EntryRecord[Name] }
+    options:
+      | string
+      | {
+          name: Name;
+          /** @deprecated Use the component states or Svelte stores instead of a payload */
+          payload: () => EntryRecord[Name];
+        }
   ) {
-    function listener() {
-      contextMenuStore.setActiveEntrySet(name, payload);
+    function listener(event: MouseEvent) {
+      // In dev mode `Ctrl + Right Click` will open the default
+      // context menu for dev purpose.
+      if (import.meta.env.DEV && event.ctrlKey) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const { name, payload } =
+        typeof options === "string"
+          ? { name: options, payload: () => undefined }
+          : options;
+
+      // TODO: We might get rid of the `payload` logic at one point
+      window.dispatchEvent(
+        new CustomEvent("custom-contextmenu", {
+          detail: {
+            name,
+            payload,
+            originalEvent: event,
+          },
+        })
+      );
     }
 
     element.addEventListener("contextmenu", listener);

--- a/crates/lgn-browser/frontend/src/components/ContextMenu.svelte
+++ b/crates/lgn-browser/frontend/src/components/ContextMenu.svelte
@@ -55,63 +55,63 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
   import ContextMenu from "@lgn/frontend/src/components/ContextMenu.svelte";
 
   import myContextMenu from "../actions/myContextMenu";
-  import myContextMenuStore from "../stores/myContextMenu";
-
-  // `onClick` doesn't do anything and closes the context menu
-  // right away. You can perform any kind of action in here
-  // (including asynchronous ones).
+  import myContextMenuStore, { ContextMenuEntryRecord } from "../stores/myContextMenu";
 
   contextMenuStore.register("my-context-menu", [
     {
       type: "item",
+      action: "do-this",
       label: "Do this",
-      onClick({ close }) { close(); },
     },
-    { type: "separator" },
     {
-      type:
-      "item",
+      type: "separator",
+    },
+    {
+      type: "item",
+      action: "do-that",
       label: "Do that",
-      onClick({ close }) { close(); },
     },
   ]);
-
-  // Since we properly defined our context entry record in our store,
-  // the `payload` variable has type `string | null` below:
 
   contextMenuStore.register("my-other-context-menu", [
     {
       type: "item",
+      action: "do-something-else",
       label: "Do this other thing",
-      onClick({ close, payload }) {
-        console.log(payload); // Will print `"I am a payload"`
-
-        close();
-      },
     },
-    { type: "separator" },
+    {
+      type: "separator",
+    },
     {
       type: "item",
+      action: "do-another-thing",
       label: "Do that other thing",
-      onClick({ close, payload }) {
-        console.log(payload); // Will print `"I am a payload"` too
-
-        close(); },
     },
   ]);
+
+  function handleContextMenuAction({
+    detail: { action }
+  }: ContextMenuActionEvent<ContextMenuEntryRecord>) {
+    switch (action) {
+      case "do-this": {
+        // ...
+      }
+
+      // ...
+    }
+  }
 </script>
+
+<svelte:window on:contextmenu-action={handleContextMenuAction} />
 
 <ContextMenu contextMenuStore={myContextMenuStore}
 
 <div>
-  <div>If you right click me, a default context menu is shown.</div>
-  <div use:myContextMenu={{ name: "my-context-menu" }}>
+  <div>If you right click me, the default context menu is shown.</div>
+  <div use:myContextMenu={"my-context-menu"}>
     If you right click me "Do this" and "Do that" entries are displayed.
   </div>
-  <div use:myContextMenu={{
-    name: "my-other-context-menu",
-    payload: "I am a payload",
-  }}>
+  <div use:myContextMenu={"my-other-context-menu"}>
     If you right click me "Do this other thing"
     and "Do that other thing" entries are displayed.
   </div>
@@ -123,7 +123,9 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
   import { remToPx } from "../lib/html";
   import { sleep } from "../lib/promises";
   import { Position } from "../lib/types";
-  import { Entry, Store as ContextMenuStore } from "../stores/contextMenu";
+  import { Store as ContextMenuStore } from "../stores/contextMenu";
+  import { buildCustomEvent, Entry, ItemEntry } from "../types/contextMenu";
+  import { phantoms } from "../types/phantom";
 
   type State =
     | { type: "hidden" }
@@ -143,22 +145,21 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
 
   const widthPx = remToPx(widthRem) as number;
 
-  const defaultEntries: Entry<unknown>[] = [
-    { type: "item", label: "Help", onClick: ({ close }) => close() },
-    { type: "item", label: "About", onClick: ({ close }) => close() },
-  ];
+  const defaultEntries: Entry<unknown>[] = phantoms([
+    { action: "help", type: "item", label: "Help" },
+    { action: "about", type: "item", label: "About" },
+  ]);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export let contextMenuStore: ContextMenuStore<any>;
-
-  $: entryRecord = contextMenuStore.entryRecord;
-
-  $: activeEntrySet = contextMenuStore.activeEntrySet;
 
   let state: State = { type: "hidden" };
 
   let currentEntries: Entry<unknown>[] = [];
 
-  let currentPayload: unknown;
+  let entrySetName: string | null = null;
+
+  let entrySetPayload: unknown = null;
 
   function computePositionFrom(
     { clientX, clientY, view }: MouseEvent,
@@ -191,7 +192,7 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
     return { x, y };
   }
 
-  async function handleContextMenu(event: MouseEvent) {
+  async function handleDefaultContextMenu(event: MouseEvent) {
     // In dev mode `Ctrl + Right Click` will open the default
     // context menu for dev purpose.
     if (import.meta.env.DEV && event.ctrlKey) {
@@ -201,11 +202,54 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
     event.preventDefault();
     event.stopPropagation();
 
+    let position = computePositionFrom(event, defaultEntries);
+
+    // First we "close" the current context menu if it's open
+    if ("position" in state) {
+      await close();
+    }
+
+    currentEntries = defaultEntries;
+
+    entrySetName = null;
+
+    state = {
+      type: "appearing",
+      position,
+    };
+
+    await sleep(50);
+
+    state = {
+      type: "shown",
+      position: state.position,
+    };
+  }
+
+  async function handleCustomContextMenu(
+    event: CustomEvent<{
+      name: string;
+      payload: string;
+      originalEvent: MouseEvent;
+    }>
+  ) {
+    // In dev mode `Ctrl + Right Click` will open the default
+    // context menu for dev purpose.
+    if (import.meta.env.DEV && event.detail.originalEvent.ctrlKey) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
     const newCurrentEntries =
-      ($activeEntrySet && $entryRecord && $entryRecord[$activeEntrySet.name]) ||
+      ($contextMenuStore && $contextMenuStore[event.detail.name]) ||
       defaultEntries;
 
-    let position = computePositionFrom(event, newCurrentEntries);
+    let position = computePositionFrom(
+      event.detail.originalEvent,
+      newCurrentEntries
+    );
 
     // First we "close" the current context menu if it's open
     if ("position" in state) {
@@ -214,14 +258,14 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
 
     currentEntries = newCurrentEntries;
 
-    currentPayload = $activeEntrySet?.payload ?? null;
+    entrySetName = event.detail.name;
 
     state = {
       type: "appearing",
       position,
     };
 
-    await sleep(50).promise;
+    await sleep(50);
 
     state = {
       type: "shown",
@@ -234,19 +278,31 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
       return;
     }
 
-    contextMenuStore.removeActiveEntrySet();
-
     state = { type: "disappearing", position: state.position };
 
-    await sleep(50).promise;
+    await sleep(50);
 
     state = { type: "hidden" };
   }
+
+  function dispatchContextMenuActionEvent(entry: ItemEntry<unknown>) {
+    if (entrySetName == null) {
+      return;
+    }
+
+    window.dispatchEvent(
+      buildCustomEvent(close, entrySetName, entry.action, entrySetPayload)
+    );
+  }
 </script>
 
-<svelte:window on:contextmenu={handleContextMenu} />
+<svelte:window
+  on:contextmenu={handleDefaultContextMenu}
+  on:custom-contextmenu={handleCustomContextMenu}
+/>
 
 <div
+  id="context-menu"
   class="root"
   class:opacity-100={state.type === "shown"}
   class:opacity-0={state.type === "disappearing" || state.type === "appearing"}
@@ -265,7 +321,7 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
         <div
           class="item"
           class:danger={entry.tag === "danger"}
-          on:click={() => entry.onClick({ close, payload: currentPayload })}
+          on:click={() => dispatchContextMenuActionEvent(entry)}
         >
           {entry.label}
         </div>

--- a/crates/lgn-browser/frontend/src/components/TopBar.svelte
+++ b/crates/lgn-browser/frontend/src/components/TopBar.svelte
@@ -137,19 +137,19 @@
       {#if userInitials}
         {userInitials}
       {:else}
-        <Icon icon="mdi:account-circle" />
+        <Icon icon="ic:account-circle" />
       {/if}
     </div>
     {#if window.__TAURI__}
       <div class="window-decorations">
         <div class="window-decoration" bind:this={topBarMinimize}>
-          <Icon icon="mdi:window-minimize" />
+          <Icon icon="ic:baseline-minimize" />
         </div>
         <div class="window-decoration" bind:this={topBarMaximize}>
-          <Icon icon="mdi:window-maximize" />
+          <Icon icon="ic:outline-square" />
         </div>
         <div class="window-decoration danger" bind:this={topBarClose}>
-          <Icon icon="mdi:window-close" />
+          <Icon icon="ic:baseline-close" />
         </div>
       </div>
     {/if}

--- a/crates/lgn-browser/frontend/src/lib/promises.ts
+++ b/crates/lgn-browser/frontend/src/lib/promises.ts
@@ -60,7 +60,7 @@ export async function retry<T>(
  *
  * Doesn't throw.
  */
-export function sleep(ms: number) {
+export function abortableSleep(ms: number) {
   let abort = () => {
     log.warn("`abort` function not implemented by the promise builder");
   };
@@ -83,4 +83,21 @@ export function sleep(ms: number) {
   });
 
   return { abort, promise };
+}
+
+/**
+ * Sleeps for n ms, this function uses `setTimeout` under the hood.
+ *
+ * Doesn't throw.
+ */
+export function sleep(ms: number) {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(undefined);
+    }, ms);
+  });
 }

--- a/crates/lgn-browser/frontend/src/stores/contextMenu.ts
+++ b/crates/lgn-browser/frontend/src/stores/contextMenu.ts
@@ -1,90 +1,34 @@
-import { get, Writable, writable } from "svelte/store";
-import log from "../lib/log";
-
-export type Entry<Payload> =
-  | {
-      type: "item";
-      label: string;
-      tag?: "danger";
-      onClick: (args: {
-        close: () => void;
-        payload: Payload;
-      }) => void | Promise<void>;
-    }
-  | { type: "separator" };
+import { Writable, writable } from "svelte/store";
+import { Entry } from "../types/contextMenu";
 
 export type Store<EntryRecord extends Record<string, unknown>> = {
-  entryRecord: Writable<
-    Partial<Record<keyof EntryRecord, Entry<EntryRecord[keyof EntryRecord]>[]>>
-  >;
-  activeEntrySet: Writable<{
-    name: keyof EntryRecord;
-    payload: EntryRecord[keyof EntryRecord];
-  } | null>;
-  setActiveEntrySet<Name extends keyof EntryRecord>(
-    name: Name,
-    payload: EntryRecord[Name]
-  ): void;
-  removeActiveEntrySet(): void;
-  register<Name extends keyof EntryRecord>(
-    name: Name,
-    entries: Entry<EntryRecord[Name]>[]
-  ): void;
-  remove<Name extends keyof EntryRecord>(name: Name): void;
-};
+  [Name in keyof EntryRecord]: {
+    subscribe: Writable<
+      Partial<Record<Name, Entry<EntryRecord[Name]>[]>>
+    >["subscribe"];
+    register<Name extends keyof EntryRecord>(
+      name: Name,
+      entries: Entry<EntryRecord[Name]>[]
+    ): void;
+  };
+}[keyof EntryRecord];
 
 export default function buildContextMenuStore<
   EntryRecord extends Record<string, unknown>
 >(): Store<EntryRecord> {
-  const entryRecordStore: Store<EntryRecord>["entryRecord"] = writable({});
-
-  const activeEntrySetStore: Store<EntryRecord>["activeEntrySet"] =
-    writable(null);
+  const { update, subscribe } = writable({});
 
   return {
-    entryRecord: entryRecordStore,
-    activeEntrySet: activeEntrySetStore,
-    /**
-     * "Activates" a context menu entry set
-     * When the menu will be opened, it'll show the entries for this entry set
-     */
-    setActiveEntrySet(name, payload) {
-      const entrySets = get(entryRecordStore);
-
-      if (name in entrySets) {
-        return activeEntrySetStore.set({ name, payload });
-      }
-
-      log.warn(
-        `Trying to activate a context menu entry set that has not been registered: ${name}`
-      );
-
-      activeEntrySetStore.set(null);
-    },
-    /**
-     * Sets the active entry set to "null"
-     */
-    removeActiveEntrySet() {
-      activeEntrySetStore.set(null);
-    },
+    subscribe,
     /**
      * Register the context menu entries that can be used later on
      * by any dom element using the `contextMenu` action.
      */
     register(name, entries) {
-      entryRecordStore.update((entrySets) => ({
+      update((entrySets) => ({
         ...entrySets,
         [name]: entries,
       }));
-    },
-    /** Removes the context menu entries */
-    remove(name) {
-      entryRecordStore.update(
-        ({ [name]: _, ...entrySets }) =>
-          entrySets as Partial<
-            Record<keyof EntryRecord, Entry<EntryRecord[keyof EntryRecord]>[]>
-          >
-      );
     },
   };
 }

--- a/crates/lgn-browser/frontend/src/types/contextMenu.ts
+++ b/crates/lgn-browser/frontend/src/types/contextMenu.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+import { Phantom } from "./phantom";
+
+export type ItemEntry<Payload> = Phantom<
+  { type: "item"; action: string; label: string; tag?: "danger" },
+  Payload
+>;
+
+export type SeparatorEntry<Payload> = Phantom<{ type: "separator" }, Payload>;
+
+export type Entry<Payload> = ItemEntry<Payload> | SeparatorEntry<Payload>;
+
+// The `as const` casting is not necessary in this case
+// but it prevents the type to be inferred as `string`
+// in some older versions of TS
+export const eventName = "contextmenu-action" as const;
+
+export type EventName = typeof eventName;
+
+export type Detail<EntryRecord extends Record<string, unknown>> = {
+  [Name in keyof EntryRecord]: {
+    /** Closes the context menu */
+    close(): void;
+    /** Name of the context menu entry set */
+    entrySetName: Name;
+    /** The action of the entry in the context menu (e.g.: `"rename"`, `"new"`, etc...) */
+    action: string;
+    /** The payload attached to the action */
+    payload: EntryRecord[Name];
+  };
+}[keyof EntryRecord];
+
+export type Event<EntryRecord extends Record<string, unknown>> = CustomEvent<
+  Detail<EntryRecord>
+>;
+
+export function buildCustomEvent<
+  EntryRecord extends Record<string, unknown>,
+  Name extends keyof EntryRecord
+>(
+  close: () => void,
+  entrySetName: Name,
+  action: string,
+  payload: EntryRecord[Name]
+): Event<EntryRecord> {
+  return new CustomEvent<Detail<EntryRecord>>(eventName, {
+    detail: { close, entrySetName, action, payload },
+  });
+}
+
+export type EventHandler<EntryRecord extends Record<string, unknown>> = (
+  event: Event<EntryRecord>
+) => Promise<void> | void;
+
+/** Auto close the context menu before action is trigered */
+export function autoClose<EntryRecord extends Record<string, unknown>>(
+  handler: EventHandler<EntryRecord>
+): EventHandler<EntryRecord> {
+  return function innerHandler(event) {
+    event.detail.close();
+
+    return handler(event);
+  };
+}
+
+/** Allows to "subscribe" to a specific entry set */
+export function select<
+  EntryRecord extends Record<string, unknown>,
+  Name extends keyof EntryRecord
+>(
+  handler: EventHandler<Pick<EntryRecord, Name>>,
+  entrySetName: Name
+): EventHandler<EntryRecord> {
+  return function innerHandler(event) {
+    if (entrySetName !== event.detail.entrySetName) {
+      return;
+    }
+
+    return handler(event as Event<Pick<EntryRecord, Name>>);
+  };
+}

--- a/crates/lgn-browser/frontend/src/types/phantom.ts
+++ b/crates/lgn-browser/frontend/src/types/phantom.ts
@@ -1,0 +1,29 @@
+export type Phantom<T, U> = T & {
+  /**
+   * @deprecated @inline Don't use this attribute, it's value is always `null`!
+   *
+   * Its presence is due to the fact TypeScript doesn't support
+   * [nominal typing](https://github.com/Microsoft/TypeScript/issues/202),
+   * so we need to _structurally_ change the type and the value.
+   *
+   * You can see an example of why it matters here: https://tsplay.dev/N5460w
+   */
+  readonly "#phantom": U;
+};
+
+/**
+ * Creates a pseudo ["phantom type"](https://wiki.haskell.org/Phantom_type) from an object value.
+ *
+ * _The `#phantom` attribute is always `null` and not meant to be used as is._
+ */
+export default function phantom<T, U>(data: T): Phantom<T, U> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { ...data, "#phantom": null as any as U };
+}
+
+/**
+ * Convenient function that maps an array to create an array of phantom values
+ */
+export function phantoms<T, U>(data: T[]): Phantom<T, U>[] {
+  return data.map<Phantom<T, U>>(phantom);
+}

--- a/crates/lgn-editor-gui/frontend/.eslintrc.cjs
+++ b/crates/lgn-editor-gui/frontend/.eslintrc.cjs
@@ -17,7 +17,8 @@ module.exports = {
     "svelte3/ignore-styles": () => true,
   },
   rules: {
-    "no-console": "error",
+    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
     "@typescript-eslint/no-unused-vars": "off",
   },
 };

--- a/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
@@ -1,23 +1,22 @@
 <script lang="ts">
   import { Entries, updateEntry } from "@/lib/hierarchyTree";
-  import clickOutside from "@lgn/frontend/src/actions/clickOutside";
   import { createEventDispatcher } from "svelte";
   import Inner from "./Inner.svelte";
 
   type Item = $$Generic;
 
   type $$Slots = {
-    itemName: { itemName: string };
+    name: { itemName: string };
   };
 
   const dispatch = createEventDispatcher<{ select: Item }>();
 
   export let entries: Entries<Item>;
 
-  export let activeItem: Item | null = null;
+  export let selectedItem: Item | null = null;
 
   /**
-   * This prop function is used to compare 2 items together and must retur
+   * This prop function is used to compare 2 items together and must return
    * `true` if the items are identical.
    *
    * By default `===` is used, so primitives are compared by value and
@@ -25,8 +24,10 @@
    */
   export let itemsAreIdentical = (item1: Item, item2: Item) => item1 === item2;
 
-  function setActiveItem({ detail: item }: CustomEvent<Item>) {
-    activeItem = item;
+  let currentlyRenameItem: Item | null = null;
+
+  function setSelectedItem({ detail: item }: CustomEvent<Item>) {
+    selectedItem = item;
 
     dispatch("select", item);
   }
@@ -38,20 +39,26 @@
       itemsAreIdentical(otherItem, item) ? { name: newName } : null
     );
   }
+
+  export function edit(item: Item) {
+    currentlyRenameItem = item;
+  }
 </script>
 
-<div class="root" use:clickOutside={() => (activeItem = null)}>
+<div class="root">
   {#each Object.entries(entries) as [name, entry] (name)}
     <Inner
       {entry}
-      {activeItem}
+      {selectedItem}
       {itemsAreIdentical}
       {name}
-      on:select={setActiveItem}
+      bind:currentlyRenameItem
+      on:dblclick
+      on:select={setSelectedItem}
       on:nameChange={setName}
       let:itemName
     >
-      <slot name="itemName" slot="itemName" {itemName} />
+      <slot name="name" slot="name" {itemName} />
     </Inner>
   {/each}
 </div>

--- a/crates/lgn-editor-gui/frontend/src/data/contextMenu.ts
+++ b/crates/lgn-editor-gui/frontend/src/data/contextMenu.ts
@@ -1,52 +1,16 @@
 import { ContextMenuEntryRecord } from "@/stores/contextMenu";
-import { Entry } from "@lgn/frontend/src/stores/contextMenu";
+import { Entry } from "@lgn/frontend/src/types/contextMenu";
+import { phantoms } from "@lgn/frontend/src/types/phantom";
 
-const entries: Entry<ContextMenuEntryRecord["resource"]>[] = [
-  {
-    type: "item",
-    label: "Rename",
-    onClick({ close }) {
-      close();
-    },
-  },
-  {
-    type: "item",
-    label: "Clone",
-    onClick({ close }) {
-      close();
-    },
-  },
-  {
-    type: "item",
-    label: "Delete",
-    tag: "danger",
-    onClick({ close }) {
-      close();
-    },
-  },
+const entries: Entry<ContextMenuEntryRecord["resource"]>[] = phantoms([
+  { type: "item", action: "rename", label: "Rename" },
+  { type: "item", action: "clone", label: "Clone" },
+  { type: "item", action: "delete", label: "Delete", tag: "danger" },
   { type: "separator" },
-  {
-    type: "item",
-    label: "Create new...",
-    onClick({ close }) {
-      close();
-    },
-  },
-  {
-    type: "item",
-    label: "Import...",
-    onClick({ close }) {
-      close();
-    },
-  },
+  { type: "item", action: "create-new", label: "Create new..." },
+  { type: "item", action: "import", label: "Import..." },
   { type: "separator" },
-  {
-    type: "item",
-    label: "Help",
-    onClick({ close }) {
-      close();
-    },
-  },
-];
+  { type: "item", action: "help", label: "Help" },
+]);
 
 export default entries;

--- a/crates/lgn-editor-gui/frontend/src/stores/contextMenu.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/contextMenu.ts
@@ -1,7 +1,8 @@
 import buildContextMenuStore from "@lgn/frontend/src/stores/contextMenu";
+import { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
 
 export type ContextMenuEntryRecord = {
-  resource: { itemName: string };
+  resource: { item: ResourceDescription | null; name: string };
 };
 
 export default buildContextMenuStore<ContextMenuEntryRecord>();

--- a/crates/lgn-runtime-gui/frontend/.eslintrc.cjs
+++ b/crates/lgn-runtime-gui/frontend/.eslintrc.cjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 module.exports = {
   env: {
     browser: true,
@@ -17,7 +19,8 @@ module.exports = {
     "svelte3/ignore-styles": () => true,
   },
   rules: {
-    "no-console": "error",
+    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
     "@typescript-eslint/no-unused-vars": "off",
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1705,7 +1705,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.9.1
-      eslint-visitor-keys: 3.1.0
+      eslint-visitor-keys: 3.2.0
     dev: true
 
   /abab/2.0.5:
@@ -1756,7 +1756,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.2
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2656,11 +2656,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-visitor-keys/3.1.0:
-    resolution: {integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /eslint-visitor-keys/3.2.0:
     resolution: {integrity: sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3071,7 +3066,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.2
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Getting there with the context menu.

Some things to improve/fix:

- ~For now the `contextMenu` action will listen to the `contextmenu` event and set a store accordingly with both the entry set (i.e. the list of actions that can be performed) and a "payload" is set, then the ContextMenu component will reactively open up and display the proper menu entry set. That works but it's 1. a bit complex and 2. there can be some race condition where the payload is "stale". I'd like to work on an implementation that would skip the action and sent the `contextmenu-action` custom event directly without the need for the action~ I stop using the `payload` feature and handled it only with the reactive states of Svelte. So far so good, at least for the resources' context menu.
- When the context menu is open more than once it suddenly doesn't "do" anything. _update: fixed_