### PR TITLE
Testing out a class based Svelte store

### DIFF
--- a/crates/lgn-browser/frontend/src/actions/contextMenu.ts
+++ b/crates/lgn-browser/frontend/src/actions/contextMenu.ts
@@ -1,4 +1,4 @@
-import { Store as ContextMenuStore } from "../stores/contextMenu";
+import ContextMenuStore from "../stores/contextMenu";
 
 /**
  * Builds a type safe `contextMenu` action that automatically uses

--- a/crates/lgn-browser/frontend/src/components/ContextMenu.svelte
+++ b/crates/lgn-browser/frontend/src/components/ContextMenu.svelte
@@ -118,7 +118,7 @@ export default buildContextMenu<ContextMenuEntryRecord>(myContextMenuStore);
   import { remToPx } from "../lib/html";
   import { sleep } from "../lib/promises";
   import { Position } from "../lib/types";
-  import { Store as ContextMenuStore } from "../stores/contextMenu";
+  import ContextMenuStore from "../stores/contextMenu";
   import { buildCustomEvent, Entry, ItemEntry } from "../types/contextMenu";
 
   type State =

--- a/crates/lgn-browser/frontend/src/components/TopBar.svelte
+++ b/crates/lgn-browser/frontend/src/components/TopBar.svelte
@@ -50,12 +50,12 @@
   function onMenuMouseEnter(id: TopBarMenuId) {
     // We set the topBarMenu value (and therefore open said menu dropdown)
     // only when a menu is open
-    $topBarMenu && topBarMenu.set(id);
+    $topBarMenu && ($topBarMenu = id);
   }
 
   function onMenuClick(id: TopBarMenuId) {
     // Simple menu dropdown display toggle
-    $topBarMenu ? topBarMenu.close() : topBarMenu.set(id);
+    $topBarMenu ? topBarMenu.close() : ($topBarMenu = id);
   }
 
   function onMenuItemClick(title: string) {

--- a/crates/lgn-browser/frontend/src/lib/store.ts
+++ b/crates/lgn-browser/frontend/src/lib/store.ts
@@ -1,0 +1,107 @@
+import { noop, safe_not_equal as safeNotEqual } from "svelte/internal";
+import {
+  StartStopNotifier,
+  Subscriber,
+  Unsubscriber,
+  Updater,
+} from "svelte/store";
+
+/** A store orchestrator is an object that contains and orchestrate/manipulate store(s) but is not a store itself */
+export interface Orchestrator {
+  name: string;
+}
+
+type Invalidator<T> = (value?: T) => void;
+
+type SubscribeInvalidate<T> = {
+  subscribe: Subscriber<T>;
+  invalidate: Invalidator<T>;
+};
+
+export class Readable<T> {
+  protected subscriberQueue: {
+    subscribeInvalidate: SubscribeInvalidate<T>;
+    value: T;
+  }[] = [];
+  protected start: StartStopNotifier<T> = noop;
+  protected stop: Unsubscriber | null = null;
+  protected subscribers: Set<SubscribeInvalidate<T>> = new Set();
+
+  value: T;
+
+  constructor(value: T, start: StartStopNotifier<T> = noop) {
+    this.value = value;
+    this.start = start;
+  }
+
+  subscribe(run: Subscriber<T>, invalidate: Invalidator<T> = noop) {
+    const subscriber: SubscribeInvalidate<T> = { subscribe: run, invalidate };
+
+    this.subscribers.add(subscriber);
+
+    if (this.subscribers.size === 1) {
+      this.stop = this.start.call(this, this.set.bind(this)) || noop;
+    }
+
+    run(this.value);
+
+    return () => {
+      this.subscribers.delete(subscriber);
+
+      if (this.subscribers.size === 0 && this.stop) {
+        this.stop();
+        this.stop = null;
+      }
+    };
+  }
+
+  protected set(newValue: T): void {
+    if (!safeNotEqual(this.value, newValue)) {
+      return;
+    }
+
+    this.value = newValue;
+
+    if (this.stop) {
+      const runQueue = !this.subscriberQueue.length;
+
+      for (const subscriber of this.subscribers) {
+        subscriber.invalidate();
+
+        this.subscriberQueue.push({
+          subscribeInvalidate: subscriber,
+          value: this.value,
+        });
+      }
+
+      if (runQueue) {
+        for (const {
+          subscribeInvalidate: { subscribe },
+          value,
+        } of this.subscriberQueue) {
+          subscribe(value);
+        }
+
+        this.subscriberQueue.length = 0;
+      }
+    }
+  }
+
+  protected update(fn: Updater<T>): void {
+    this.set(fn(this.value));
+  }
+}
+
+export class Writable<T> extends Readable<T> {
+  constructor(value: T, start: StartStopNotifier<T> = noop) {
+    super(value, start);
+  }
+
+  override set(newValue: T): void {
+    super.set(newValue);
+  }
+
+  override update(fn: Updater<T>): void {
+    super.update(fn);
+  }
+}

