### PR TITLE
Analytics: Hack to force github pages to support the SPA

### DIFF
--- a/crates/lgn-analytics-gui/frontend/404.html
+++ b/crates/lgn-analytics-gui/frontend/404.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/crates/lgn-analytics-gui/frontend/index.html
+++ b/crates/lgn-analytics-gui/frontend/index.html
@@ -9,6 +9,7 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"
     />
+    %INJECTED_SCRIPT%
   </head>
   <body>
     <div id="root"></div>

--- a/crates/lgn-analytics-gui/frontend/src/components/Header.svelte
+++ b/crates/lgn-analytics-gui/frontend/src/components/Header.svelte
@@ -2,7 +2,11 @@
   import User from "./User.svelte";
   import { authClient } from "@lgn/web-client/src/lib/auth";
   import { onMount } from "svelte";
+  import { link } from "svelte-navigator";
+  import iconPath from "../../icons/128x128.png";
+
   let user: string | undefined;
+
   onMount(async () => {
     user = (await authClient.userInfo()).name;
   });
@@ -10,15 +14,10 @@
 
 <div class="w-full flex justify-between pl-6 pt-4 pr-4">
   <div class="flex items-center gap-3">
-    <img
-      src="../icons/128x128.png"
-      alt="logo"
-      style="height:24px"
-      class="inline"
-    />
-    <span class="font-bold text-xl"
-      ><a href="/">Legion Performance Analytics</a></span
-    >
+    <img src={iconPath} alt="logo" style="height:24px" class="inline" />
+    <span class="font-bold text-xl">
+      <a href="/" use:link>Legion Performance Analytics</a>
+    </span>
   </div>
   {#if user}
     <div class="flex justify-between items-center">

--- a/crates/lgn-analytics-gui/frontend/src/components/ProcessList.svelte
+++ b/crates/lgn-analytics-gui/frontend/src/components/ProcessList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { link } from "svelte-navigator";
   import {
     PerformanceAnalyticsClientImpl,
     ProcessInstance,
@@ -78,36 +79,33 @@
             <td>
               {#if nbLogBlocks > 0 && processInfo}
                 <div>
-                  <a href={`/log/${processInfo?.processId}`}
-                    ><i
-                      title="Log ({nbLogBlocks})"
-                      class="bi bi-card-text"
-                    /></a
-                  >
+                  <a href={`/log/${processInfo?.processId}`} use:link>
+                    <i title="Log ({nbLogBlocks})" class="bi bi-card-text" />
+                  </a>
                 </div>
               {/if}
             </td>
             <td>
               {#if nbMetricBlocks > 0 && processInfo}
                 <div>
-                  <a href={`/metrics/${processInfo?.processId}`}
-                    ><i
+                  <a href={`/metrics/${processInfo?.processId}`} use:link>
+                    <i
                       title="Metrics ({nbMetricBlocks})"
                       class="bi bi-graph-up"
-                    /></a
-                  >
+                    />
+                  </a>
                 </div>
               {/if}
             </td>
             <td>
               {#if nbCpuBlocks > 0 && processInfo}
                 <div>
-                  <a href={`/timeline/${processInfo?.processId}`}
-                    ><i
+                  <a href={`/timeline/${processInfo?.processId}`} use:link>
+                    <i
                       title="Timeline ({nbCpuBlocks})"
                       class="bi bi-body-text"
-                    /></a
-                  >
+                    />
+                  </a>
                 </div>
               {/if}
             </td>

--- a/crates/lgn-analytics-gui/frontend/src/pages/Timeline.svelte
+++ b/crates/lgn-analytics-gui/frontend/src/pages/Timeline.svelte
@@ -1,4 +1,7 @@
 <script context="module" lang="ts">
+  import { SpanTrack } from "@lgn/proto-telemetry/dist/analytics";
+  import { Block } from "@lgn/proto-telemetry/dist/block";
+
   type Thread = {
     streamInfo: Stream;
     maxDepth: number;
@@ -25,15 +28,12 @@
     Loaded,
   }
 
-  import { SpanTrack } from "@lgn/proto-telemetry/dist/analytics";
-
   type ThreadBlockLOD = {
     state: LODState;
     tracks: SpanTrack[];
     lodId: number;
   };
 
-  import { Block } from "@lgn/proto-telemetry/dist/block";
   type ThreadBlock = {
     blockDefinition: Block; // block metadata stored in data lake
     beginMs: number; // relative to main process

--- a/crates/lgn-analytics-gui/frontend/vite.config.js
+++ b/crates/lgn-analytics-gui/frontend/vite.config.js
@@ -4,9 +4,71 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import viteTsProto from "@lgn/vite-plugin-ts-proto";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const githubSpaHack = `
+<!-- Start Single Page Apps for GitHub Pages -->
+<script type="text/javascript">
+  // Single Page Apps for GitHub Pages
+  // MIT License
+  // https://github.com/rafgraph/spa-github-pages
+  // This script checks to see if a redirect is present in the query string,
+  // converts it back into the correct url and adds it to the
+  // browser's history using window.history.replaceState(...),
+  // which won't cause the browser to attempt to load the new url.
+  // When the single page app is loaded further down in this file,
+  // the correct url will be waiting in the browser's history for
+  // the single page app to route accordingly.
+  (function (l) {
+    if (l.search[1] === "/") {
+      var decoded = l.search
+        .slice(1)
+        .split("&")
+        .map(function (s) {
+          return s.replace(/~and~/g, "&");
+        })
+        .join("?");
+      window.history.replaceState(
+        null,
+        null,
+        l.pathname.slice(0, -1) + decoded + l.hash
+      );
+    }
+  })(window.location);
+</script>
+<!-- End Single Page Apps for GitHub Pages -->
+`;
+
+const shouldInjectSpaHack = process.env.GITHUB_PAGES === "true";
+
+/** @param {Record<string, string>} env */
+function htmlPlugin(env) {
+  return {
+    name: "html-transform",
+    transformIndexHtml: {
+      transform: (/** @type {string} */ html) =>
+        html.replace(/%(.*?)%/g, (match, p1) => env[p1] ?? match),
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(dirname, "index.html"),
+        ...(shouldInjectSpaHack
+          ? { notFound: path.resolve(dirname, "404.html") }
+          : {}),
+      },
+    },
+  },
   plugins: [
     tsconfigPaths({
       extensions: [".ts", ".svelte"],
@@ -15,5 +77,6 @@ export default defineConfig({
     viteTsProto({
       modules: [{ name: "@lgn/proto-telemetry", glob: "*.proto" }],
     }),
+    htmlPlugin({ INJECTED_SCRIPT: shouldInjectSpaHack ? githubSpaHack : "" }),
   ],
 });


### PR DESCRIPTION
This pr also fixes some small issues with the logo and the anchors.

`pnpm start` and `pnpm build` work just like before, you need to provide the `GITHUB_PAGES="true"` env var to make this work.