### PR TITLE
Implemented a basic content-store server with authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "analytics-srv"
 version = "0.1.0"
 dependencies = [
@@ -300,6 +315,20 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1040,6 +1069,27 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "monorepo-base",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -4025,6 +4075,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
+name = "iri-string"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
+dependencies = [
+ "nom 7.1.0",
+]
+
+[[package]]
 name = "ispc-tex"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4632,9 +4691,12 @@ dependencies = [
  "hyper",
  "indicatif",
  "itertools 0.10.3",
+ "lgn-cli-utils",
  "lgn-config",
  "lgn-content-store-proto",
  "lgn-online",
+ "lgn-telemetry-sink",
+ "lgn-tracing",
  "lru",
  "pin-project",
  "pretty_env_logger",
@@ -4649,7 +4711,11 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.9",
+ "toml",
  "tonic",
+ "tonic-web",
+ "tower",
+ "tower-http",
  "uuid",
 ]
 
@@ -5118,6 +5184,7 @@ dependencies = [
  "tonic-build",
  "tonic-web",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "webbrowser",
@@ -5908,6 +5975,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -9973,6 +10050,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb284cac1883d54083a0edbdc9cabf931dfed87455f8c7266c01ece6394a43a"
 dependencies = [
+ "async-compression",
+ "base64 0.13.0",
  "bitflags",
  "bytes",
  "futures-core",
@@ -9980,9 +10059,18 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "httpdate",
+ "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.0",
+ "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10154,6 +10242,15 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/lgn-content-store2/Cargo.toml
+++ b/crates/lgn-content-store2/Cargo.toml
@@ -15,10 +15,25 @@ name = "lgn-content-store-cli"
 path = "src/bin.rs"
 required-features = ["cli"]
 
+[[bin]]
+name = "lgn-content-store-srv"
+path = "src/server.rs"
+required-features = ["server"]
+
 [features]
-default = ["aws", "redis", "lru", "cli"]
+default = ["aws", "redis", "lru", "cli", "server"]
 aws = ["aws-config", "aws-sdk-s3", "aws-sdk-dynamodb"]
 cli = ["clap", "indicatif", "bytesize"]
+server = [
+    "clap",
+    "tonic-web",
+    "tower",
+    "tower-http",
+    "bytesize",
+    "lgn-cli-utils",
+    "lgn-tracing",
+    "lgn-telemetry-sink",
+]
 
 [dependencies]
 anyhow = "1.0"
@@ -40,6 +55,9 @@ itertools = "0.10"
 lgn-online = { path = "../lgn-online", version = "0.1.0" }
 lgn-config = { path = "../lgn-config", version = "0.1.0" }
 lgn-content-store-proto = { path = "../lgn-content-store-proto", version = "0.1.0" }
+lgn-tracing = { path = "../lgn-tracing", version = "0.1.0", optional = true }
+lgn-telemetry-sink = { path = "../lgn-telemetry-sink", version = "0.1.0", optional = true }
+lgn-cli-utils = { path = "../lgn-cli-utils", version = "0.1.0", optional = true }
 lru = { version = "0.7", optional = true }
 pin-project = "1"
 redis = { version = "0.21.0", features = ["tokio-comp"], optional = true }
@@ -52,6 +70,10 @@ tonic = "0.6"
 tokio = { version = "1", features = ["full", "tracing"] }
 tokio-stream = "0.1.8"
 tokio-util = { version = "0.6.9", features = ["full"] }
+toml = "0.5"
+tonic-web = { version = "0.2", optional = true }
+tower = { version = "0.4", optional = true }
+tower-http = { version = "0.2", features = ["cors"], optional = true }
 
 [dev-dependencies]
 uuid = { version = "0.8", features = ["v4"] }
@@ -61,3 +83,17 @@ hyper = "0.14"
 pretty_env_logger = "0.4"
 rand = "0.8"
 testcontainers = "0.12"
+
+[[package.metadata.monorepo.publish]]
+name = "content-store-srv"
+type = "docker"
+template = """
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates
+
+{ copy_all }
+
+ENTRYPOINT ["{ binaries.lgn-content-store-srv }"]
+"""
+allow-aws-ecr-creation = true

--- a/crates/lgn-content-store2/src/server.rs
+++ b/crates/lgn-content-store2/src/server.rs
@@ -1,0 +1,115 @@
+//! A content-store implementation that stores immutable assets in a efficient
+//! and cachable manner.
+
+use bytesize::ByteSize;
+use clap::Parser;
+use http::{header, Method};
+use lgn_cli_utils::termination_handler::AsyncTerminationHandler;
+use lgn_content_store2::{AwsDynamoDbProvider, AwsS3Provider, GrpcService};
+use lgn_content_store_proto::content_store_server::ContentStoreServer;
+use lgn_online::authentication::{jwt::RequestAuthorizer, UserInfo};
+use lgn_telemetry_sink::TelemetryGuard;
+use lgn_tracing::prelude::*;
+use std::{net::SocketAddr, time::Duration};
+use tonic::transport::Server;
+use tower_http::{
+    auth::RequireAuthorizationLayer,
+    cors::{CorsLayer, Origin},
+};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(short, long)]
+    debug: bool,
+
+    #[clap(short, long, default_value = "0.0.0.0:5000")]
+    listen_endpoint: SocketAddr,
+
+    #[clap(
+        long,
+        default_value = "",
+        help = "The list of origins that are allowed to make requests, for CORS"
+    )]
+    origins: Vec<http::HeaderValue>,
+
+    #[clap(long, default_value = "128KiB")]
+    size_treshold: ByteSize,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Args = Args::parse();
+
+    let _telemetry_guard = TelemetryGuard::default()
+        .unwrap()
+        .with_log_level(if args.debug {
+            LevelFilter::Debug
+        } else {
+            LevelFilter::Info
+        });
+
+    span_scope!("lgn-content-store-srv::main");
+
+    let cors = CorsLayer::new()
+        .allow_origin(Origin::list(args.origins))
+        .allow_credentials(true)
+        .max_age(Duration::from_secs(60 * 60))
+        .allow_headers(vec![
+            header::ACCEPT,
+            header::ACCEPT_LANGUAGE,
+            header::AUTHORIZATION,
+            header::CONTENT_LANGUAGE,
+            header::CONTENT_TYPE,
+            header::HeaderName::from_static("x-grpc-web"),
+        ])
+        .allow_methods(vec![
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::HEAD,
+            Method::OPTIONS,
+            Method::CONNECT,
+        ])
+        .expose_headers(tower_http::cors::Any {});
+
+    let signature_validation_config = lgn_online::authentication::SignatureValidationConfig::new()
+        .map_err(|err| anyhow::anyhow!("failed to load signature validation config: {}", err))?;
+
+    let validation = signature_validation_config.validation().await?;
+
+    let auth_layer =
+        RequireAuthorizationLayer::custom(RequestAuthorizer::<UserInfo, _, _>::new(validation));
+
+    let layer = tower::ServiceBuilder::new() //todo: compose with cors layer
+        .layer(auth_layer)
+        .layer(cors)
+        .into_inner();
+
+    let mut server = Server::builder().accept_http1(true).layer(layer);
+
+    // Hardcode AWS providers for now.
+    let aws_s3_url = "s3://legionlabs-content-store/".parse().unwrap();
+    let aws_s3_provider = AwsS3Provider::new(aws_s3_url).await;
+    let aws_dynamo_db_provider = AwsDynamoDbProvider::new("legionlabs-content-store").await;
+    let grpc_service = GrpcService::new(
+        aws_dynamo_db_provider,
+        aws_s3_provider,
+        args.size_treshold
+            .as_u64()
+            .try_into()
+            .expect("size_treshold is too big"),
+    );
+
+    let service = ContentStoreServer::new(grpc_service);
+    let server = server.add_service(tonic_web::enable(service));
+
+    let handler = AsyncTerminationHandler::new()?;
+
+    info!("Listening on {}", args.listen_endpoint);
+
+    tokio::select! {
+        _ = handler.wait() => Ok(()),
+        res = server.serve(args.listen_endpoint) => res.map_err(Into::into),
+    }
+}

