### PR TITLE
remove "vulkan" from default lgn-renderer features

### DIFF
--- a/crates/lgn-graphics-api/Cargo.toml
+++ b/crates/lgn-graphics-api/Cargo.toml
@@ -18,7 +18,6 @@ lgn-utils = { path = "../lgn-utils", version = "0.1.0" }
 
 backtrace = { version = "0.3", optional = true }
 bitflags = "1.3"
-bumpalo = "3.8"
 crossbeam-channel = "0.5"
 fnv = "1.0"
 raw-window-handle = "0.4"
@@ -28,6 +27,10 @@ strum = { version = "0.23", features = ["derive"] }
 # vulkan backend
 ash = { version = ">= 0.33", features = ["linked"], optional = true }
 vk-mem = { git = "https://github.com/legion-labs/vk-mem-rs", rev = "9b998c5a49e297c8419adc12079335b57fe3809c", optional = true }
+
+# non-vulkan backend
+[target.'cfg(not(any(target_os = "linux", target_os = "windows")))'.dependencies]
+bumpalo = "3.8"
 
 [package.metadata.docs.rs]
 features = ["serde", "vulkan"]

--- a/crates/lgn-renderer/Cargo.toml
+++ b/crates/lgn-renderer/Cargo.toml
@@ -46,5 +46,5 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 uuid = { version = "0.8", features = ["wasm-bindgen"] }
 
 [features]
-default = ["lgn-graphics-api/vulkan"]
+default = []
 vulkan = ["lgn-graphics-api/vulkan"]

--- a/crates/lgn-runtime-srv/Cargo.toml
+++ b/crates/lgn-runtime-srv/Cargo.toml
@@ -49,3 +49,8 @@ standalone = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 lgn-winit = { path = "../lgn-winit", features = ["x11"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+lgn-streamer = { path = "../lgn-streamer", version = "0.1.0", features = [
+    "vulkan",
+] }

--- a/tests/graphics-sandbox/Cargo.toml
+++ b/tests/graphics-sandbox/Cargo.toml
@@ -35,5 +35,10 @@ clap = { version = "3.0", features = ["derive"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 lgn-winit = { path = "../../crates/lgn-winit", features = ["x11"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+lgn-presenter-snapshot = { path = "../../crates/lgn-presenter-snapshot", version = "0.1.0", features = [
+    "vulkan",
+] }
+
 [dev-dependencies]
 lgn-test-utils = { path = "../../crates/lgn-test-utils" }


### PR DESCRIPTION
Fixed unused dependency check in `lgn-graphics-api` (when running cargo-udeps), due to use of `bumpalo` crate in non-vulkan builds.
* turned off default use of "vulkan" feature in `lgn-renderer`
* was already testing for os support of vulkan in editor-srv, added same checks in runtime-srv and graphics-sandbox