### PR TITLE
Editor client: Save new resource name and delete for good in the API

### DIFF
--- a/crates/lgn-editor-gui/frontend/benchmarks/lib/hierarchyTree.bench.ts
+++ b/crates/lgn-editor-gui/frontend/benchmarks/lib/hierarchyTree.bench.ts
@@ -3,15 +3,19 @@ import { suite } from "../benchmark";
 import { Entries } from "@/lib/hierarchyTree";
 import resources from "../resources/resourcesResponse.json";
 
-export const resourcesSuite = suite("Entries.unflatten", (bench) => {
-  bench.add("Unflatten entries", { iter: 10_000 }, () => {
-    return () => {
-      Entries.unflatten(resources, Symbol);
-    };
-  });
+export const resourcesSuite = suite("Entries.fromArray", (bench) => {
+  bench.add(
+    "Transforms resources into hierarchy tree entries",
+    { iter: 10_000 },
+    () => {
+      return () => {
+        Entries.fromArray(resources, Symbol);
+      };
+    }
+  );
 
   bench.add("Compute size of entries", { iter: 10_000 }, () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     return () => {
       entries.size;
@@ -19,7 +23,7 @@ export const resourcesSuite = suite("Entries.unflatten", (bench) => {
   });
 
   bench.add("Find early entry in entries", { iter: 10_000 }, () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     return () => {
       entries.find((entry) => entry.name === "DebugCube1");
@@ -27,7 +31,7 @@ export const resourcesSuite = suite("Entries.unflatten", (bench) => {
   });
 
   bench.add("Find late entry in entries", { iter: 10_000 }, () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     return () => {
       entries.find((entry) => entry.name === "ground.mat");
@@ -35,7 +39,7 @@ export const resourcesSuite = suite("Entries.unflatten", (bench) => {
   });
 
   bench.add("Update early entry in entries", { iter: 10_000 }, () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     return () => {
       entries.update((entry) =>
@@ -45,7 +49,7 @@ export const resourcesSuite = suite("Entries.unflatten", (bench) => {
   });
 
   bench.add("Update late entry in entries", { iter: 10_000 }, () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     return () => {
       entries.update((entry) =>
@@ -55,7 +59,7 @@ export const resourcesSuite = suite("Entries.unflatten", (bench) => {
   });
 
   bench.add("Remove early entry from entries", { iter: 10_000 }, () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     return () => {
       entries.remove(entries.entries[2]);
@@ -63,7 +67,7 @@ export const resourcesSuite = suite("Entries.unflatten", (bench) => {
   });
 
   bench.add("Remove late entry from entries", { iter: 10_000 }, () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     return () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -73,7 +77,7 @@ export const resourcesSuite = suite("Entries.unflatten", (bench) => {
 });
 
 export const bigResourcesSuite = suite(
-  "Entries.unflatten - big resources",
+  "Entries.fromArray - big resources",
   (bench) => {
     const bigResources: { path: string; id: string; version: number }[] = [];
 
@@ -85,14 +89,18 @@ export const bigResourcesSuite = suite(
       });
     }
 
-    bench.add("Unflatten entries - big resources", { iter: 100 }, () => {
-      return () => {
-        Entries.unflatten(bigResources, Symbol);
-      };
-    });
+    bench.add(
+      "Transforms resources into hierarchy tree entries - big resources",
+      { iter: 100 },
+      () => {
+        return () => {
+          Entries.fromArray(bigResources, Symbol);
+        };
+      }
+    );
 
     bench.add("Compute size of entries - big resources", { iter: 100 }, () => {
-      const entries = Entries.unflatten(bigResources, Symbol);
+      const entries = Entries.fromArray(bigResources, Symbol);
 
       return () => {
         entries.size;
@@ -103,7 +111,7 @@ export const bigResourcesSuite = suite(
       "Find early entry in entries - big resources",
       { iter: 100 },
       () => {
-        const entries = Entries.unflatten(bigResources, Symbol);
+        const entries = Entries.fromArray(bigResources, Symbol);
 
         return () => {
           entries.find((entry) => entry.name === "DebugCube1");
@@ -115,7 +123,7 @@ export const bigResourcesSuite = suite(
       "Find late entry in entries - big resources",
       { iter: 100 },
       () => {
-        const entries = Entries.unflatten(bigResources, Symbol);
+        const entries = Entries.fromArray(bigResources, Symbol);
 
         return () => {
           entries.find((entry) => entry.name === "ground.mat");
@@ -127,7 +135,7 @@ export const bigResourcesSuite = suite(
       "Update early entry in entries - big resources",
       { iter: 100 },
       () => {
-        const entries = Entries.unflatten(bigResources, Symbol);
+        const entries = Entries.fromArray(bigResources, Symbol);
 
         return () => {
           entries.update((entry) =>
@@ -143,7 +151,7 @@ export const bigResourcesSuite = suite(
       "Update late entry in entries - big resources",
       { iter: 100 },
       () => {
-        const entries = Entries.unflatten(bigResources, Symbol);
+        const entries = Entries.fromArray(bigResources, Symbol);
 
         return () => {
           entries.update((entry) =>
@@ -159,7 +167,7 @@ export const bigResourcesSuite = suite(
       "Remove early entry from entries - big resources",
       { iter: 100 },
       () => {
-        const entries = Entries.unflatten(bigResources, Symbol);
+        const entries = Entries.fromArray(bigResources, Symbol);
 
         return () => {
           entries.remove(entries.entries[2]);
@@ -171,7 +179,7 @@ export const bigResourcesSuite = suite(
       "Remove late entry from entries - big resources",
       { iter: 100 },
       () => {
-        const entries = Entries.unflatten(bigResources, Symbol);
+        const entries = Entries.fromArray(bigResources, Symbol);
 
         return () => {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/crates/lgn-editor-gui/frontend/src/api/index.ts
+++ b/crates/lgn-editor-gui/frontend/src/api/index.ts
@@ -157,6 +157,23 @@ export async function createResource({
   });
 }
 
+export async function renameResource({
+  id,
+  newPath,
+}: {
+  id: string;
+  newPath: string;
+}) {
+  return resourceBrowserClient.renameResource({
+    id,
+    newPath,
+  });
+}
+
+export async function removeResource({ id }: { id: string }) {
+  return resourceBrowserClient.deleteResource({ id });
+}
+
 /**
  * Used for logging purpose
  * @param jsonCommand

--- a/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/Inner.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/Inner.svelte
@@ -14,7 +14,7 @@
 
   const dispatch = createEventDispatcher<{
     highlight: Entry<Item>;
-    nameChange: { entry: Entry<Item>; newName: string };
+    nameEdited: { entry: Entry<Item>; newName: string };
   }>();
 
   // TODO: Temporary extension to icon name map, should be dynamic
@@ -50,11 +50,11 @@
     currentlyRenameEntry = null;
 
     if (nameValue.trim().length) {
-      dispatch("nameChange", { entry, newName: nameValue.trim() });
+      dispatch("nameEdited", { entry, newName: nameValue.trim() });
     }
   }
 
-  function cancelEdition() {
+  function cancelNameEdit() {
     mode = "view";
   }
 
@@ -80,7 +80,7 @@
   $: nameValue = mode === "edit" ? entryName() : "";
 
   $: if (!isHighlighted) {
-    cancelEdition();
+    cancelNameEdit();
   }
 </script>
 
@@ -107,7 +107,7 @@
       {:else}
         <form
           on:submit={renameFile}
-          on:keydown={(event) => event.key === "Escape" && cancelEdition()}
+          on:keydown={(event) => event.key === "Escape" && cancelNameEdit()}
         >
           <TextInput autoFocus autoSelect size="sm" bind:value={nameValue} />
         </form>
@@ -123,7 +123,7 @@
           {highlightedEntry}
           bind:currentlyRenameEntry
           on:highlight
-          on:nameChange
+          on:nameEdited
           let:itemName
         >
           <slot name="name" slot="name" {itemName} />

--- a/crates/lgn-editor-gui/frontend/src/components/resources/CreateResourceModal.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/resources/CreateResourceModal.svelte
@@ -50,7 +50,7 @@
       }
 
       // TODO: As soon as the folder-ish resources are supported, uncomment
-      // const path = join(payload.path, $name.value);
+      // const path = join([payload.path, $name.value]);
       const resourcePath = $name.value;
 
       const resourceType = $type.value.item;

--- a/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
@@ -24,7 +24,7 @@ export class Entries<Item> {
    * ## Example
    *
    * ```typescript
-   * const entries = Entries.unflatten([
+   * const entries = Entries.fromArray([
    *   { path: "/foo/bar", value: "hello" },
    *   { path: "/foo/baz", value: "another hello" },
    *   { path: "/foo", value: "another value" },
@@ -39,7 +39,7 @@ export class Entries<Item> {
    * assert(deepEqual(entries.entries, expectedEntries));
    * ```
    */
-  static unflatten<Item extends { path: string }, AltItem>(
+  static fromArray<Item extends { path: string }, AltItem>(
     items: Item[],
     /** This function is called when an `Item` is not present, typically used for "folders" */
     buildItemFromName: (name: string) => Item | AltItem
@@ -113,8 +113,6 @@ export class Entries<Item> {
 
     entries.#sort();
 
-    entries.#setIndices();
-
     return entries;
   }
 
@@ -161,6 +159,8 @@ export class Entries<Item> {
     }
 
     sort(this.entries);
+
+    this.#setIndices();
   }
 
   /**
@@ -256,6 +256,8 @@ export class Entries<Item> {
     }
 
     this.entries = update(this.entries);
+
+    this.#sort();
 
     return this;
   }

--- a/crates/lgn-editor-gui/frontend/src/lib/path.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/path.ts
@@ -62,20 +62,16 @@ export function extension(path: Path): string | null {
 
 /**
  * Joins path parts using the detected main separator.
+ *
  * A custom main separator can be provided if needed.
  *
- * If no custom separators are provided, and the main separator
- * cannot be detected, `"/"` is used by default.
+ * If no custom separators are provided `"/"` is used by default.
  */
-export function join(
-  root: Path,
-  part: string | Path,
-  separator = detectMainPathSeparator(root) || "/"
-): Path {
-  return `${root}${separator}${part}`;
+export function join(parts: string[], separator = "/"): Path {
+  return parts.join(separator);
 }
 
-/** Joins the path compenents into a `Path` using the provided main separator */
+/** Joins the path components into a `Path` using the provided main separator */
 export function absolute(
   components: string[],
   mainSeparator: MainSeparator

--- a/crates/lgn-editor-gui/frontend/src/pages/Home.svelte
+++ b/crates/lgn-editor-gui/frontend/src/pages/Home.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
   import { Panel, PanelList } from "@lgn/web-client/src/components/panel";
   import ContextMenu from "@lgn/web-client/src/components/ContextMenu.svelte";
+  import Notifications from "@lgn/web-client/src/components/Notifications.svelte";
   import ViewportPanel from "@lgn/web-client/src/components/panel/ViewportPanel.svelte";
   import ModalContainer from "@lgn/web-client/src/components/modal/ModalContainer.svelte";
   import TopBar from "@lgn/web-client/src/components/TopBar.svelte";
   import StatusBar from "@lgn/web-client/src/components/StatusBar.svelte";
-  import { getAllResources, getResourceProperties } from "@/api";
+  import {
+    getAllResources,
+    getResourceProperties,
+    removeResource,
+    renameResource,
+  } from "@/api";
   import PropertyGrid from "@/components/propertyGrid/PropertyGrid.svelte";
-  import currentResource from "@/stores/currentResource";
+  import currentResourceStore from "@/stores/currentResource";
+  import HierarchyTreeOrchestrator from "@/stores/hierarchyTree";
   import { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
   import HierarchyTree from "@/components/hierarchyTree/HierarchyTree.svelte";
   import log from "@lgn/web-client/src/lib/log";
-  import { Entries } from "@/lib/hierarchyTree";
+  import { Entry } from "@/lib/hierarchyTree";
   import contextMenu from "@/actions/contextMenu";
   import contextMenuStore, {
     ContextMenuEntryRecord,
@@ -27,6 +34,8 @@
   import { SvelteComponent } from "svelte";
   import allResourcesStore from "@/stores/allResources";
   import viewportOrchestrator from "@/stores/viewport";
+  import notificationsStore from "@/stores/notifications";
+  import { components, join } from "@/lib/path";
 
   contextMenuStore.register("resource", contextMenuEntries);
 
@@ -39,13 +48,19 @@
 
   viewportOrchestrator.activate(editorViewportKey);
 
-  const { activeViewportStore, viewportStore } = viewportOrchestrator;
-
   const modalStore = new ModalStore();
 
-  const { data: currentResourceData } = currentResource;
+  const { data: currentResourceData } = currentResourceStore;
 
   const createResourceModalId = Symbol();
+
+  const resourceEntriesOrchestrator =
+    new HierarchyTreeOrchestrator<ResourceDescription>();
+
+  const {
+    entries: resourceEntriesStore,
+    currentlyRenameEntry: currentlyRenameResourceStore,
+  } = resourceEntriesOrchestrator;
 
   let allResourcesData = allResourcesStore.data;
 
@@ -55,13 +70,18 @@
 
   let resourceHierarchyTree: HierarchyTree<ResourceDescription> | null = null;
 
+  $: if ($allResourcesData) {
+    console.log("loading");
+    resourceEntriesOrchestrator.load($allResourcesData);
+  }
+
   function fetchCurrentResourceDescription() {
     if (!currentResourceDescription) {
       return;
     }
 
     try {
-      currentResource.run(() => {
+      currentResourceStore.run(() => {
         if (!currentResourceDescription) {
           throw new Error("Current resource description not found");
         }
@@ -69,8 +89,69 @@
         return getResourceProperties(currentResourceDescription);
       });
     } catch (error) {
+      notificationsStore.push(Symbol(), {
+        type: "error",
+        title: "Resources",
+        message: "An error occured while loading the resource",
+      });
+
       log.error(
         log.json`An error occured while loading the resource ${currentResourceDescription}: ${error}`
+      );
+    }
+  }
+
+  async function saveEditedResourceProperty({
+    detail: { entry, newName },
+  }: CustomEvent<{
+    entry: Entry<ResourceDescription | symbol>;
+    newName: string;
+  }>) {
+    if (typeof entry.item === "symbol") {
+      return;
+    }
+
+    const pathComponents = components(entry.item.path);
+
+    if (!pathComponents) {
+      return;
+    }
+
+    const newPath = join([...pathComponents.slice(0, -1), newName]);
+
+    try {
+      await renameResource({ id: entry.item.id, newPath });
+    } catch (error) {
+      notificationsStore.push(Symbol(), {
+        type: "error",
+        title: "Resources",
+        message: "An error occured while renaming the resource",
+      });
+
+      log.error(
+        log.json`An error occured while renaming the resource ${entry.item}: ${error}`
+      );
+    }
+  }
+
+  async function removeResourceProperty({
+    detail: entry,
+  }: CustomEvent<Entry<ResourceDescription | symbol>>) {
+    if (typeof entry.item === "symbol") {
+      return;
+    }
+
+    try {
+      await removeResource({ id: entry.item.id });
+    } catch (error) {
+      notificationsStore.push(Symbol(), {
+        type: "error",
+        title: "Resources",
+        message: "An error occured while removing the resource",
+      });
+
+      log.error(
+        log.json`An error occured while removing the resource ${entry.item}: ${error}`
       );
     }
   }
@@ -81,7 +162,7 @@
     allResourcesPromise = allResourcesStore.run(getAllResources);
   }
 
-  function handleResourceRename({
+  async function handleResourceRename({
     detail: { action },
   }: ContextMenuActionEvent<Pick<ContextMenuEntryRecord, "resource">>) {
     if (!currentResourceDescription) {
@@ -94,7 +175,7 @@
           return;
         }
 
-        resourceHierarchyTree.edit(currentResourceDescription);
+        resourceHierarchyTree.startNameEdit(currentResourceDescription);
 
         return;
       }
@@ -110,9 +191,9 @@
       }
 
       case "new": {
-        // TODO: Fix the typings
         modalStore.open(
           createResourceModalId,
+          // TODO: Fix the typings
           CreateResourceModal as unknown as SvelteComponent,
           currentResourceDescription
         );
@@ -128,6 +209,8 @@
 <ModalContainer store={modalStore} />
 
 <ContextMenu store={contextMenuStore} />
+
+<Notifications store={notificationsStore} />
 
 <svelte:window
   on:contextmenu-action={autoClose(select(handleResourceRename, "resource"))}
@@ -173,9 +256,14 @@
             <div slot="tab" let:tab>{tab}</div>
             <div slot="content" class="resource-browser-content">
               {#if $allResourcesData}
+                <!-- Works as expected, the type error seems to be related to Svelte
+                     https://github.com/sveltejs/svelte/issues/7225 -->
                 <HierarchyTree
-                  entries={Entries.unflatten($allResourcesData, Symbol)}
                   on:select={fetchCurrentResourceDescription}
+                  on:nameEdited={saveEditedResourceProperty}
+                  on:removed={removeResourceProperty}
+                  bind:entries={$resourceEntriesStore}
+                  bind:currentlyRenameEntry={$currentlyRenameResourceStore}
                   bind:highlightedItem={currentResourceDescription}
                   bind:this={resourceHierarchyTree}
                 >

--- a/crates/lgn-editor-gui/frontend/src/stores/hierarchyTree.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/hierarchyTree.ts
@@ -1,0 +1,29 @@
+/**
+ * A store orchestrator that contains all the currently displayed items
+ * (as a record of hierarchy tree Entries), the entry that's currently being renamed, etc...
+ *
+ * It could also contain an array of id pointing to the currently expanded entries in the tree.
+ */
+
+import { Entries, Entry } from "@/lib/hierarchyTree";
+import { Orchestrator, Writable } from "@lgn/web-client/src/lib/store";
+
+export default class<Item extends { path: string }> implements Orchestrator {
+  name = "hierarchTree";
+
+  // `symbol` is used only for folder like resources
+  // (which will be replaced by proper resources eventually)
+
+  currentlyRenameEntry: Writable<Entry<Item | symbol> | null>;
+  entries: Writable<Entries<Item | symbol>>;
+
+  constructor(resources: Item[] = []) {
+    this.currentlyRenameEntry = new Writable<Entry<Item | symbol> | null>(null);
+
+    this.entries = new Writable(Entries.fromArray(resources, Symbol));
+  }
+
+  load(resources: Item[]) {
+    this.entries.set(Entries.fromArray(resources, Symbol));
+  }
+}

--- a/crates/lgn-editor-gui/frontend/src/stores/notifications.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/notifications.ts
@@ -1,0 +1,3 @@
+import NotificationsStore from "@lgn/web-client/src/stores/notifications";
+
+export default new NotificationsStore();

--- a/crates/lgn-editor-gui/frontend/tests/lib/hierarchyTree.test.ts
+++ b/crates/lgn-editor-gui/frontend/tests/lib/hierarchyTree.test.ts
@@ -3,13 +3,13 @@ import resources from "@/resources/resourcesResponse.json";
 
 describe("updateEntry", () => {
   it("updates no entry names when the provided function always returns null in the Entries", () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     expect(entries.update(() => null)).toEqual(entries);
   });
 
   it("updates no entry names when the provided function always return an empty string in the Entries", () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     expect(
       entries.update((entry) => ({
@@ -20,7 +20,7 @@ describe("updateEntry", () => {
   });
 
   it('updates 1 entry name "leaf" when the provided function returns a non empty string for a "leaf" entry', () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     expect(
       entries.update((entry) =>
@@ -32,7 +32,7 @@ describe("updateEntry", () => {
   });
 
   it('updates 1 entry name "node" when the provided function returns a non empty string for a "node" entry', () => {
-    const entries = Entries.unflatten(resources, Symbol);
+    const entries = Entries.fromArray(resources, Symbol);
 
     expect(
       entries.update((entry) =>
@@ -42,8 +42,8 @@ describe("updateEntry", () => {
   });
 });
 
-describe("unflatten", () => {
-  it("unflattens a `ResourceDescription` array into a hierarchical tree", () => {
-    expect(Entries.unflatten(resources, Symbol)).toMatchSnapshot();
+describe("fromArray", () => {
+  it("transforms a `ResourceDescription` array into a hierarchical tree", () => {
+    expect(Entries.fromArray(resources, Symbol)).toMatchSnapshot();
   });
 });

--- a/crates/lgn-web-client/frontend/src/components/Notifications.svelte
+++ b/crates/lgn-web-client/frontend/src/components/Notifications.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import NotificationsStore from "../stores/notifications";
+
+  export let store: NotificationsStore;
+</script>
+
+<div class="root">
+  {#each Object.getOwnPropertySymbols($store) as key}
+    {@const notification = $store[key]}
+
+    <div class="notification" on:click={() => notification.close()}>
+      <div
+        class="title"
+        class:success={notification.type === "success"}
+        class:warning={notification.type === "warning"}
+        class:error={notification.type === "error"}
+      >
+        {notification.title}
+      </div>
+      <div class="message">
+        {notification.message}
+      </div>
+      <div class="progress">
+        <div
+          class="progress-inner"
+          style="width: {notification.percentage}%;"
+        />
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style lang="postcss">
+  .root {
+    @apply absolute right-4 top-12 space-y-4 z-50;
+  }
+
+  .notification {
+    @apply w-80 bg-gray-800 shadow-lg shadow-gray-800 rounded-sm hover:bg-gray-700 cursor-pointer;
+  }
+
+  .title {
+    @apply border-b-2 px-2 py-2;
+  }
+
+  .title.success {
+    @apply border-green-800;
+  }
+
+  .title.warning {
+    @apply border-orange-800;
+  }
+
+  .title.error {
+    @apply border-red-800;
+  }
+
+  .message {
+    @apply px-2 py-2;
+  }
+
+  .progress {
+    @apply h-2 bg-gray-700 rounded-b-sm;
+  }
+
+  .progress-inner {
+    @apply h-full bg-gray-400 rounded-b-sm;
+  }
+</style>

--- a/crates/lgn-web-client/frontend/src/stores/notifications.ts
+++ b/crates/lgn-web-client/frontend/src/stores/notifications.ts
@@ -1,0 +1,88 @@
+import { Writable } from "../lib/store";
+
+export type Notification = {
+  type: "success" | "warning" | "error";
+  title: string;
+  message: string;
+  timeout?: number;
+};
+
+type Value = Notification & {
+  close(): void;
+  started: number;
+  timeout: number;
+  percentage: number;
+};
+
+const intervalMs = 16;
+
+function p(partialValue: number, totalValue: number) {
+  return (100 * partialValue) / totalValue;
+}
+
+export default class extends Writable<Record<symbol, Value>> {
+  #timeout: number;
+
+  constructor(timeout = 5_000) {
+    super({});
+
+    this.#timeout = timeout;
+  }
+
+  push(key: symbol, value: Notification) {
+    this.update((notifications) => {
+      if (key in notifications) {
+        return notifications;
+      }
+
+      const timeout =
+        typeof value.timeout === "number" ? value.timeout : this.#timeout;
+
+      const update = this.update.bind(this);
+
+      const intervalId = setInterval(() => {
+        this.update((notifications) => {
+          const notification = notifications[key];
+
+          const percentage =
+            100 - p(Date.now() - notification.started, timeout);
+
+          return {
+            ...notifications,
+            [key]: { ...notification, percentage },
+          };
+        });
+      }, intervalMs);
+
+      const timeoutId = setTimeout(() => {
+        this.update((notifications) => {
+          clearInterval(intervalId);
+
+          const { [key]: _, ...restNotifications } = notifications;
+
+          return restNotifications;
+        });
+      }, timeout);
+
+      return {
+        ...notifications,
+        [key]: {
+          ...value,
+          started: Date.now(),
+          timeout,
+          percentage: 100,
+          close() {
+            clearTimeout(timeoutId);
+            clearInterval(intervalId);
+
+            update((notifications) => {
+              const { [key]: _, ...restNotifications } = notifications;
+
+              return restNotifications;
+            });
+          },
+        },
+      };
+    });
+  }
+}

--- a/npm-pkgs/vite-plugin-ts-proto/index.ts
+++ b/npm-pkgs/vite-plugin-ts-proto/index.ts
@@ -7,7 +7,7 @@ import os from "os";
 import { existsSync } from "fs";
 
 /**
- * Recursively searchs the ts-proto binary path from a base directory
+ * Recursively searches the ts-proto binary path from a base directory
  */
 function resolveTsProtoPath(binName: string, baseDir: string) {
   function search(pathParts: string[]): string | null {


### PR DESCRIPTION
Comes with a notification system

I faced a type inference bug with Svelte/TS: sveltejs/language-tools#1371, but it's not blocking