--- a/crates/lgn-online/Cargo.toml
+++ b/crates/lgn-online/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { version = "1.13", features = ["full", "tracing"] }
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.23", features = ["http2"] }
 tower = "0.4.8"
+tower-http = { version = "0.2", features = ["full"] }
 tower-service = "0.3.1"
 tonic = { version = "0.6", features = ["tls-roots"] }
 tonic-web = "0.2"

--- a/crates/lgn-online/src/authentication/config.rs
+++ b/crates/lgn-online/src/authentication/config.rs
@@ -1,0 +1,101 @@
+use super::{
+    jwt::{
+        signature_validation::{
+            AwsCognitoSignatureValidation, BoxedSignatureValidation, NoSignatureValidation,
+            RsaSignatureValidation,
+        },
+        Validation,
+    },
+    BoxedAuthenticator, Error, OAuthClient, Result, TokenCache,
+};
+use serde::Deserialize;
+use url::Url;
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum AuthenticatorConfig {
+    #[serde(rename = "oauth")]
+    OAuth(OAuthClientConfig),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct OAuthClientConfig {
+    pub issuer_url: String,
+    pub client_id: String,
+    pub redirect_uri: Option<Url>,
+}
+
+impl AuthenticatorConfig {
+    pub fn new() -> Result<Self> {
+        lgn_config::Config::new()
+            .get("authentication.authenticator")
+            .ok_or_else(|| {
+                Error::Other(anyhow::anyhow!("failed to load authenticator config").into())
+            })
+    }
+
+    /// Instanciate an `Authenticator` from the configuration.
+    pub async fn authenticator(&self) -> anyhow::Result<BoxedAuthenticator> {
+        match self {
+            AuthenticatorConfig::OAuth(config) => Ok(BoxedAuthenticator(Box::new(
+                TokenCache::new_with_application_name(
+                    OAuthClient::new_from_config(config).await?,
+                    "lgn-online",
+                ),
+            ))),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum SignatureValidationConfig {
+    Disabled {},
+    Rsa(RsaSignatureValidationConfig),
+    AwsCognito(AwsCognitoSignatureValidationConfig),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct RsaSignatureValidationConfig {
+    n: String,
+    e: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct AwsCognitoSignatureValidationConfig {
+    region: String,
+    user_pool_id: String,
+}
+
+impl SignatureValidationConfig {
+    pub fn new() -> Result<Self> {
+        lgn_config::Config::new()
+            .get("authentication.signature_validation")
+            .ok_or_else(|| {
+                Error::Other(anyhow::anyhow!("failed to load signature validation config").into())
+            })
+    }
+
+    /// Instanciate a `SignatureValidation` from the configuration.
+    pub async fn signature_validation(&self) -> anyhow::Result<BoxedSignatureValidation> {
+        Ok(BoxedSignatureValidation(match self {
+            SignatureValidationConfig::Disabled {} => Box::new(NoSignatureValidation {}),
+            SignatureValidationConfig::Rsa(config) => Box::new(
+                RsaSignatureValidation::new_from_components(&config.n, &config.e)?,
+            ),
+            SignatureValidationConfig::AwsCognito(config) => Box::new(
+                AwsCognitoSignatureValidation::new(&config.region, &config.user_pool_id).await?,
+            ),
+        }))
+    }
+
+    /// Instanciate a `Validation` from the configuration.
+    pub async fn validation(&self) -> anyhow::Result<Validation<BoxedSignatureValidation>> {
+        match self.signature_validation().await {
+            Ok(signature_validation) => Ok(Validation::new(signature_validation)),
+            Err(err) => Err(err),
+        }
+    }
+}

--- a/crates/lgn-online/src/authentication/errors.rs
+++ b/crates/lgn-online/src/authentication/errors.rs
@@ -22,4 +22,4 @@ impl Error {
     }
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/lgn-online/src/authentication/jwt/mod.rs
+++ b/crates/lgn-online/src/authentication/jwt/mod.rs
@@ -1,9 +1,11 @@
 mod header;
+mod request_authorizer;
 mod token;
 mod validation;
 
 pub mod signature_validation;
 
 pub use header::Header;
+pub use request_authorizer::RequestAuthorizer;
 pub use token::Token;
 pub use validation::{UnsecureValidation, Validation};

--- a/crates/lgn-online/src/authentication/jwt/request_authorizer.rs
+++ b/crates/lgn-online/src/authentication/jwt/request_authorizer.rs
@@ -1,0 +1,135 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use hyper::{Request, Response, StatusCode};
+use lgn_tracing::warn;
+use tower_http::auth::AuthorizeRequest;
+
+use super::{
+    signature_validation::{NoSignatureValidation, SignatureValidation},
+    Token, Validation,
+};
+
+/// An authentication layer that validates JWT tokens and exposes its claims.
+pub struct RequestAuthorizer<Claims, SV, ResBody> {
+    validation: Arc<Validation<SV>>,
+    _phantom: PhantomData<(Claims, ResBody)>,
+}
+
+impl<Claims, SV, ResBody> Clone for RequestAuthorizer<Claims, SV, ResBody> {
+    fn clone(&self) -> Self {
+        Self {
+            validation: Arc::clone(&self.validation),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Claims, ResBody> Default for RequestAuthorizer<Claims, NoSignatureValidation, ResBody> {
+    fn default() -> Self {
+        Self {
+            validation: Arc::new(Validation::default()),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Claims, SV, ResBody> RequestAuthorizer<Claims, SV, ResBody>
+where
+    ResBody: Default,
+{
+    pub fn new(validation: Validation<SV>) -> Self {
+        Self {
+            validation: Arc::new(validation),
+            _phantom: PhantomData,
+        }
+    }
+
+    fn get_token<ReqBody>(request: &mut Request<ReqBody>) -> Result<Token<'_>, Response<ResBody>> {
+        if let Some(header) = request.headers().get("Authorization") {
+            match header.to_str() {
+                Ok(authorization) => {
+                    let parts = authorization.split_whitespace().collect::<Vec<_>>();
+
+                    if parts.len() != 2 {
+                        warn!("Invalid authorization header: expected `Bearer <jwt>`");
+
+                        Err(Response::builder()
+                            .status(StatusCode::UNAUTHORIZED)
+                            .body(ResBody::default())
+                            .unwrap())
+                    } else if parts[0] != "Bearer" {
+                        warn!("Invalid authorization header: expected `Bearer <jwt>` but got `{} <...>`", parts[0]);
+
+                        Err(Response::builder()
+                            .status(StatusCode::UNAUTHORIZED)
+                            .body(ResBody::default())
+                            .unwrap())
+                    } else {
+                        match Token::try_from(parts[1]) {
+                            Ok(token) => Ok(token),
+                            Err(err) => {
+                                warn!(
+                                    "Invalid authorization header: could not parse JWT token: {}",
+                                    err
+                                );
+
+                                Err(Response::builder()
+                                    .status(StatusCode::UNAUTHORIZED)
+                                    .body(ResBody::default())
+                                    .unwrap())
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!("Invalid authorization header: {}", err);
+
+                    Err(Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(ResBody::default())
+                        .unwrap())
+                }
+            }
+        } else {
+            warn!("No authorization header found");
+
+            Err(Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(ResBody::default())
+                .unwrap())
+        }
+    }
+}
+
+impl<Claims, SV, ReqBody, ResBody> AuthorizeRequest<ReqBody>
+    for RequestAuthorizer<Claims, SV, ResBody>
+where
+    Claims: serde::de::DeserializeOwned + Send + Sync + 'static,
+    SV: SignatureValidation,
+    ResBody: Default,
+{
+    type ResponseBody = ResBody;
+
+    fn authorize(
+        &mut self,
+        request: &mut Request<ReqBody>,
+    ) -> Result<(), Response<Self::ResponseBody>> {
+        let token = Self::get_token(request)?;
+
+        match token.into_claims::<Claims, _>(&self.validation) {
+            Ok(claims) => {
+                request.extensions_mut().insert(claims);
+
+                Ok(())
+            }
+            Err(err) => {
+                warn!("Invalid JWT token: {}", err);
+
+                Err(Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .body(ResBody::default())
+                    .unwrap())
+            }
+        }
+    }
+}

--- a/crates/lgn-online/src/authentication/jwt/token.rs
+++ b/crates/lgn-online/src/authentication/jwt/token.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use anyhow::{anyhow, Context};
 
 use super::{signature_validation::SignatureValidation, Header, Validation};
@@ -60,7 +58,7 @@ impl<'a> Token<'a> {
     /// Convert the token into its claims.
     ///
     /// This method validates the token and is recommended.
-    pub fn into_claims<C, T>(self, validation: &Validation<'_, T>) -> anyhow::Result<C>
+    pub fn into_claims<C, T>(self, validation: &Validation<T>) -> anyhow::Result<C>
     where
         C: serde::de::DeserializeOwned,
         T: SignatureValidation,
@@ -68,8 +66,8 @@ impl<'a> Token<'a> {
         self.validate(validation)?.into_claims_unsafe()
     }
 
-    /// Validate the token without consuming it.
-    pub fn validate<T>(self, validation: &Validation<'_, T>) -> anyhow::Result<Self>
+    /// Validate the token.
+    pub fn validate<T>(self, validation: &Validation<T>) -> anyhow::Result<Self>
     where
         T: SignatureValidation,
     {
@@ -136,16 +134,8 @@ impl<'a> TryFrom<&'a str> for Token<'a> {
     }
 }
 
-impl<'a> From<Token<'a>> for &'a str {
-    fn from(token: Token<'a>) -> Self {
-        token.raw
-    }
-}
-
-impl Deref for Token<'_> {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        self.raw
+impl std::fmt::Display for Token<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.raw)
     }
 }

--- a/crates/lgn-online/src/authentication/jwt/validation.rs
+++ b/crates/lgn-online/src/authentication/jwt/validation.rs
@@ -8,10 +8,11 @@ use super::{
     Token,
 };
 
-pub type UnsecureValidation<'a> = Validation<'a, NoSignatureValidation>;
+pub type UnsecureValidation = Validation<NoSignatureValidation>;
 
 /// Provides JWT validation.
-pub struct Validation<'a, SV = NoSignatureValidation> {
+#[derive(Clone)]
+pub struct Validation<SV = NoSignatureValidation> {
     /// A tolerance for the not-before and expiry times.
     leeway: time::Duration,
 
@@ -30,16 +31,16 @@ pub struct Validation<'a, SV = NoSignatureValidation> {
     validate_nbf: bool,
 
     /// A issuer to check.
-    iss: Option<&'a str>,
+    iss: Option<String>,
 
     /// A subject identifier to check.
-    sub: Option<&'a str>,
+    sub: Option<String>,
 
     /// A audience to check.
-    aud: Option<&'a str>,
+    aud: Option<String>,
 }
 
-impl<SV> Default for Validation<'_, SV>
+impl<SV> Default for Validation<SV>
 where
     SV: Default,
 {
@@ -57,7 +58,7 @@ where
     }
 }
 
-impl<'a, SV> Validation<'a, SV>
+impl<'a, SV> Validation<SV>
 where
     SV: SignatureValidation,
 {
@@ -105,20 +106,20 @@ where
     }
 
     /// Sets the issuer to check.
-    pub fn with_iss(mut self, iss: &'a str) -> Self {
-        self.iss = Some(iss);
+    pub fn with_iss(mut self, iss: impl Into<String>) -> Self {
+        self.iss = Some(iss.into());
         self
     }
 
     /// Sets the subject identifier to check.
-    pub fn with_sub(mut self, sub: &'a str) -> Self {
-        self.sub = Some(sub);
+    pub fn with_sub(mut self, sub: impl Into<String>) -> Self {
+        self.sub = Some(sub.into());
         self
     }
 
     /// Sets the audience to check.
-    pub fn with_aud(mut self, aud: &'a str) -> Self {
-        self.aud = Some(aud);
+    pub fn with_aud(mut self, aud: impl Into<String>) -> Self {
+        self.aud = Some(aud.into());
         self
     }
 
@@ -156,7 +157,7 @@ where
             }
         }
 
-        if let Some(iss) = self.iss {
+        if let Some(iss) = &self.iss {
             match &claims.iss {
                 Some(claims_iss) => {
                     if iss != claims_iss {
@@ -171,7 +172,7 @@ where
             }
         }
 
-        if let Some(sub) = self.sub {
+        if let Some(sub) = &self.sub {
             match &claims.sub {
                 Some(claims_sub) => {
                     if sub != claims_sub {
@@ -189,7 +190,7 @@ where
             }
         }
 
-        if let Some(aud) = self.aud {
+        if let Some(aud) = &self.aud {
             match &claims.aud {
                 Some(claims_aud) => {
                     if aud != claims_aud {

--- a/crates/lgn-web-client/src/lib.rs
+++ b/crates/lgn-web-client/src/lib.rs
@@ -45,8 +45,6 @@ use lgn_online::authentication::{
 use tauri::{plugin::Plugin, Invoke, Manager, Runtime};
 use url::Url;
 
-const DEFAULT_PORT: u16 = 80;
-
 type OAuthClientTokenCache = OnlineTokenCache<OAuthClient>;
 
 #[tauri::command]
@@ -106,8 +104,7 @@ impl<R: Runtime> BrowserPlugin<R> {
 
         let oauth_client = OAuthClient::new(issuer_url.to_string(), client_id)
             .await?
-            .set_redirect_uri(redirect_uri)?
-            .set_port(redirect_uri.port().unwrap_or(DEFAULT_PORT));
+            .set_redirect_uri(redirect_uri)?;
 
         let oauth_client = Arc::new(OAuthClientTokenCache::new(oauth_client, projects_dir));
 

--- a/legion.toml
+++ b/legion.toml
@@ -36,12 +36,20 @@ test_nested = 42
 [logging.level_filters]
 #webrtc = "WARN"
 
-[oauth]
+[authentication.signature_validation]
+type = "aws_cognito"
+region = "ca-central-1"
+user_pool_id = "ca-central-1_SkZKDimWz"
+
+[authentication.authenticator]
+type = "oauth"
 issuer_url = "https://cognito-idp.ca-central-1.amazonaws.com/ca-central-1_SkZKDimWz"
 client_id = "5m58nrjfv6kr144prif9jk62di"
+redirect_uri = "http://localhost:3000/"
 
 [content_store.provider]
-type = "local"
+type = "grpc"
+url = "http://localhost:5000"
 
 [content_store.caching_provider]
 type = "lru"


### PR DESCRIPTION
This PR adds a tentative content-store server application in the `lgn-content-store2` crate.

It also fixes a number of things in the `lgn-online` crate to allow for dynamic configuration of signature validators and client authenticators. Also, it implements server JWT authorization.