### PR TITLE
monorepo: select package based on example binary

### DIFF
--- a/build/monorepo/src/build.rs
+++ b/build/monorepo/src/build.rs
@@ -50,9 +50,10 @@ pub fn run(mut args: Args, ctx: &Context) -> Result<()> {
         .push(env!("CARGO_PKG_NAME").into());
 
     let mut packages = args.package_args.to_selected_packages(ctx)?;
-    let bin = args.build_args.bin.first();
-    if let Some(bin) = bin {
+    if let Some(bin) = args.build_args.bin.first() {
         packages.select_package_from_bin(bin.as_str(), ctx)?;
+    } else if let Some(example) = args.build_args.example.first() {
+        packages.select_package_from_example(example.as_str(), ctx)?;
     }
     cmd.run_on_packages(ctx, &packages)
 }

--- a/build/monorepo/src/run.rs
+++ b/build/monorepo/src/run.rs
@@ -45,22 +45,24 @@ pub fn run(args: &Args, ctx: &Context) -> Result<()> {
     );
     if let Some(bin) = bin {
         packages.select_package_from_bin(bin.as_str(), ctx)?;
+    } else if let Some(example) = args.build_args.example.first() {
+        packages.select_package_from_example(example.as_str(), ctx)?;
     }
-    trace_name = format!(
-        "trace-{}-{}-{}.json",
-        trace_name,
-        std::time::SystemTime::UNIX_EPOCH
-            .elapsed()
-            .unwrap()
-            .as_secs(),
-        if args.build_args.release {
-            "release"
-        } else {
-            "debug"
-        }
-    )
-    .replace(":", "-"); // Windows doesn't like colons in the filename
     let env = if let Some(trace_file) = &args.ctrace {
+        trace_name = format!(
+            "trace-{}-{}-{}.json",
+            trace_name,
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_secs(),
+            if args.build_args.release {
+                "release"
+            } else {
+                "debug"
+            }
+        )
+        .replace(":", "-"); // Windows doesn't like colons in the filename
         vec![(
             "LGN_TRACE_FILE",
             Some(


### PR DESCRIPTION
Fix running example binaries.
For example:
cargo mrun --example change_detection
(in package lgn_ecs)