### PR TITLE
Editor srv resource copy extension

### DIFF
--- a/crates/lgn-data-offline/src/resource/path_name.rs
+++ b/crates/lgn-data-offline/src/resource/path_name.rs
@@ -1,4 +1,4 @@
-use std::{fmt, hash::Hash, str::FromStr};
+use std::{fmt, hash::Hash, ops::Add, str::FromStr};
 
 use lgn_data_runtime::ResourceTypeAndId;
 use serde::{Deserialize, Serialize};
@@ -89,6 +89,14 @@ impl ResourcePathName {
         } else if let Some(new_path) = new_path {
             *self = new_path;
         }
+    }
+}
+
+impl Add<&'_ str> for ResourcePathName {
+    type Output = Self;
+
+    fn add(self, rhs: &'_ str) -> Self::Output {
+        (self.0 + rhs).into()
     }
 }
 


### PR DESCRIPTION
When creating a resource with a name that already exists its name was "incremented", so x becomes x1 and x10 becomes x11 but the extension was ignored, so "x.psd" became "x.psd1", this pr makes "x.psd" becomes "x1.psd"