### PR TITLE
Editor client: Hierarchical tree - add keyboard navigation

### DIFF
--- a/crates/lgn-browser/frontend/src/actions/keyboardNavigation.ts
+++ b/crates/lgn-browser/frontend/src/actions/keyboardNavigation.ts
@@ -1,0 +1,91 @@
+import { keepElementVisible } from "../lib/html";
+import { Writable } from "svelte/store";
+
+export type Store = {
+  currentIndex: number | null;
+};
+
+export type Config = {
+  disabled: boolean;
+  listener?(index: number): void;
+  size: number;
+  store: Writable<Store>;
+};
+
+/** Will "mark" the html element as a "navigable" item */
+export function keyboardNavigationItem(
+  htmlElement: HTMLElement,
+  index: number
+) {
+  htmlElement.dataset.keyboardNavigationItemIndex = index.toString();
+}
+
+export default function keyboardNavigation(
+  htmlElement: HTMLElement,
+  { disabled, listener, size, store }: Config
+) {
+  function handleWindowKeyword(event: KeyboardEvent) {
+    if (disabled) {
+      return null;
+    }
+
+    store.update(({ currentIndex }) => {
+      let newIndex: number | null = null;
+
+      switch (event.key) {
+        case "ArrowUp": {
+          // `currentIndex` should never be lt 0
+          newIndex =
+            currentIndex === null || currentIndex <= 0
+              ? size - 1
+              : currentIndex - 1;
+
+          break;
+        }
+
+        case "ArrowDown": {
+          // currentIndex should never be gt `items.length - 1`
+          newIndex =
+            currentIndex === null || currentIndex >= size - 1
+              ? 0
+              : currentIndex + 1;
+
+          break;
+        }
+      }
+
+      if (newIndex == null) {
+        return { currentIndex };
+      }
+
+      event.preventDefault();
+
+      const element = htmlElement.querySelector(
+        `[data-keyboard-navigation-item-index="${newIndex}"]`
+      );
+
+      if (!element) {
+        return { currentIndex };
+      }
+
+      // Auto scroll to "follow" the user focus when using the arrow keys
+      keepElementVisible(htmlElement, element);
+
+      listener && listener(newIndex);
+
+      return { currentIndex: newIndex };
+    });
+  }
+
+  window.addEventListener("keydown", handleWindowKeyword);
+
+  return {
+    update({ disabled: newDisabled, size: newSize }: Config) {
+      disabled = newDisabled;
+      size = newSize;
+    },
+    destroy() {
+      window.removeEventListener("keydown", handleWindowKeyword);
+    },
+  };
+}