--- a/crates/lgn-browser/frontend/src/stores/contextMenu.ts
+++ b/crates/lgn-browser/frontend/src/stores/contextMenu.ts
@@ -1,32 +1,17 @@
-import { Writable, writable } from "svelte/store";
+import { Writable } from "../lib/store";
 import { Entry } from "../types/contextMenu";
 
-export type Store<EntryRecord extends Record<string, unknown>> = {
-  [Name in keyof EntryRecord]: {
-    subscribe: Writable<Partial<Record<Name, Entry[]>>>["subscribe"];
-    register<Name extends keyof EntryRecord>(
-      name: Name,
-      entries: Entry[]
-    ): void;
-  };
-}[keyof EntryRecord];
-
-export default function buildContextMenuStore<
+export default class Store<
   EntryRecord extends Record<string, unknown>
->(): Store<EntryRecord> {
-  const { update, subscribe } = writable({});
+> extends Writable<EntryRecord> {
+  constructor() {
+    super({} as EntryRecord);
+  }
 
-  return {
-    subscribe,
-    /**
-     * Register the context menu entries that can be used later on
-     * by any dom element using the `contextMenu` action.
-     */
-    register(name, entries) {
-      update((entrySets) => ({
-        ...entrySets,
-        [name]: entries,
-      }));
-    },
-  };
+  register<Name extends keyof EntryRecord>(name: Name, entries: Entry[]): void {
+    this.update((entrySets) => ({
+      ...entrySets,
+      [name]: entries,
+    }));
+  }
 }

--- a/crates/lgn-browser/frontend/src/stores/statusBarData.ts
+++ b/crates/lgn-browser/frontend/src/stores/statusBarData.ts
@@ -1,3 +1,3 @@
-import { writable, Writable } from "svelte/store";
+import { Writable } from "../lib/store";
 
-export const statusStore: Writable<string | null> = writable(null);
+export const statusStore = new Writable<string | null>(null);

--- a/crates/lgn-browser/frontend/src/stores/topBarMenu.ts
+++ b/crates/lgn-browser/frontend/src/stores/topBarMenu.ts
@@ -1,4 +1,4 @@
-import { writable } from "svelte/store";
+import { Writable } from "../lib/store";
 
 export const menus = [
   { id: 1, title: "File" },
@@ -13,14 +13,18 @@ export const menus = [
 // as the menu might become dynamic at one point
 export type Id = typeof menus[number]["id"];
 
-const openedMenuStore = writable<Id | null>(null);
+class Store extends Writable<Id | null> {
+  constructor() {
+    super(null);
+  }
 
-export default {
-  subscribe: openedMenuStore.subscribe,
   close() {
-    openedMenuStore.set(null);
-  },
-  set(id: Id) {
-    openedMenuStore.set(id);
-  },
-};
+    super.set(null);
+  }
+
+  override set(id: Id) {
+    super.set(id);
+  }
+}
+
+export default new Store();

--- a/crates/lgn-browser/frontend/src/stores/userInfo.ts
+++ b/crates/lgn-browser/frontend/src/stores/userInfo.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api";
 import { UserInfo } from "../lib/auth";
 import { createAwsCognito } from "../lib/auth/browser";
 import { getCookie } from "../lib/cookie";
-import asyncStore from "./asyncStore";
+import { AsyncStoreOrchestrator } from "./asyncStore";
 
 export async function getUserInfo() {
   const awsCognitoAuthenticator = createAwsCognito();
@@ -18,4 +18,4 @@ export async function getUserInfo() {
   return awsCognitoAuthenticator.getUserInfo(accessToken);
 }
 
-export default asyncStore<UserInfo>();
+export default new AsyncStoreOrchestrator<UserInfo>();

--- a/crates/lgn-editor-gui/frontend/src/pages/Home.svelte
+++ b/crates/lgn-editor-gui/frontend/src/pages/Home.svelte
@@ -14,7 +14,7 @@
   import HierarchyTree from "@/components/hierarchyTree/HierarchyTree.svelte";
   import log from "@lgn/frontend/src/lib/log";
   import { Entries } from "@/lib/hierarchyTree";
-  import asyncStore from "@lgn/frontend/src/stores/asyncStore";
+  import { AsyncStoreOrchestratorList } from "@lgn/frontend/src/stores/asyncStore";
   import contextMenu from "@/actions/contextMenu";
   import contextMenuStore, {
     ContextMenuEntryRecord,
@@ -30,7 +30,9 @@
 
   const { data: currentResourceData } = currentResource;
 
-  const allResourcesStore = asyncStore<ResourceDescription[]>();
+  const allResourcesStore = new AsyncStoreOrchestratorList<
+    ResourceDescription[]
+  >();
 
   let allResourcesData = allResourcesStore.data;
 

--- a/crates/lgn-editor-gui/frontend/src/stores/contextMenu.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/contextMenu.ts
@@ -1,8 +1,8 @@
-import buildContextMenuStore from "@lgn/frontend/src/stores/contextMenu";
+import ContextMenyStore from "@lgn/frontend/src/stores/contextMenu";
 import { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
 
 export type ContextMenuEntryRecord = {
   resource: { item: ResourceDescription | null; name: string };
 };
 
-export default buildContextMenuStore<ContextMenuEntryRecord>();
+export default new ContextMenyStore<ContextMenuEntryRecord>();

--- a/crates/lgn-editor-gui/frontend/src/stores/currentResource.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/currentResource.ts
@@ -1,4 +1,4 @@
 import { ResourceWithProperties } from "@/lib/propertyGrid";
-import asyncStore from "@lgn/frontend/src/stores/asyncStore";
+import { AsyncStoreOrchestrator } from "@lgn/frontend/src/stores/asyncStore";
 
-export default asyncStore<ResourceWithProperties>();
+export default new AsyncStoreOrchestrator<ResourceWithProperties>();


### PR DESCRIPTION
## Description

Since we started using Svelte (and its stores) I tried to enumerate some of the use cases where the default implementation falls short. I could see around 5 use cases so far (2 of them are very well explained here: https://github.com/sveltejs/svelte/issues/7193):

- *`get` a value from a store*: by default a Readable store exposes a `subscribe` function only, additionally, a Writable store will expose both a `set` and an `update` method. This is not optimal when you need to "orchestrate" (more on this below) more than 1 store and when their value depends on each other's (making the `derived` function useless). In that case you might have to `get` the value that's inside a store, and actually you _can_ using the `get` function exported by `svelte/store` but it comes with a price at runtime since it basically creates a subscriber function, subscribe to the store, get the value, and returns it. In a class based implementation `value` can be a property, which solves the above issue entirely (at least as of today).
- *Custom `set` method*: with the current implementation, creating a store with a custom `set` function works very well... until you call the `update` function. Indeed, the `update` function will always call the _default_ `set` function, not the custom one. It's trivial to fix this with a class and using inheritance.
- *Deeply nested value in an object store*: it's pretty common to have an object, and sometimes a complex one, in a store. The main issue is that, since Svelte's reactivity relies on assignments, you must write something like: `myStore.prop1[index].prop2 = newValue`, or `myStore = newStore`. Technically the 2 approaches are equivalent (the store is updated, and all the reactive statements are activated), but it can be complex (and not efficient) to "recreate" a `newStore` value, and when the update is dynamic the path can be known at runtime but not a compile time (making the `myStore.prop1[index].prop2` syntax unusable). A library solves this elegantly: https://github.com/bryanmylee/svelte-keyed, but I think this is just an edge case to a more general issue:
- *Lack of _writable_ derived stores*: you can make a writable store, a derived store... But you can't (out of the box) make a `derived writable` store. A library (https://github.com/PixievoltNo1/svelte-writable-derived) solves this issue and could also solve the issue above (as we basically just want to have a deeply nested value of an object store as a writable derived store). Also, and as you can notice, the implementation relies on `get` (which makes sense) and could be improved thanks to the class based store (as noted above)
- *Store "extensions"*: I also found the `const { subscribe } = writable(...); return { subscribe, myMethod: ... };` pattern a bit clunky (and rather confusing at times, especially when you need to manage more than one store). I know it's basically the good old "composition vs inheritance" but in that exact case I found inheritance to somewhat easier to reason about. Notice that's probably related to the lack of proper typing for Stores in Svelte, so it's not an actual issue. N.B.: I just realized the svelte derived store exports a function that does pretty much the same thing as svelte-keyed: https://github.com/PixievoltNo1/svelte-writable-derived#named-export-propertystore

Additionally to the above issues (and potential solutions) we have 1 more use case: what I call a store(s) "orchestrator" where the object is not a store, but can contain 1 to n stores. A good example of this is the `AsyncStoreOrchestrator` that provides several methods to deal with the inner stores but is _not_ a store itself. So far this concept is very much abstract and I only added an `Orchestrator` interface for the sake of consistency and naming conventions.

## Proposed solution

In short: a full rewrite of the Svelte store implementation, but as a class. This is basically what this pull request does. If that works and is ok with everyone we can go one step further and implement the following methods:
- `derived`: that basically re-implements Svelte's `derived` function
- `derivedWritable`: an adaptation of the code provided here https://github.com/PixievoltNo1/svelte-writable-derived/blob/master/index.mjs (License MIT)
- `derivedKeyed`: based on the above, but accepting a string of format `prop1.0.prop2` that would basically achieve the same thing as `svelte-keyed` (no adaptation of the original code base)

## Drawbacks

- We rewrite the whole code, so we have to maintain it, and any bugfix/improvement have to be added in our code base (this is mitigated by the fact the code hasn't changed the last 6 months: https://github.com/sveltejs/svelte/blob/master/src/runtime/store/index.ts) 
- License issues? The 2 libraries (Svelte and Svelte writable derived) are MIT so it should probably be ok
- Opens the door to potential bugs, so far all the existing stores work well, but who knows?
- Since the stores are class based, this pattern doesn't work as expected: `const { subscribe } = writable(0);`, but it's replaced by class inheritance which in that case looks cleaner to me, and should be easier to maintain (even though I'm not a big fan of classes in general)

What do you think @TimNitsas @jelmansouri ?