### PR TITLE
Minor async/await fix in Metrics.svelte

### DIFF
--- a/crates/lgn-analytics-gui/frontend/src/pages/Metrics.svelte
+++ b/crates/lgn-analytics-gui/frontend/src/pages/Metrics.svelte
@@ -46,7 +46,7 @@
     return [minMs, maxMs];
   }
 
-  onMount(() => {
+  onMount(async () => {
     canvas = document.getElementById("canvas_plot") as HTMLCanvasElement;
     if (!canvas) {
       throw new Error("Canvas can't be found or is invalid");
@@ -58,7 +58,7 @@
     }
     renderingContext = ctx;
 
-    fetchProcessInfo();
+    await fetchProcessInfo();
     drawCanvas();
   });
 


### PR DESCRIPTION
Very minor fix as I was reading code in lgn-analytics-gui. The bug was not really visible because `fetchProcessInfo()` updates the `metrics` property which is reactive so it ends up triggering the desired div update :)

Could not find a valid eslint warning for this kind of behavior.

https://stackoverflow.com/questions/67175079/detect-missing-await-in-javascript-methods-in-vscode
https://github.com/eslint/eslint/issues/13567