--- a/crates/lgn-browser/frontend/src/actions/remoteWindowInputs/index.ts
+++ b/crates/lgn-browser/frontend/src/actions/remoteWindowInputs/index.ts
@@ -450,7 +450,7 @@ export default function remoteWindowInputs(
 ) {
   element.style.touchAction = "none";
 
-  element.tabIndex = 0;
+  element.tabIndex = -1;
 
   const state: State = {
     mouseState: "Released",

--- a/crates/lgn-editor-gui/frontend/src/api/index.ts
+++ b/crates/lgn-editor-gui/frontend/src/api/index.ts
@@ -45,7 +45,11 @@ export async function getAllResources() {
       : resourceDescriptions;
   }
 
-  return getMoreResources("");
+  const allResources = await getMoreResources("");
+
+  return allResources.sort((resource1, resource2) =>
+    resource1.path > resource2.path ? 1 : -1
+  );
 }
 
 /**

--- a/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/Inner.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/Inner.svelte
@@ -3,6 +3,7 @@
   import { createEventDispatcher } from "svelte";
   import { extension } from "@/lib/path";
   import Icon from "@iconify/svelte";
+  import { keyboardNavigationItem } from "@lgn/frontend/src/actions/keyboardNavigation";
   import TextInput from "../inputs/TextInput.svelte";
 
   type Item = $$Generic;
@@ -12,8 +13,8 @@
   };
 
   const dispatch = createEventDispatcher<{
-    select: Item;
-    nameChange: { item: Item; newName: string };
+    select: Entry<Item>;
+    nameChange: { entry: Entry<Item>; newName: string };
   }>();
 
   // TODO: Temporary extension to icon name map, should be dynamic
@@ -28,82 +29,71 @@
 
   export let entry: Entry<Item>;
 
-  export let selectedItem: Item | null = null;
+  export let selectedEntry: Entry<Item> | null = null;
 
-  export let name: string;
-
-  // TODO: This should be in a store
-  export let expanded = true;
-
-  export let itemsAreIdentical: (item1: Item, item2: Item) => boolean;
+  export let panelIsFocused: boolean;
 
   // TODO: Should be in a store?
-  export let currentlyRenameItem: Item | null = null;
+  export let currentlyRenameEntry: Entry<Item> | null = null;
 
   let mode: "view" | "edit";
 
-  function toggleExpand() {
-    expanded = !expanded;
-  }
+  let isExpanded = true;
 
   function select() {
-    dispatch("select", entry.item);
+    dispatch("select", entry);
   }
 
   function renameFile(event: Event) {
     event.preventDefault();
 
-    currentlyRenameItem = null;
+    currentlyRenameEntry = null;
 
     if (nameValue.trim().length) {
-      dispatch("nameChange", { item: entry.item, newName: nameValue.trim() });
-
-      nameValue = name;
+      dispatch("nameChange", { entry, newName: nameValue.trim() });
     }
   }
 
-  function cancelEdition(event?: KeyboardEvent) {
-    if (event && event.key !== "Escape") {
-      return;
-    }
-
+  function cancelEdition() {
     mode = "view";
-
-    nameValue = name;
   }
 
-  $: isSelected = selectedItem
-    ? itemsAreIdentical(entry.item, selectedItem)
-    : false;
+  function entryName() {
+    return entry.name.trim();
+  }
 
-  $: nameValue = name;
+  function toggleExpanded() {
+    isExpanded = !isExpanded;
+  }
 
-  $: nameExtension = extension(name);
+  $: isSelected = selectedEntry ? entry === selectedEntry : false;
+
+  $: nameExtension = extension(entry.name);
 
   $: iconName =
     (nameExtension && iconNames[nameExtension]) ||
     "ic:outline-insert-drive-file";
 
   $: mode =
-    currentlyRenameItem && itemsAreIdentical(currentlyRenameItem, entry.item)
-      ? "edit"
-      : "view";
+    currentlyRenameEntry && currentlyRenameEntry === entry ? "edit" : "view";
+
+  $: nameValue = mode === "edit" ? entryName() : "";
 
   $: if (!isSelected) {
     cancelEdition();
   }
 </script>
 
-<div class="root" on:dblclick>
+<div class="root" on:dblclick use:keyboardNavigationItem={entry.index}>
   <div
     class="name"
-    class:font-semibold={entry.entries}
+    class:font-semibold={entry.subEntries}
     class:lg-space={mode === "view"}
-    class:selected-view={isSelected && !entry.entries && mode === "view"}
+    class:selected-view={isSelected && mode === "view"}
     on:mousedown={select}
   >
-    {#if entry.entries}
-      <div class="icon" class:expanded on:click={toggleExpand}>
+    {#if entry.subEntries}
+      <div class="icon" class:expanded={isExpanded} on:click={toggleExpanded}>
         <Icon icon="ic:chevron-right" />
       </div>
     {:else}
@@ -113,23 +103,25 @@
     {/if}
     <div class="name">
       {#if mode === "view"}
-        <slot name="name" itemName={name} />
+        <slot name="name" itemName={entry.name} />
       {:else}
-        <form on:submit={renameFile} on:keydown={cancelEdition}>
+        <form
+          on:submit={renameFile}
+          on:keydown={(event) => event.key === "Escape" && cancelEdition()}
+        >
           <TextInput autoFocus autoSelect size="sm" bind:value={nameValue} />
         </form>
       {/if}
     </div>
   </div>
-  {#if entry.entries && expanded}
-    {#each Object.entries(entry.entries || {}) as [name, entry] (name)}
-      <div class="files">
+  {#if entry.subEntries && isExpanded}
+    {#each entry.subEntries || [] as entry (entry.name)}
+      <div class="sub-entries">
         <svelte:self
           {entry}
-          {selectedItem}
-          {name}
-          {itemsAreIdentical}
-          bind:currentlyRenameItem
+          {selectedEntry}
+          {panelIsFocused}
+          bind:currentlyRenameEntry
           on:select
           on:nameChange
           let:itemName
@@ -143,7 +135,7 @@
 
 <style lang="postcss">
   .root {
-    @apply flex flex-col cursor-pointer;
+    @apply flex flex-col cursor-pointer border-dotted border-gray-400;
   }
 
   .name {
@@ -166,7 +158,7 @@
     @apply rotate-90;
   }
 
-  .files {
-    @apply pl-2 ml-1.5 list-none border-l border-dotted border-gray-400;
+  .sub-entries {
+    @apply pl-2 ml-3 list-none border-l border-dotted border-gray-400;
   }
 </style>

--- a/crates/lgn-editor-gui/frontend/src/data/fake.ts
+++ b/crates/lgn-editor-gui/frontend/src/data/fake.ts
@@ -1,54 +1,106 @@
 import { Entries } from "@/lib/hierarchyTree";
 
-export const fakeFileSystemEntries: Entries<number> = {
-  Archives: {
+export const fakeFileSystemEntries = new Entries([
+  {
+    name: "Archives",
+    index: 0,
     item: 1,
-    entries: {
-      "quarterly-results.zip": {
+    depth: 0,
+    subEntries: [
+      {
+        name: "quarterly-results.zip",
+        index: 1,
         item: 2,
+        depth: 1,
+        subEntries: null,
       },
-      "data.zip": {
+      {
+        name: "data.zip",
+        index: 2,
         item: 3,
+        depth: 1,
+        subEntries: null,
       },
-    },
+    ],
   },
-  Assets: {
+  {
+    name: "Assets",
+    index: 3,
     item: 4,
-    entries: {
-      Nature: {
-        item: 6,
-        entries: {
-          "sand.png": {
+    depth: 0,
+    subEntries: [
+      {
+        name: "Nature",
+        index: 4,
+        item: 5,
+        depth: 1,
+        subEntries: [
+          {
+            name: "sand.png",
+            index: 5,
+            item: 6,
+            depth: 2,
+            subEntries: null,
+          },
+          {
+            name: "tree.png",
+            index: 6,
             item: 7,
+            depth: 2,
+            subEntries: null,
           },
-          "tree.png": {
+          {
+            name: "rock.jpg",
+            index: 7,
             item: 8,
+            depth: 2,
+            subEntries: null,
           },
-          "rock.jpg": {
-            item: 9,
-          },
-        },
+        ],
       },
-      City: {
-        item: 10,
-        entries: {
-          "building.jpg": {
+      {
+        name: "City",
+        index: 8,
+        item: 9,
+        depth: 1,
+        subEntries: [
+          {
+            name: "building.jpg",
+            index: 9,
+            item: 10,
+            depth: 2,
+            subEntries: null,
+          },
+          {
+            name: "street.png",
+            index: 10,
             item: 11,
+            depth: 2,
+            subEntries: null,
           },
-          "street.png": {
-            item: 12,
-          },
-        },
+        ],
       },
-      "other.jpg": {
+      {
+        name: "other.jpg",
+        index: 11,
+        item: 12,
+        depth: 1,
+        subEntries: null,
+      },
+      {
+        name: "concept.png",
+        index: 12,
         item: 13,
+        depth: 1,
+        subEntries: null,
       },
-      "concept.png": {
-        item: 14,
-      },
-    },
+    ],
   },
-  "TODO.pdf": {
-    item: 15,
+  {
+    name: "TODO.pdf",
+    index: 13,
+    item: 14,
+    depth: 0,
+    subEntries: null,
   },
-};
+]);

--- a/crates/lgn-editor-gui/frontend/src/lib/array.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/array.ts
@@ -1,11 +1,52 @@
 /** Adds the missing `filterMap` function that both `map` and `filter` an array in one iteration */
 export function filterMap<T, U>(
   array: T[],
-  f: (arg: T, index: number, array: T[]) => U | null
+  f: (item: T, index: number, array: T[]) => U | null
 ): U[] {
   return array.reduce<U[]>((acc, value, index, array) => {
     const newValue = f(value, index, array);
 
     return newValue ? [...acc, newValue] : acc;
   }, []);
+}
+
+/** Take and accumulate an array elements into a new array as long as the provided predicate returns `true` */
+export function takeWhile<T>(
+  array: T[],
+  pred: (item: T, index: number, array: T[]) => boolean
+): T[] {
+  if (!array.length) {
+    return [];
+  }
+
+  function takeWhileIndex(slice: T[], index: number): T[] {
+    if (!slice.length) {
+      return [];
+    }
+
+    const [head, ...tail] = slice;
+
+    return pred(head, index, array)
+      ? [head, ...takeWhileIndex(tail, index + 1)]
+      : [];
+  }
+
+  return takeWhileIndex(array, 0);
+}
+
+/** Removes an element from an array. Uses the `filter` method under the hood. */
+export function remove<T>(array: T[], removedEntry: T) {
+  return array.filter((entry) => entry !== removedEntry);
+}
+
+/**
+ * Prepend an item to an array if the provided predicate function returns false.
+ * Typically used to add an item to an array only if it's not already present.
+ */
+export function prependIfNonPresent<T>(
+  array: T[],
+  pred: (item: T, index: number, array: T[]) => boolean,
+  item: () => T
+): T[] {
+  return array.some(pred) ? array : [item(), ...array];
 }

--- a/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
@@ -1,144 +1,244 @@
+import { prependIfNonPresent } from "./array";
 import { components } from "./path";
 
-export type Entry<Item> = {
+export type Entry<Item, WithIndex extends boolean = true> = {
+  name: string;
+  depth: number;
   item: Item;
-  entries?: Entries<Item> | null;
-};
+  subEntries: Entry<Item, WithIndex>[] | null;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & (WithIndex extends true ? { index: number } : {});
 
-export type Entries<Item> = Record<string, Entry<Item>>;
+/** A wrapper class around the `Entry<Item>[]` type. */
+export class Entries<Item> {
+  entries: Entry<Item>[];
 
-// TODO: Improve performance if needed
-/**
- * Takes a whole `Entries` object and a function called for each entry in this object.
- *
- * If the function returns `null` nothing happens,
- * if an item and/or a name is returned, then the entry will be updated.
- */
-export function updateEntry<Item>(
-  entries: Entries<Item>,
-  updateItem: (
-    name: string,
-    item: Item
-  ) => { name: string } | { item: Item } | { name: string; item: Item } | null
-): Entries<Item> {
-  return Object.fromEntries(
-    Object.entries(entries).map(([name, entry]) => {
-      const updatedItem = updateItem(name, entry.item);
+  #size: number | null = null;
 
-      if (updatedItem) {
-        return [
-          ("name" in updatedItem && updatedItem.name.trim()) || name,
-          "item" in updatedItem ? { ...entry, item: updatedItem.item } : entry,
-        ];
-      }
-
-      if (!entry.entries) {
-        return [name, entry];
-      }
-
-      return [
-        name,
-        {
-          ...entry,
-          entries: updateEntry(entry.entries, updateItem),
-        },
-      ];
-    })
-  );
-}
-
-// TODO: Improve performance if needed
-/**
- * Build an `Entries` object from any flat arrays of object.
- * Objects must contain a `path` attribute.
- *
- * ## Example
- *
- * ```typescript
- * const entries = unflatten([
- *   { path: "/foo/bar", value: "hello" },
- *   { path: "/foo/baz", value: "another hello" },
- *   { path: "/foo", value: "another value" },
- *   { path: "baz", value: "a baz value" },
- *   { path: "/foo/bar/baz", value: "another baz value" },
- * ]);
- *
- * const expectedEntries = {
- *   foo: {
- *     item: null,
- *     entries: {
- *       bar: {
- *         item: { path: "/foo/bar", value: "hello" },
- *         entries: {
- *           baz: {
- *             item: { path: "/foo/bar/baz", value: "another baz value" },
- *           },
- *         },
- *       },
- *       baz: {
- *         item: { path: "/foo/baz", value: "another hello" },
- *       },
- *     },
- *   },
- *   baz: {
- *     item: { path: "baz", value: "a baz value" },
- *   },
- * };
- *
- * // Given a `deepEqual` function:
- * console.assert(deepEqual(entries, expectedEntries));
- * ```
- */
-export function unflatten<Item extends { path: string }>(
-  items: Item[]
-): Entries<Item | null> {
-  if (!items.length) {
-    return {};
-  }
-
-  function buildEntriesFromPathComponents(
-    [pathComponent, ...otherPathComponents]: string[],
-    item: Item,
-    entries: Entries<Item | null>
-  ): Entries<Item | null> {
-    const entry =
-      pathComponent in entries ? entries[pathComponent] : { item: null };
-
-    return {
-      ...entries,
-      [pathComponent]: otherPathComponents.length
-        ? {
-            ...entry,
-            entries: buildEntriesFromPathComponents(
-              otherPathComponents,
-              item,
-              entry.entries || {}
-            ),
-          }
-        : { ...entry, item },
-    };
-  }
-
-  function buildEntriesFromItems(
-    [item, ...otherItems]: Item[],
-    entries: Entries<Item | null> = {}
-  ): Entries<Item | null> {
-    const pathComponents = components(item.path);
-
-    if (!pathComponents.length) {
-      return entries;
+  // TODO: Improve performance if needed
+  /**
+   * Build an `Entries` object from any flat arrays of object.
+   * Objects must contain a `path` attribute.
+   *
+   * ## Example
+   *
+   * ```typescript
+   * const entries = Entries.unflatten([
+   *   { path: "/foo/bar", value: "hello" },
+   *   { path: "/foo/baz", value: "another hello" },
+   *   { path: "/foo", value: "another value" },
+   *   { path: "baz", value: "a baz value" },
+   *   { path: "/foo/bar/baz", value: "another baz value" },
+   * ]);
+   *
+   * const expectedEntries = {
+   * };
+   *
+   * // Given an `assert` and a `deepEqual` function:
+   * assert(deepEqual(entries.entries, expectedEntries));
+   * ```
+   */
+  static unflatten<Item extends { path: string }, AltItem>(
+    items: Item[],
+    /** This function is called when an `Item` is not present, typically used for "folders" */
+    buildItemFromName: (name: string) => Item | AltItem
+  ): Entries<Item | AltItem> {
+    if (!items.length) {
+      return new Entries([]);
     }
 
-    const populatedEntries = buildEntriesFromPathComponents(
-      pathComponents,
-      item,
-      entries
-    );
+    function buildEntriesFromPathComponents(
+      [pathComponent, ...otherPathComponents]: string[],
+      item: Item,
+      entries: Entry<Item | AltItem, false>[],
+      depth = 0
+    ): Entry<Item | AltItem, false>[] {
+      const extendedEntries = prependIfNonPresent(
+        entries,
+        (entry) => entry.name === pathComponent,
+        () => ({
+          depth,
+          name: pathComponent,
+          item: otherPathComponents.length
+            ? buildItemFromName(pathComponent)
+            : item,
+          subEntries: null,
+        })
+      );
 
-    return otherItems.length
-      ? buildEntriesFromItems(otherItems, populatedEntries)
-      : populatedEntries;
+      return extendedEntries.map((entry) => {
+        if (entry.name !== pathComponent) {
+          return entry;
+        }
+
+        return {
+          ...entry,
+          subEntries: otherPathComponents.length
+            ? buildEntriesFromPathComponents(
+                otherPathComponents,
+                item,
+                entry.subEntries || [],
+                depth + 1
+              )
+            : entry.subEntries || null,
+        };
+      });
+    }
+
+    function buildEntriesFromItems(
+      [item, ...otherItems]: Item[],
+      entries: Entry<Item | AltItem, false>[] = []
+    ): Entry<Item | AltItem, false>[] {
+      const pathComponents = components(item.path);
+
+      if (!pathComponents.length) {
+        return entries;
+      }
+
+      const populatedEntries = buildEntriesFromPathComponents(
+        pathComponents,
+        item,
+        entries
+      );
+
+      return otherItems.length
+        ? buildEntriesFromItems(otherItems, populatedEntries)
+        : populatedEntries;
+    }
+
+    const entries = buildEntriesFromItems(items);
+
+    if (!entries.length) {
+      return new Entries([]);
+    }
+
+    function sort(entries: Entry<Item | AltItem, false>[]): void {
+      entries
+        .sort((entry1, entry2) => (entry1.name > entry2.name ? 1 : -1))
+        .map((entry) => ({
+          ...entry,
+          subEntries: entry.subEntries ? sort(entry.subEntries) : null,
+        }));
+    }
+
+    sort(entries);
+
+    let index = 0;
+
+    function addIndex(
+      entries: Entry<Item | AltItem, false>[]
+    ): Entry<Item | AltItem>[] {
+      return entries.map((entry) => ({
+        ...entry,
+        index: index++,
+        subEntries: entry.subEntries ? addIndex(entry.subEntries) : null,
+      }));
+    }
+
+    return new Entries(addIndex(entries));
   }
 
-  return buildEntriesFromItems(items);
+  /** Builds an `Entries` object from and array of `Entry` */
+  constructor(entries: Entry<Item>[]) {
+    this.entries = entries;
+  }
+
+  /** Computes the size of the `Entries` */
+  get size(): number {
+    if (typeof this.#size === "number") {
+      return this.#size;
+    }
+
+    function count(entries: Entry<Item>[], size = 0): number {
+      return entries.reduce(
+        (s, entry) =>
+          entry.subEntries ? count(entry.subEntries, s + 1) : s + 1,
+        size
+      );
+    }
+
+    this.#size = count(this.entries);
+
+    return this.#size;
+  }
+
+  // TODO: Improve performance if needed
+  /**
+   * Finds an entry in an `Entries` array.
+   */
+  find(pred: (entry: Entry<Item>) => boolean): Entry<Item> | null {
+    function find(entries: Entry<Item>[]): Entry<Item> | null {
+      for (const entry of entries) {
+        if (pred(entry)) {
+          return entry;
+        }
+
+        if (entry.subEntries) {
+          const foundEntry = find(entry.subEntries);
+
+          if (foundEntry) {
+            return foundEntry;
+          }
+        }
+      }
+
+      return null;
+    }
+
+    return find(this.entries);
+  }
+
+  // TODO: Improve performance if needed
+  /**
+   * Finds an entry index in an `Entries` array.
+   *
+   * Unlike `Array.prototype.findIndex`, this method returns `null` if the index is not found, not -1.
+   */
+  findIndex(pred: (entry: Entry<Item>) => boolean): number | null {
+    const entry = this.find(pred);
+
+    return entry?.index ?? null;
+  }
+
+  // TODO: Improve performance if needed
+  /**
+   * Takes a whole `Entries` object and a function called for each entry in this object.
+   *
+   * If the function returns `null` nothing happens,
+   * if an item and/or a name is returned, then the entry will be updated.
+   */
+  update(
+    shouldUpdate: (
+      entry: Entry<Item>
+    ) => Pick<Entry<Item>, "item" | "name"> | null
+  ): Entries<Item> {
+    function update(entries: Entry<Item>[]): Entry<Item>[] {
+      return entries.map((entry) => {
+        const updatedEntry = shouldUpdate(entry);
+
+        if (updatedEntry) {
+          return {
+            ...entry,
+            ...updatedEntry,
+            name:
+              ("name" in updatedEntry && updatedEntry.name.trim()) ||
+              entry.name,
+          };
+        }
+
+        if (!entry.subEntries) {
+          return entry;
+        }
+
+        return {
+          ...entry,
+          subEntries: update(entry.subEntries),
+        };
+      });
+    }
+
+    this.entries = update(this.entries);
+
+    return this;
+  }
 }

--- a/crates/lgn-editor-gui/frontend/src/lib/path.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/path.ts
@@ -1,12 +1,14 @@
 /** Dummy alias for string */
 export type Path = string;
 
+export type MainSeparator = "/" | "\\";
+
 /**
  * Detects the main path separator / or \\
  * If both seperators are present in the string
  * the main separator will be assumed to be the first found
  */
-export function detectMainPathSeparator(path: Path): string | null {
+export function detectMainPathSeparator(path: Path): MainSeparator | null {
   for (const c of path) {
     if (c === "/") {
       return "/";
@@ -56,4 +58,18 @@ export function extension(path: Path): string | null {
   }
 
   return pathFileNameParts.reverse()[0];
+}
+
+/** Joins the path compenents into a `Path` using the provided main separator */
+export function absolute(
+  components: string[],
+  mainSeparator: MainSeparator
+): Path {
+  const cleanComponents = components.filter(Boolean);
+
+  if (!cleanComponents.length) {
+    return `${mainSeparator}`;
+  }
+
+  return `${mainSeparator}${cleanComponents.join(mainSeparator)}`;
 }

--- a/crates/lgn-editor-gui/frontend/src/pages/Home.svelte
+++ b/crates/lgn-editor-gui/frontend/src/pages/Home.svelte
@@ -13,7 +13,7 @@
   import ScriptEditor from "@/components/ScriptEditor.svelte";
   import HierarchyTree from "@/components/hierarchyTree/HierarchyTree.svelte";
   import log from "@lgn/frontend/src/lib/log";
-  import { unflatten } from "@/lib/hierarchyTree";
+  import { Entries } from "@/lib/hierarchyTree";
   import asyncStore from "@lgn/frontend/src/stores/asyncStore";
   import contextMenu from "@/actions/contextMenu";
   import contextMenuStore, {
@@ -133,12 +133,13 @@
         </div>
         <div class="h-separator" />
         <div class="resource-browser">
-          <Panel tabs={["Resource Browser"]}>
+          <Panel let:isFocused tabs={["Resource Browser"]}>
             <div slot="tab" let:tab>{tab}</div>
             <div slot="content" class="resource-browser-content">
               {#if $allResourcesData}
                 <HierarchyTree
-                  entries={unflatten($allResourcesData)}
+                  entries={Entries.unflatten($allResourcesData, Symbol)}
+                  panelIsFocused={isFocused}
                   on:dblclick={fetchCurrentResourceDescription}
                   bind:selectedItem={currentResourceDescription}
                   bind:this={resourceHierarchyTree}

--- a/crates/lgn-editor-gui/frontend/tests/lib/__snapshots__/hierarchyTree.test.ts.snap
+++ b/crates/lgn-editor-gui/frontend/tests/lib/__snapshots__/hierarchyTree.test.ts.snap
@@ -1,463 +1,727 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unflatten Unflattens a \`ResourceDescription\` array into a hierarchical tree 1`] = `
-Object {
-  "entity": Object {
-    "entries": Object {
-      "DebugCube0": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,db051b98-6ff5-4bac-bea8-50b5a13c3f1b)",
-          "path": "/entity/DebugCube0",
-          "version": 1,
+exports[`unflatten unflattens a \`ResourceDescription\` array into a hierarchical tree 1`] = `
+Entries {
+  "entries": Array [
+    Object {
+      "depth": 0,
+      "index": 0,
+      "item": Symbol(entity),
+      "name": "entity",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 1,
+          "item": Object {
+            "id": "(09cde0390abe0694,db051b98-6ff5-4bac-bea8-50b5a13c3f1b)",
+            "path": "/entity/DebugCube0",
+            "version": 1,
+          },
+          "name": "DebugCube0",
+          "subEntries": null,
         },
-      },
-      "DebugCube1": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,202e3aa6-f158-4c77-890b-3f59b183b6bd)",
-          "path": "/entity/DebugCube1",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 2,
+          "item": Object {
+            "id": "(09cde0390abe0694,202e3aa6-f158-4c77-890b-3f59b183b6bd)",
+            "path": "/entity/DebugCube1",
+            "version": 1,
+          },
+          "name": "DebugCube1",
+          "subEntries": null,
         },
-      },
-      "DebugCube2": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,7483c534-fe2a-4f16-b655-e9afe39a93ba)",
-          "path": "/entity/DebugCube2",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 3,
+          "item": Object {
+            "id": "(09cde0390abe0694,7483c534-fe2a-4f16-b655-e9afe39a93ba)",
+            "path": "/entity/DebugCube2",
+            "version": 1,
+          },
+          "name": "DebugCube2",
+          "subEntries": null,
         },
-      },
-      "TEST_ENTITY_NAME.dc": Object {
-        "item": Object {
-          "id": "(0bac9261332b6ce8,d8fe06a0-1317-46f5-902b-266b0eae6fa8)",
-          "path": "/entity/TEST_ENTITY_NAME.dc",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 4,
+          "item": Object {
+            "id": "(0bac9261332b6ce8,d8fe06a0-1317-46f5-902b-266b0eae6fa8)",
+            "path": "/entity/TEST_ENTITY_NAME.dc",
+            "version": 1,
+          },
+          "name": "TEST_ENTITY_NAME.dc",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
-  "image": Object {
-    "entries": Object {
-      "ground.psd": Object {
-        "item": Object {
-          "id": "(4976b194d8a1e0c2,8ee3dcef-1aa4-4772-ad9b-28066f06909e)",
-          "path": "/image/ground.psd",
-          "version": 1,
+    Object {
+      "depth": 0,
+      "index": 5,
+      "item": Symbol(image),
+      "name": "image",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 6,
+          "item": Object {
+            "id": "(4976b194d8a1e0c2,8ee3dcef-1aa4-4772-ad9b-28066f06909e)",
+            "path": "/image/ground.psd",
+            "version": 1,
+          },
+          "name": "ground.psd",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
-  "prefab": Object {
-    "entries": Object {
-      "props": Object {
-        "entries": Object {
-          "cube.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,270c28b5-6368-4a21-8ef1-a7d03f85abb3)",
-              "path": "/prefab/props/cube.ent",
-              "version": 1,
+    Object {
+      "depth": 0,
+      "index": 7,
+      "item": Symbol(prefab),
+      "name": "prefab",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 8,
+          "item": Symbol(props),
+          "name": "props",
+          "subEntries": Array [
+            Object {
+              "depth": 2,
+              "index": 9,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,270c28b5-6368-4a21-8ef1-a7d03f85abb3)",
+                "path": "/prefab/props/cube.ent",
+                "version": 1,
+              },
+              "name": "cube.ent",
+              "subEntries": null,
             },
-          },
-          "cube_group.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,45d44b64-b97c-486d-a0d7-151974c28263)",
-              "path": "/prefab/props/cube_group.ent",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 10,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,45d44b64-b97c-486d-a0d7-151974c28263)",
+                "path": "/prefab/props/cube_group.ent",
+                "version": 1,
+              },
+              "name": "cube_group.ent",
+              "subEntries": null,
             },
-          },
-          "cube_group_cube_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,7d0e930c-eb69-45c4-a695-fcb787f3700f)",
-              "path": "/prefab/props/cube_group_cube_1.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 11,
+              "item": Object {
+                "id": "(91dc60590cba171e,7d0e930c-eb69-45c4-a695-fcb787f3700f)",
+                "path": "/prefab/props/cube_group_cube_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_cube_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_group_cube_2.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,c6db12c5-47a6-407d-94da-b6853f36eb8a)",
-              "path": "/prefab/props/cube_group_cube_2.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 12,
+              "item": Object {
+                "id": "(91dc60590cba171e,c6db12c5-47a6-407d-94da-b6853f36eb8a)",
+                "path": "/prefab/props/cube_group_cube_2.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_cube_2.ent.ins",
+              "subEntries": null,
             },
-          },
+          ],
         },
-        "item": null,
-      },
+      ],
     },
-    "item": null,
-  },
-  "world": Object {
-    "entries": Object {
-      "sample_1": Object {
-        "entries": Object {
-          "cube_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,7d083d64-cbf9-4786-ae8b-44924b3e2035)",
-              "path": "/world/sample_1/cube_1.ent.ins",
-              "version": 1,
+    Object {
+      "depth": 0,
+      "index": 13,
+      "item": Symbol(world),
+      "name": "world",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 14,
+          "item": Symbol(sample_1),
+          "name": "sample_1",
+          "subEntries": Array [
+            Object {
+              "depth": 2,
+              "index": 15,
+              "item": Object {
+                "id": "(91dc60590cba171e,7d083d64-cbf9-4786-ae8b-44924b3e2035)",
+                "path": "/world/sample_1/cube_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_2.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,ee30f104-3ef5-46e7-af16-4f085bd6f8e3)",
-              "path": "/world/sample_1/cube_2.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 16,
+              "item": Object {
+                "id": "(91dc60590cba171e,ee30f104-3ef5-46e7-af16-4f085bd6f8e3)",
+                "path": "/world/sample_1/cube_2.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_2.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_3.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,4f595c8b-3b9a-41d6-9cf6-a7557dd2e8ee)",
-              "path": "/world/sample_1/cube_3.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 17,
+              "item": Object {
+                "id": "(91dc60590cba171e,4f595c8b-3b9a-41d6-9cf6-a7557dd2e8ee)",
+                "path": "/world/sample_1/cube_3.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_3.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_group_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,181f9358-000f-47db-9583-7c9448c3dba8)",
-              "path": "/world/sample_1/cube_group_1.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 18,
+              "item": Object {
+                "id": "(91dc60590cba171e,181f9358-000f-47db-9583-7c9448c3dba8)",
+                "path": "/world/sample_1/cube_group_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "ground.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,e07c7027-a823-47e5-b0dd-8871e27adfce)",
-              "path": "/world/sample_1/ground.ent",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 19,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,e07c7027-a823-47e5-b0dd-8871e27adfce)",
+                "path": "/world/sample_1/ground.ent",
+                "version": 1,
+              },
+              "name": "ground.ent",
+              "subEntries": null,
             },
-          },
-          "ground.mat": Object {
-            "item": Object {
-              "id": "(07dd9f5d1793ed64,48909c46-ad4f-4d6b-a522-2e16e81ba082)",
-              "path": "/world/sample_1/ground.mat",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 20,
+              "item": Object {
+                "id": "(07dd9f5d1793ed64,48909c46-ad4f-4d6b-a522-2e16e81ba082)",
+                "path": "/world/sample_1/ground.mat",
+                "version": 1,
+              },
+              "name": "ground.mat",
+              "subEntries": null,
             },
-          },
-          "ground.mesh": Object {
-            "item": Object {
-              "id": "(80b97dd7e2e9edca,7948dc8c-8bc6-4aaf-b3cf-0a21633edc44)",
-              "path": "/world/sample_1/ground.mesh",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 21,
+              "item": Object {
+                "id": "(80b97dd7e2e9edca,7948dc8c-8bc6-4aaf-b3cf-0a21633edc44)",
+                "path": "/world/sample_1/ground.mesh",
+                "version": 1,
+              },
+              "name": "ground.mesh",
+              "subEntries": null,
             },
-          },
+          ],
         },
-        "item": null,
-      },
-      "sample_1.ent": Object {
-        "item": Object {
-          "id": "(1c0ff9e497b0740f,5d6c8521-ef7f-4402-8fac-01c5c4f53329)",
-          "path": "/world/sample_1.ent",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 22,
+          "item": Object {
+            "id": "(1c0ff9e497b0740f,5d6c8521-ef7f-4402-8fac-01c5c4f53329)",
+            "path": "/world/sample_1.ent",
+            "version": 1,
+          },
+          "name": "sample_1.ent",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
+  ],
 }
 `;
 
-exports[`updateEntry Updates 1 entry name "leaf" when the provided function returns a non empty string for a "leaf" entry 1`] = `
-Object {
-  "entity": Object {
-    "entries": Object {
-      "DebugCube0": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,db051b98-6ff5-4bac-bea8-50b5a13c3f1b)",
-          "path": "/entity/DebugCube0",
-          "version": 1,
+exports[`updateEntry updates 1 entry name "leaf" when the provided function returns a non empty string for a "leaf" entry 1`] = `
+Entries {
+  "entries": Array [
+    Object {
+      "depth": 0,
+      "index": 0,
+      "item": Symbol(entity),
+      "name": "entity",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 1,
+          "item": Object {
+            "id": "(09cde0390abe0694,db051b98-6ff5-4bac-bea8-50b5a13c3f1b)",
+            "path": "/entity/DebugCube0",
+            "version": 1,
+          },
+          "name": "DebugCube0",
+          "subEntries": null,
         },
-      },
-      "DebugCube1": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,202e3aa6-f158-4c77-890b-3f59b183b6bd)",
-          "path": "/entity/DebugCube1",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 2,
+          "item": Object {
+            "id": "(09cde0390abe0694,202e3aa6-f158-4c77-890b-3f59b183b6bd)",
+            "path": "/entity/DebugCube1",
+            "version": 1,
+          },
+          "name": "DebugCube1",
+          "subEntries": null,
         },
-      },
-      "DebugCube2": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,7483c534-fe2a-4f16-b655-e9afe39a93ba)",
-          "path": "/entity/DebugCube2",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 3,
+          "item": Object {
+            "id": "(09cde0390abe0694,7483c534-fe2a-4f16-b655-e9afe39a93ba)",
+            "path": "/entity/DebugCube2",
+            "version": 1,
+          },
+          "name": "DebugCube2",
+          "subEntries": null,
         },
-      },
-      "TEST_ENTITY_NAME.dc": Object {
-        "item": Object {
-          "id": "(0bac9261332b6ce8,d8fe06a0-1317-46f5-902b-266b0eae6fa8)",
-          "path": "/entity/TEST_ENTITY_NAME.dc",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 4,
+          "item": Object {
+            "id": "(0bac9261332b6ce8,d8fe06a0-1317-46f5-902b-266b0eae6fa8)",
+            "path": "/entity/TEST_ENTITY_NAME.dc",
+            "version": 1,
+          },
+          "name": "TEST_ENTITY_NAME.dc",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
-  "image": Object {
-    "entries": Object {
-      "ground.psd": Object {
-        "item": Object {
-          "id": "(4976b194d8a1e0c2,8ee3dcef-1aa4-4772-ad9b-28066f06909e)",
-          "path": "/image/ground.psd",
-          "version": 1,
+    Object {
+      "depth": 0,
+      "index": 5,
+      "item": Symbol(image),
+      "name": "image",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 6,
+          "item": Object {
+            "id": "(4976b194d8a1e0c2,8ee3dcef-1aa4-4772-ad9b-28066f06909e)",
+            "path": "/image/ground.psd",
+            "version": 1,
+          },
+          "name": "ground.psd",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
-  "prefab": Object {
-    "entries": Object {
-      "props": Object {
-        "entries": Object {
-          "cube.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,270c28b5-6368-4a21-8ef1-a7d03f85abb3)",
-              "path": "/prefab/props/cube.ent",
-              "version": 1,
+    Object {
+      "depth": 0,
+      "index": 7,
+      "item": Symbol(prefab),
+      "name": "prefab",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 8,
+          "item": Symbol(props),
+          "name": "props",
+          "subEntries": Array [
+            Object {
+              "depth": 2,
+              "index": 9,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,270c28b5-6368-4a21-8ef1-a7d03f85abb3)",
+                "path": "/prefab/props/cube.ent",
+                "version": 1,
+              },
+              "name": "cube.ent",
+              "subEntries": null,
             },
-          },
-          "cube_group_cube_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,7d0e930c-eb69-45c4-a695-fcb787f3700f)",
-              "path": "/prefab/props/cube_group_cube_1.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 10,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,45d44b64-b97c-486d-a0d7-151974c28263)",
+                "path": "/prefab/props/cube_group.ent",
+                "version": 1,
+              },
+              "name": "new_cube_group.ent",
+              "subEntries": null,
             },
-          },
-          "cube_group_cube_2.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,c6db12c5-47a6-407d-94da-b6853f36eb8a)",
-              "path": "/prefab/props/cube_group_cube_2.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 11,
+              "item": Object {
+                "id": "(91dc60590cba171e,7d0e930c-eb69-45c4-a695-fcb787f3700f)",
+                "path": "/prefab/props/cube_group_cube_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_cube_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "new_cube_group.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,45d44b64-b97c-486d-a0d7-151974c28263)",
-              "path": "/prefab/props/cube_group.ent",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 12,
+              "item": Object {
+                "id": "(91dc60590cba171e,c6db12c5-47a6-407d-94da-b6853f36eb8a)",
+                "path": "/prefab/props/cube_group_cube_2.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_cube_2.ent.ins",
+              "subEntries": null,
             },
-          },
+          ],
         },
-        "item": null,
-      },
+      ],
     },
-    "item": null,
-  },
-  "world": Object {
-    "entries": Object {
-      "sample_1": Object {
-        "entries": Object {
-          "cube_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,7d083d64-cbf9-4786-ae8b-44924b3e2035)",
-              "path": "/world/sample_1/cube_1.ent.ins",
-              "version": 1,
+    Object {
+      "depth": 0,
+      "index": 13,
+      "item": Symbol(world),
+      "name": "world",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 14,
+          "item": Symbol(sample_1),
+          "name": "sample_1",
+          "subEntries": Array [
+            Object {
+              "depth": 2,
+              "index": 15,
+              "item": Object {
+                "id": "(91dc60590cba171e,7d083d64-cbf9-4786-ae8b-44924b3e2035)",
+                "path": "/world/sample_1/cube_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_2.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,ee30f104-3ef5-46e7-af16-4f085bd6f8e3)",
-              "path": "/world/sample_1/cube_2.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 16,
+              "item": Object {
+                "id": "(91dc60590cba171e,ee30f104-3ef5-46e7-af16-4f085bd6f8e3)",
+                "path": "/world/sample_1/cube_2.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_2.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_3.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,4f595c8b-3b9a-41d6-9cf6-a7557dd2e8ee)",
-              "path": "/world/sample_1/cube_3.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 17,
+              "item": Object {
+                "id": "(91dc60590cba171e,4f595c8b-3b9a-41d6-9cf6-a7557dd2e8ee)",
+                "path": "/world/sample_1/cube_3.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_3.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_group_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,181f9358-000f-47db-9583-7c9448c3dba8)",
-              "path": "/world/sample_1/cube_group_1.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 18,
+              "item": Object {
+                "id": "(91dc60590cba171e,181f9358-000f-47db-9583-7c9448c3dba8)",
+                "path": "/world/sample_1/cube_group_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "ground.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,e07c7027-a823-47e5-b0dd-8871e27adfce)",
-              "path": "/world/sample_1/ground.ent",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 19,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,e07c7027-a823-47e5-b0dd-8871e27adfce)",
+                "path": "/world/sample_1/ground.ent",
+                "version": 1,
+              },
+              "name": "ground.ent",
+              "subEntries": null,
             },
-          },
-          "ground.mat": Object {
-            "item": Object {
-              "id": "(07dd9f5d1793ed64,48909c46-ad4f-4d6b-a522-2e16e81ba082)",
-              "path": "/world/sample_1/ground.mat",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 20,
+              "item": Object {
+                "id": "(07dd9f5d1793ed64,48909c46-ad4f-4d6b-a522-2e16e81ba082)",
+                "path": "/world/sample_1/ground.mat",
+                "version": 1,
+              },
+              "name": "ground.mat",
+              "subEntries": null,
             },
-          },
-          "ground.mesh": Object {
-            "item": Object {
-              "id": "(80b97dd7e2e9edca,7948dc8c-8bc6-4aaf-b3cf-0a21633edc44)",
-              "path": "/world/sample_1/ground.mesh",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 21,
+              "item": Object {
+                "id": "(80b97dd7e2e9edca,7948dc8c-8bc6-4aaf-b3cf-0a21633edc44)",
+                "path": "/world/sample_1/ground.mesh",
+                "version": 1,
+              },
+              "name": "ground.mesh",
+              "subEntries": null,
             },
-          },
+          ],
         },
-        "item": null,
-      },
-      "sample_1.ent": Object {
-        "item": Object {
-          "id": "(1c0ff9e497b0740f,5d6c8521-ef7f-4402-8fac-01c5c4f53329)",
-          "path": "/world/sample_1.ent",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 22,
+          "item": Object {
+            "id": "(1c0ff9e497b0740f,5d6c8521-ef7f-4402-8fac-01c5c4f53329)",
+            "path": "/world/sample_1.ent",
+            "version": 1,
+          },
+          "name": "sample_1.ent",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
+  ],
 }
 `;
 
-exports[`updateEntry Updates 1 entry name "node" when the provided function returns a non empty string for a "node" entry 1`] = `
-Object {
-  "entity": Object {
-    "entries": Object {
-      "DebugCube0": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,db051b98-6ff5-4bac-bea8-50b5a13c3f1b)",
-          "path": "/entity/DebugCube0",
-          "version": 1,
+exports[`updateEntry updates 1 entry name "node" when the provided function returns a non empty string for a "node" entry 1`] = `
+Entries {
+  "entries": Array [
+    Object {
+      "depth": 0,
+      "index": 0,
+      "item": Symbol(entity),
+      "name": "entity",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 1,
+          "item": Object {
+            "id": "(09cde0390abe0694,db051b98-6ff5-4bac-bea8-50b5a13c3f1b)",
+            "path": "/entity/DebugCube0",
+            "version": 1,
+          },
+          "name": "DebugCube0",
+          "subEntries": null,
         },
-      },
-      "DebugCube1": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,202e3aa6-f158-4c77-890b-3f59b183b6bd)",
-          "path": "/entity/DebugCube1",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 2,
+          "item": Object {
+            "id": "(09cde0390abe0694,202e3aa6-f158-4c77-890b-3f59b183b6bd)",
+            "path": "/entity/DebugCube1",
+            "version": 1,
+          },
+          "name": "DebugCube1",
+          "subEntries": null,
         },
-      },
-      "DebugCube2": Object {
-        "item": Object {
-          "id": "(09cde0390abe0694,7483c534-fe2a-4f16-b655-e9afe39a93ba)",
-          "path": "/entity/DebugCube2",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 3,
+          "item": Object {
+            "id": "(09cde0390abe0694,7483c534-fe2a-4f16-b655-e9afe39a93ba)",
+            "path": "/entity/DebugCube2",
+            "version": 1,
+          },
+          "name": "DebugCube2",
+          "subEntries": null,
         },
-      },
-      "TEST_ENTITY_NAME.dc": Object {
-        "item": Object {
-          "id": "(0bac9261332b6ce8,d8fe06a0-1317-46f5-902b-266b0eae6fa8)",
-          "path": "/entity/TEST_ENTITY_NAME.dc",
-          "version": 1,
+        Object {
+          "depth": 1,
+          "index": 4,
+          "item": Object {
+            "id": "(0bac9261332b6ce8,d8fe06a0-1317-46f5-902b-266b0eae6fa8)",
+            "path": "/entity/TEST_ENTITY_NAME.dc",
+            "version": 1,
+          },
+          "name": "TEST_ENTITY_NAME.dc",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
-  "image": Object {
-    "entries": Object {
-      "ground.psd": Object {
-        "item": Object {
-          "id": "(4976b194d8a1e0c2,8ee3dcef-1aa4-4772-ad9b-28066f06909e)",
-          "path": "/image/ground.psd",
-          "version": 1,
+    Object {
+      "depth": 0,
+      "index": 5,
+      "item": Symbol(image),
+      "name": "image",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 6,
+          "item": Object {
+            "id": "(4976b194d8a1e0c2,8ee3dcef-1aa4-4772-ad9b-28066f06909e)",
+            "path": "/image/ground.psd",
+            "version": 1,
+          },
+          "name": "ground.psd",
+          "subEntries": null,
         },
-      },
+      ],
     },
-    "item": null,
-  },
-  "monde": Object {
-    "entries": Object {
-      "sample_1": Object {
-        "entries": Object {
-          "cube_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,7d083d64-cbf9-4786-ae8b-44924b3e2035)",
-              "path": "/world/sample_1/cube_1.ent.ins",
-              "version": 1,
+    Object {
+      "depth": 0,
+      "index": 7,
+      "item": Symbol(prefab),
+      "name": "prefab",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 8,
+          "item": Symbol(props),
+          "name": "props",
+          "subEntries": Array [
+            Object {
+              "depth": 2,
+              "index": 9,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,270c28b5-6368-4a21-8ef1-a7d03f85abb3)",
+                "path": "/prefab/props/cube.ent",
+                "version": 1,
+              },
+              "name": "cube.ent",
+              "subEntries": null,
             },
-          },
-          "cube_2.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,ee30f104-3ef5-46e7-af16-4f085bd6f8e3)",
-              "path": "/world/sample_1/cube_2.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 10,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,45d44b64-b97c-486d-a0d7-151974c28263)",
+                "path": "/prefab/props/cube_group.ent",
+                "version": 1,
+              },
+              "name": "cube_group.ent",
+              "subEntries": null,
             },
-          },
-          "cube_3.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,4f595c8b-3b9a-41d6-9cf6-a7557dd2e8ee)",
-              "path": "/world/sample_1/cube_3.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 11,
+              "item": Object {
+                "id": "(91dc60590cba171e,7d0e930c-eb69-45c4-a695-fcb787f3700f)",
+                "path": "/prefab/props/cube_group_cube_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_cube_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_group_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,181f9358-000f-47db-9583-7c9448c3dba8)",
-              "path": "/world/sample_1/cube_group_1.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 12,
+              "item": Object {
+                "id": "(91dc60590cba171e,c6db12c5-47a6-407d-94da-b6853f36eb8a)",
+                "path": "/prefab/props/cube_group_cube_2.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_cube_2.ent.ins",
+              "subEntries": null,
             },
-          },
-          "ground.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,e07c7027-a823-47e5-b0dd-8871e27adfce)",
-              "path": "/world/sample_1/ground.ent",
-              "version": 1,
-            },
-          },
-          "ground.mat": Object {
-            "item": Object {
-              "id": "(07dd9f5d1793ed64,48909c46-ad4f-4d6b-a522-2e16e81ba082)",
-              "path": "/world/sample_1/ground.mat",
-              "version": 1,
-            },
-          },
-          "ground.mesh": Object {
-            "item": Object {
-              "id": "(80b97dd7e2e9edca,7948dc8c-8bc6-4aaf-b3cf-0a21633edc44)",
-              "path": "/world/sample_1/ground.mesh",
-              "version": 1,
-            },
-          },
+          ],
         },
-        "item": null,
-      },
-      "sample_1.ent": Object {
-        "item": Object {
-          "id": "(1c0ff9e497b0740f,5d6c8521-ef7f-4402-8fac-01c5c4f53329)",
-          "path": "/world/sample_1.ent",
-          "version": 1,
-        },
-      },
+      ],
     },
-    "item": null,
-  },
-  "prefab": Object {
-    "entries": Object {
-      "props": Object {
-        "entries": Object {
-          "cube.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,270c28b5-6368-4a21-8ef1-a7d03f85abb3)",
-              "path": "/prefab/props/cube.ent",
-              "version": 1,
+    Object {
+      "depth": 0,
+      "index": 13,
+      "item": Symbol(world),
+      "name": "monde",
+      "subEntries": Array [
+        Object {
+          "depth": 1,
+          "index": 14,
+          "item": Symbol(sample_1),
+          "name": "sample_1",
+          "subEntries": Array [
+            Object {
+              "depth": 2,
+              "index": 15,
+              "item": Object {
+                "id": "(91dc60590cba171e,7d083d64-cbf9-4786-ae8b-44924b3e2035)",
+                "path": "/world/sample_1/cube_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_1.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_group.ent": Object {
-            "item": Object {
-              "id": "(1c0ff9e497b0740f,45d44b64-b97c-486d-a0d7-151974c28263)",
-              "path": "/prefab/props/cube_group.ent",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 16,
+              "item": Object {
+                "id": "(91dc60590cba171e,ee30f104-3ef5-46e7-af16-4f085bd6f8e3)",
+                "path": "/world/sample_1/cube_2.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_2.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_group_cube_1.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,7d0e930c-eb69-45c4-a695-fcb787f3700f)",
-              "path": "/prefab/props/cube_group_cube_1.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 17,
+              "item": Object {
+                "id": "(91dc60590cba171e,4f595c8b-3b9a-41d6-9cf6-a7557dd2e8ee)",
+                "path": "/world/sample_1/cube_3.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_3.ent.ins",
+              "subEntries": null,
             },
-          },
-          "cube_group_cube_2.ent.ins": Object {
-            "item": Object {
-              "id": "(91dc60590cba171e,c6db12c5-47a6-407d-94da-b6853f36eb8a)",
-              "path": "/prefab/props/cube_group_cube_2.ent.ins",
-              "version": 1,
+            Object {
+              "depth": 2,
+              "index": 18,
+              "item": Object {
+                "id": "(91dc60590cba171e,181f9358-000f-47db-9583-7c9448c3dba8)",
+                "path": "/world/sample_1/cube_group_1.ent.ins",
+                "version": 1,
+              },
+              "name": "cube_group_1.ent.ins",
+              "subEntries": null,
             },
-          },
+            Object {
+              "depth": 2,
+              "index": 19,
+              "item": Object {
+                "id": "(1c0ff9e497b0740f,e07c7027-a823-47e5-b0dd-8871e27adfce)",
+                "path": "/world/sample_1/ground.ent",
+                "version": 1,
+              },
+              "name": "ground.ent",
+              "subEntries": null,
+            },
+            Object {
+              "depth": 2,
+              "index": 20,
+              "item": Object {
+                "id": "(07dd9f5d1793ed64,48909c46-ad4f-4d6b-a522-2e16e81ba082)",
+                "path": "/world/sample_1/ground.mat",
+                "version": 1,
+              },
+              "name": "ground.mat",
+              "subEntries": null,
+            },
+            Object {
+              "depth": 2,
+              "index": 21,
+              "item": Object {
+                "id": "(80b97dd7e2e9edca,7948dc8c-8bc6-4aaf-b3cf-0a21633edc44)",
+                "path": "/world/sample_1/ground.mesh",
+                "version": 1,
+              },
+              "name": "ground.mesh",
+              "subEntries": null,
+            },
+          ],
         },
-        "item": null,
-      },
+        Object {
+          "depth": 1,
+          "index": 22,
+          "item": Object {
+            "id": "(1c0ff9e497b0740f,5d6c8521-ef7f-4402-8fac-01c5c4f53329)",
+            "path": "/world/sample_1.ent",
+            "version": 1,
+          },
+          "name": "sample_1.ent",
+          "subEntries": null,
+        },
+      ],
     },
-    "item": null,
-  },
+  ],
 }
 `;

--- a/crates/lgn-editor-gui/frontend/tests/lib/__snapshots__/propertyGrid.test.ts.snap
+++ b/crates/lgn-editor-gui/frontend/tests/lib/__snapshots__/propertyGrid.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`Color\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`Color\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -10,7 +10,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`Quat\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`Quat\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -25,7 +25,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`Speed\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`Speed\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -35,7 +35,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`String\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`String\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -45,7 +45,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`Vec3\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`Vec3\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -59,7 +59,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`bool\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`bool\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -69,7 +69,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`f32\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`f32\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -79,7 +79,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`f64\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`f64\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -89,7 +89,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`i32\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`i32\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -99,7 +99,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`u8\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`u8\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -109,7 +109,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`u32\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`u32\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -119,7 +119,7 @@ Object {
 }
 `;
 
-exports[`buildDefaultPrimitiveProperty Builds a default primitive value from ptype \`usize\` 1`] = `
+exports[`buildDefaultPrimitiveProperty builds a default primitive value from ptype \`usize\` 1`] = `
 Object {
   "attributes": Object {},
   "name": "My resource property",
@@ -129,7 +129,7 @@ Object {
 }
 `;
 
-exports[`formatProperties It properly formats the properties received from the server 1`] = `
+exports[`formatProperties properly formats the properties received from the server 1`] = `
 Array [
   Object {
     "attributes": Object {},

--- a/crates/lgn-editor-gui/frontend/tests/lib/array.ts
+++ b/crates/lgn-editor-gui/frontend/tests/lib/array.ts
@@ -1,0 +1,33 @@
+import { filterMap, takeWhile } from "@/lib/array";
+
+describe("filterMap", () => {
+  it("returns an empty array when the provided array is empty", () => {
+    expect(filterMap([], () => null)).toEqual([]);
+  });
+
+  it("returns an empty array when the provided array is not empty but the provided function returns always `null`", () => {
+    expect(filterMap([1, 2, 3], () => null)).toEqual([]);
+  });
+
+  it("returns an array of even number multiplied by 2 when the provided function returns `null` if a number is odd and the number multiplied by 2 if the number is even", () => {
+    expect(
+      filterMap([1, 2, 3, 4, 5, 6], (x) => (x % 2 === 0 ? x * 2 : null))
+    ).toEqual([4, 6, 8, 12]);
+  });
+});
+
+describe("takeWhile", () => {
+  it("returns an empty array when the provided array is empty", () => {
+    expect(takeWhile([], () => false)).toEqual([]);
+  });
+
+  it("returns an empty array when the provided array is not empty but the provided function returns always `false`", () => {
+    expect(takeWhile([1, 2, 3], () => false)).toEqual([]);
+  });
+
+  it("returns an array containing only the first even numbers when the provided function returns always `true` when the number is even and `false` when it's odd", () => {
+    expect(takeWhile([2, 4, 6, 7, 8, 10], (x) => x % 2 === 0)).toEqual([
+      2, 4, 6,
+    ]);
+  });
+});

--- a/crates/lgn-editor-gui/frontend/tests/lib/hierarchyTree.test.ts
+++ b/crates/lgn-editor-gui/frontend/tests/lib/hierarchyTree.test.ts
@@ -1,46 +1,49 @@
-import { unflatten, updateEntry } from "@/lib/hierarchyTree";
+import { Entries } from "@/lib/hierarchyTree";
 import resources from "@/resources/resourcesResponse.json";
 
 describe("updateEntry", () => {
-  it("Updates no entry names when the provided function always returns null in the Entries", () => {
-    const entries = unflatten(resources);
+  it("updates no entry names when the provided function always returns null in the Entries", () => {
+    const entries = Entries.unflatten(resources, Symbol);
 
-    expect(updateEntry(entries, () => null)).toEqual(entries);
+    expect(entries.update(() => null)).toEqual(entries);
   });
 
-  it("Updates no entry names when the provided function always return an empty string in the Entries", () => {
-    const entries = unflatten(resources);
+  it("updates no entry names when the provided function always return an empty string in the Entries", () => {
+    const entries = Entries.unflatten(resources, Symbol);
 
     expect(
-      updateEntry(entries, () => ({
+      entries.update((entry) => ({
+        ...entry,
         name: "",
       }))
     ).toEqual(entries);
   });
 
-  it('Updates 1 entry name "leaf" when the provided function returns a non empty string for a "leaf" entry', () => {
-    const entries = unflatten(resources);
+  it('updates 1 entry name "leaf" when the provided function returns a non empty string for a "leaf" entry', () => {
+    const entries = Entries.unflatten(resources, Symbol);
 
     expect(
-      updateEntry(entries, (name) =>
-        name === "cube_group.ent" ? { name: "new_cube_group.ent" } : null
+      entries.update((entry) =>
+        entry.name === "cube_group.ent"
+          ? { ...entry, name: "new_cube_group.ent" }
+          : null
       )
     ).toMatchSnapshot();
   });
 
-  it('Updates 1 entry name "node" when the provided function returns a non empty string for a "node" entry', () => {
-    const entries = unflatten(resources);
+  it('updates 1 entry name "node" when the provided function returns a non empty string for a "node" entry', () => {
+    const entries = Entries.unflatten(resources, Symbol);
 
     expect(
-      updateEntry(entries, (name) =>
-        name === "world" ? { name: "monde" } : null
+      entries.update((entry) =>
+        entry.name === "world" ? { ...entry, name: "monde" } : null
       )
     ).toMatchSnapshot();
   });
 });
 
 describe("unflatten", () => {
-  it("Unflattens a `ResourceDescription` array into a hierarchical tree", () => {
-    expect(unflatten(resources)).toMatchSnapshot();
+  it("unflattens a `ResourceDescription` array into a hierarchical tree", () => {
+    expect(Entries.unflatten(resources, Symbol)).toMatchSnapshot();
   });
 });

--- a/crates/lgn-editor-gui/frontend/tests/lib/propertyGrid.test.ts
+++ b/crates/lgn-editor-gui/frontend/tests/lib/propertyGrid.test.ts
@@ -25,7 +25,7 @@ import {
 import propertiesResponse from "@/resources/propertiesResponse.json";
 
 describe("formatProperties", () => {
-  it("It properly formats the properties received from the server", () => {
+  it("properly formats the properties received from the server", () => {
     expect(
       formatProperties(propertiesResponse as unknown as ResourceProperty[])
     ).toMatchSnapshot();
@@ -33,73 +33,73 @@ describe("formatProperties", () => {
 });
 
 describe("buildDefaultPrimitiveProperty", () => {
-  it("Builds a default primitive value from ptype `bool`", () => {
+  it("builds a default primitive value from ptype `bool`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "bool")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `Speed`", () => {
+  it("builds a default primitive value from ptype `Speed`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "Speed")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `Color`", () => {
+  it("builds a default primitive value from ptype `Color`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "Color")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `String`", () => {
+  it("builds a default primitive value from ptype `String`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "String")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `i32`", () => {
+  it("builds a default primitive value from ptype `i32`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "i32")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `u32`", () => {
+  it("builds a default primitive value from ptype `u32`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "u32")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `f32`", () => {
+  it("builds a default primitive value from ptype `f32`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "f32")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `f64`", () => {
+  it("builds a default primitive value from ptype `f64`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "f64")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `usize`", () => {
+  it("builds a default primitive value from ptype `usize`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "usize")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `u8`", () => {
+  it("builds a default primitive value from ptype `u8`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "u8")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `Vec3`", () => {
+  it("builds a default primitive value from ptype `Vec3`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "Vec3")
     ).toMatchSnapshot();
   });
 
-  it("Builds a default primitive value from ptype `Quat`", () => {
+  it("builds a default primitive value from ptype `Quat`", () => {
     expect(
       buildDefaultPrimitiveProperty("My resource property", "Quat")
     ).toMatchSnapshot();
@@ -107,7 +107,7 @@ describe("buildDefaultPrimitiveProperty", () => {
 });
 
 describe("propertyIsBoolean", () => {
-  it("Returns `true` when the property's `ptype` === `bool`", () => {
+  it("returns `true` when the property's `ptype` === `bool`", () => {
     expect(
       propertyIsBoolean(
         buildDefaultPrimitiveProperty("My resource property", "bool")
@@ -115,7 +115,7 @@ describe("propertyIsBoolean", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `bool`", () => {
+  it("returns `false` when the property's `ptype` !== `bool`", () => {
     expect(
       propertyIsBoolean(
         buildDefaultPrimitiveProperty("My resource property", "Color")
@@ -125,7 +125,7 @@ describe("propertyIsBoolean", () => {
 });
 
 describe("propertyIsColor", () => {
-  it("Returns `true` when the property's `ptype` === `Color`", () => {
+  it("returns `true` when the property's `ptype` === `Color`", () => {
     expect(
       propertyIsColor(
         buildDefaultPrimitiveProperty("My resource property", "Color")
@@ -133,7 +133,7 @@ describe("propertyIsColor", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `Color`", () => {
+  it("returns `false` when the property's `ptype` !== `Color`", () => {
     expect(
       propertyIsColor(
         buildDefaultPrimitiveProperty("My resource property", "String")
@@ -143,7 +143,7 @@ describe("propertyIsColor", () => {
 });
 
 describe("propertyIsSpeed", () => {
-  it("Returns `true` when the property's `ptype` === `Speed`", () => {
+  it("returns `true` when the property's `ptype` === `Speed`", () => {
     expect(
       propertyIsSpeed(
         buildDefaultPrimitiveProperty("My resource property", "Speed")
@@ -151,7 +151,7 @@ describe("propertyIsSpeed", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `Speed`", () => {
+  it("returns `false` when the property's `ptype` !== `Speed`", () => {
     expect(
       propertyIsSpeed(
         buildDefaultPrimitiveProperty("My resource property", "String")
@@ -161,7 +161,7 @@ describe("propertyIsSpeed", () => {
 });
 
 describe("propertyIsString", () => {
-  it("Returns `true` when the property's `ptype` === `String`", () => {
+  it("returns `true` when the property's `ptype` === `String`", () => {
     expect(
       propertyIsString(
         buildDefaultPrimitiveProperty("My resource property", "String")
@@ -169,7 +169,7 @@ describe("propertyIsString", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `String`", () => {
+  it("returns `false` when the property's `ptype` !== `String`", () => {
     expect(
       propertyIsString(
         buildDefaultPrimitiveProperty("My resource property", "i32")
@@ -179,7 +179,7 @@ describe("propertyIsString", () => {
 });
 
 describe("propertyIsNumber", () => {
-  it("Returns `true` when the property's `ptype` === `i32`", () => {
+  it("returns `true` when the property's `ptype` === `i32`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "i32")
@@ -187,7 +187,7 @@ describe("propertyIsNumber", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `u32`", () => {
+  it("returns `true` when the property's `ptype` === `u32`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "u32")
@@ -195,7 +195,7 @@ describe("propertyIsNumber", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `f32`", () => {
+  it("returns `true` when the property's `ptype` === `f32`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "f32")
@@ -203,7 +203,7 @@ describe("propertyIsNumber", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `f64`", () => {
+  it("returns `true` when the property's `ptype` === `f64`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "f64")
@@ -211,7 +211,7 @@ describe("propertyIsNumber", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `usize`", () => {
+  it("returns `true` when the property's `ptype` === `usize`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "usize")
@@ -219,7 +219,7 @@ describe("propertyIsNumber", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `u8`", () => {
+  it("returns `true` when the property's `ptype` === `u8`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "u8")
@@ -227,7 +227,7 @@ describe("propertyIsNumber", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `i32`", () => {
+  it("returns `false` when the property's `ptype` !== `i32`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -235,7 +235,7 @@ describe("propertyIsNumber", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property's `ptype` !== `u32`", () => {
+  it("returns `false` when the property's `ptype` !== `u32`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -243,7 +243,7 @@ describe("propertyIsNumber", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property's `ptype` !== `f32`", () => {
+  it("returns `false` when the property's `ptype` !== `f32`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -251,7 +251,7 @@ describe("propertyIsNumber", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property's `ptype` !== `f64`", () => {
+  it("returns `false` when the property's `ptype` !== `f64`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -259,7 +259,7 @@ describe("propertyIsNumber", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property's `ptype` !== `usize`", () => {
+  it("returns `false` when the property's `ptype` !== `usize`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -267,7 +267,7 @@ describe("propertyIsNumber", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property's `ptype` !== `u8`", () => {
+  it("returns `false` when the property's `ptype` !== `u8`", () => {
     expect(
       propertyIsNumber(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -277,7 +277,7 @@ describe("propertyIsNumber", () => {
 });
 
 describe("propertyIsVec3", () => {
-  it("Returns `true` when the property's `ptype` === `Vec3`", () => {
+  it("returns `true` when the property's `ptype` === `Vec3`", () => {
     expect(
       propertyIsVec3(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -285,7 +285,7 @@ describe("propertyIsVec3", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `Vec3`", () => {
+  it("returns `false` when the property's `ptype` !== `Vec3`", () => {
     expect(
       propertyIsVec3(
         buildDefaultPrimitiveProperty("My resource property", "Quat")
@@ -295,7 +295,7 @@ describe("propertyIsVec3", () => {
 });
 
 describe("propertyIsQuat", () => {
-  it("Returns `true` when the property's `ptype` === `Quat`", () => {
+  it("returns `true` when the property's `ptype` === `Quat`", () => {
     expect(
       propertyIsQuat(
         buildDefaultPrimitiveProperty("My resource property", "Quat")
@@ -303,7 +303,7 @@ describe("propertyIsQuat", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `Quat`", () => {
+  it("returns `false` when the property's `ptype` !== `Quat`", () => {
     expect(
       propertyIsQuat(
         buildDefaultPrimitiveProperty("My resource property", "bool")
@@ -324,7 +324,7 @@ describe("extractOptionPType", () => {
     ).toBe("String");
   });
 
-  it("Returns `null` if the `ptype` doesn't belong to an Option property", () => {
+  it("returns `null` if the `ptype` doesn't belong to an Option property", () => {
     expect(
       extractOptionPType({
         attributes: {},
@@ -336,7 +336,7 @@ describe("extractOptionPType", () => {
     ).toBe(null);
   });
 
-  it("Returns `null` if the `ptype` is invalid", () => {
+  it("returns `null` if the `ptype` is invalid", () => {
     expect(
       extractOptionPType({
         attributes: {},
@@ -361,7 +361,7 @@ describe("extractVecPType", () => {
     ).toBe("String");
   });
 
-  it("Returns `null` if the `ptype` doesn't belong to a Vec property", () => {
+  it("returns `null` if the `ptype` doesn't belong to a Vec property", () => {
     expect(
       extractVecPType({
         attributes: {},
@@ -373,7 +373,7 @@ describe("extractVecPType", () => {
     ).toBe(null);
   });
 
-  it("Returns `null` if the `ptype` is invalid", () => {
+  it("returns `null` if the `ptype` is invalid", () => {
     expect(
       extractVecPType({
         attributes: {},
@@ -387,61 +387,61 @@ describe("extractVecPType", () => {
 });
 
 describe("ptypeBelongsToPrimitive", () => {
-  it("Returns `true` when the `ptype` === `bool`", () => {
+  it("returns `true` when the `ptype` === `bool`", () => {
     expect(ptypeBelongsToPrimitive("bool")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `Speed`", () => {
+  it("returns `true` when the `ptype` === `Speed`", () => {
     expect(ptypeBelongsToPrimitive("Speed")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `Color`", () => {
+  it("returns `true` when the `ptype` === `Color`", () => {
     expect(ptypeBelongsToPrimitive("Color")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `String`", () => {
+  it("returns `true` when the `ptype` === `String`", () => {
     expect(ptypeBelongsToPrimitive("String")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `i32`", () => {
+  it("returns `true` when the `ptype` === `i32`", () => {
     expect(ptypeBelongsToPrimitive("i32")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `u32`", () => {
+  it("returns `true` when the `ptype` === `u32`", () => {
     expect(ptypeBelongsToPrimitive("u32")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `f32`", () => {
+  it("returns `true` when the `ptype` === `f32`", () => {
     expect(ptypeBelongsToPrimitive("f32")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `f64`", () => {
+  it("returns `true` when the `ptype` === `f64`", () => {
     expect(ptypeBelongsToPrimitive("f64")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `usize`", () => {
+  it("returns `true` when the `ptype` === `usize`", () => {
     expect(ptypeBelongsToPrimitive("usize")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `u8`", () => {
+  it("returns `true` when the `ptype` === `u8`", () => {
     expect(ptypeBelongsToPrimitive("u8")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `Vec3`", () => {
+  it("returns `true` when the `ptype` === `Vec3`", () => {
     expect(ptypeBelongsToPrimitive("Vec3")).toBe(true);
   });
 
-  it("Returns `true` when the `ptype` === `Quat`", () => {
+  it("returns `true` when the `ptype` === `Quat`", () => {
     expect(ptypeBelongsToPrimitive("Quat")).toBe(true);
   });
 
-  it("Returns `false` when the `ptype` doesn't belong to a primitive", () => {
+  it("returns `false` when the `ptype` doesn't belong to a primitive", () => {
     expect(ptypeBelongsToPrimitive("Vec<String>")).toBe(false);
   });
 });
 
 describe("propertyIsPrimitive", () => {
-  it("Returns `true` when the property's `ptype` === `bool`", () => {
+  it("returns `true` when the property's `ptype` === `bool`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "bool")
@@ -449,7 +449,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `Speed`", () => {
+  it("returns `true` when the property's `ptype` === `Speed`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "Speed")
@@ -457,7 +457,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `Color`", () => {
+  it("returns `true` when the property's `ptype` === `Color`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "Color")
@@ -465,7 +465,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `String`", () => {
+  it("returns `true` when the property's `ptype` === `String`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "String")
@@ -473,7 +473,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `i32`", () => {
+  it("returns `true` when the property's `ptype` === `i32`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "i32")
@@ -481,7 +481,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `u32`", () => {
+  it("returns `true` when the property's `ptype` === `u32`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "u32")
@@ -489,7 +489,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `f32`", () => {
+  it("returns `true` when the property's `ptype` === `f32`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "f32")
@@ -497,7 +497,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `f64`", () => {
+  it("returns `true` when the property's `ptype` === `f64`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "f64")
@@ -505,7 +505,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `usize`", () => {
+  it("returns `true` when the property's `ptype` === `usize`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "usize")
@@ -513,7 +513,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `u8`", () => {
+  it("returns `true` when the property's `ptype` === `u8`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "u8")
@@ -521,7 +521,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `Vec3`", () => {
+  it("returns `true` when the property's `ptype` === `Vec3`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "Vec3")
@@ -529,7 +529,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the property's `ptype` === `Quat`", () => {
+  it("returns `true` when the property's `ptype` === `Quat`", () => {
     expect(
       propertyIsPrimitive(
         buildDefaultPrimitiveProperty("My resource property", "Quat")
@@ -537,7 +537,7 @@ describe("propertyIsPrimitive", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` doesn't belong to a primitive", () => {
+  it("returns `false` when the property's `ptype` doesn't belong to a primitive", () => {
     expect(
       propertyIsPrimitive({
         attributes: {},
@@ -550,7 +550,7 @@ describe("propertyIsPrimitive", () => {
 });
 
 describe("propertyIsOption", () => {
-  it("Returns `true` when the property's `ptype` matches `Option<.*>`", () => {
+  it("returns `true` when the property's `ptype` matches `Option<.*>`", () => {
     expect(
       propertyIsOption(
         buildOptionProperty(
@@ -561,7 +561,7 @@ describe("propertyIsOption", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` doesn't match `Option<.*>`", () => {
+  it("returns `false` when the property's `ptype` doesn't match `Option<.*>`", () => {
     expect(
       propertyIsOption(
         buildVecProperty("My resource property", [
@@ -573,7 +573,7 @@ describe("propertyIsOption", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property is a primitive", () => {
+  it("returns `false` when the property is a primitive", () => {
     expect(
       propertyIsOption(
         buildDefaultPrimitiveProperty("My resource property", "Quat")
@@ -583,7 +583,7 @@ describe("propertyIsOption", () => {
 });
 
 describe("propertyIsVec", () => {
-  it("Returns `true` when the property's `ptype` matches `Vec<.*>`", () => {
+  it("returns `true` when the property's `ptype` matches `Vec<.*>`", () => {
     expect(
       propertyIsVec(
         buildVecProperty("My resource property", [
@@ -595,7 +595,7 @@ describe("propertyIsVec", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` doesn't match `Vec<.*>`", () => {
+  it("returns `false` when the property's `ptype` doesn't match `Vec<.*>`", () => {
     expect(
       propertyIsVec(
         buildOptionProperty(
@@ -606,7 +606,7 @@ describe("propertyIsVec", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property is a primitive", () => {
+  it("returns `false` when the property is a primitive", () => {
     expect(
       propertyIsVec(
         buildDefaultPrimitiveProperty("My resource property", "Quat")
@@ -616,7 +616,7 @@ describe("propertyIsVec", () => {
 });
 
 describe("propertyIsGroup", () => {
-  it("Returns `true` when the property's `ptype` === `group`", () => {
+  it("returns `true` when the property's `ptype` === `group`", () => {
     expect(
       propertyIsGroup(
         buildGroupProperty("My resource property", [
@@ -626,7 +626,7 @@ describe("propertyIsGroup", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property's `ptype` !== `group`", () => {
+  it("returns `false` when the property's `ptype` !== `group`", () => {
     expect(
       propertyIsGroup(
         buildOptionProperty(
@@ -637,7 +637,7 @@ describe("propertyIsGroup", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property is a primitive", () => {
+  it("returns `false` when the property is a primitive", () => {
     expect(
       propertyIsGroup(
         buildDefaultPrimitiveProperty("My resource property", "Quat")
@@ -647,7 +647,7 @@ describe("propertyIsGroup", () => {
 });
 
 describe("propertyIsComponent", () => {
-  it("Returns `true` when the property has an unknown `ptype` and it's assumed to be a Component", () => {
+  it("returns `true` when the property has an unknown `ptype` and it's assumed to be a Component", () => {
     expect(
       propertyIsComponent({
         attributes: {},
@@ -658,7 +658,7 @@ describe("propertyIsComponent", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the property is a primitive", () => {
+  it("returns `false` when the property is a primitive", () => {
     expect(
       propertyIsComponent(
         buildDefaultPrimitiveProperty("My resource property", "Quat")
@@ -666,7 +666,7 @@ describe("propertyIsComponent", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property is an Option", () => {
+  it("returns `false` when the property is an Option", () => {
     expect(
       propertyIsComponent(
         buildOptionProperty(
@@ -677,7 +677,7 @@ describe("propertyIsComponent", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property is a Vec", () => {
+  it("returns `false` when the property is a Vec", () => {
     expect(
       propertyIsComponent(
         buildVecProperty("My resource property", [
@@ -689,7 +689,7 @@ describe("propertyIsComponent", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property is a group", () => {
+  it("returns `false` when the property is a group", () => {
     expect(
       propertyIsComponent(
         buildGroupProperty("My resource property", [
@@ -701,7 +701,7 @@ describe("propertyIsComponent", () => {
 });
 
 describe("propertyIsBag", () => {
-  it("Returns `true` when the the property's `ptype` === `group`", () => {
+  it("returns `true` when the the property's `ptype` === `group`", () => {
     expect(
       propertyIsBag(
         buildGroupProperty("My resource property", [
@@ -711,7 +711,7 @@ describe("propertyIsBag", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the the property is a Component", () => {
+  it("returns `true` when the the property is a Component", () => {
     expect(
       propertyIsBag({
         attributes: {},
@@ -722,7 +722,7 @@ describe("propertyIsBag", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the the property's `ptype` matches `Vec<*>`", () => {
+  it("returns `true` when the the property's `ptype` matches `Vec<*>`", () => {
     expect(
       propertyIsBag(
         buildVecProperty("My resource property", [
@@ -732,7 +732,7 @@ describe("propertyIsBag", () => {
     ).toBe(true);
   });
 
-  it("Returns `true` when the the property's `ptype` matches `Option<*>` and the inner `ptype` is not a primitive's", () => {
+  it("returns `true` when the the property's `ptype` matches `Option<*>` and the inner `ptype` is not a primitive's", () => {
     expect(
       propertyIsBag(
         buildOptionProperty("My resource property", {
@@ -745,7 +745,7 @@ describe("propertyIsBag", () => {
     ).toBe(true);
   });
 
-  it("Returns `false` when the the property's `ptype` matches `Option<*>`and the inner `ptype` is a primitive's", () => {
+  it("returns `false` when the the property's `ptype` matches `Option<*>`and the inner `ptype` is a primitive's", () => {
     expect(
       propertyIsBag(
         buildOptionProperty(
@@ -756,7 +756,7 @@ describe("propertyIsBag", () => {
     ).toBe(false);
   });
 
-  it("Returns `false` when the property is a primitive", () => {
+  it("returns `false` when the property is a primitive", () => {
     expect(
       propertyIsBag(
         buildDefaultPrimitiveProperty("My resource property", "Quat")


### PR DESCRIPTION
Enable keyboard navigation for the hierarchy tree.

While at it I also tried to refactor/clean the way we handle "entries" (where an entry is just an abstraction over the resource in the hierarchy tree). The code responsible for the conversion resources -> entries is not optimal as of today but things will change on the backend and some the logic will not be necessary anymore so that's fine.

