### PR TITLE
Editor client: A new [editor|runtime]-server-url query param allows to override the server at runtime

### DIFF
--- a/crates/lgn-editor-gui/frontend/src/api/index.ts
+++ b/crates/lgn-editor-gui/frontend/src/api/index.ts
@@ -20,21 +20,33 @@ import type {
   ResourceWithProperties,
 } from "../lib/propertyGrid";
 
-const editorServerURL = "http://[::1]:50051";
+const defaultEditorServerURL = "http://[::1]:50051";
 
-const resourceBrowserClient = new ResourceBrowserClientImpl(
-  new EditorResourceBrowserWebImpl(editorServerURL, { debug: false })
-);
+let resourceBrowserClient: ResourceBrowserClientImpl;
 
-const propertyInspectorClient = new PropertyInspectorClientImpl(
-  new EditorPropertyInspectorWebImpl(editorServerURL, { debug: false })
-);
+let propertyInspectorClient: PropertyInspectorClientImpl;
 
-const sourceControlClient = new SourceControlClientImpl(
-  new EditorSourceControlWebImpl(editorServerURL, {
-    debug: false,
-  })
-);
+let sourceControlClient: SourceControlClientImpl;
+
+export function initApiClient({
+  editorServerUrl = defaultEditorServerURL,
+}: {
+  editorServerUrl?: string;
+}) {
+  resourceBrowserClient = new ResourceBrowserClientImpl(
+    new EditorResourceBrowserWebImpl(editorServerUrl, { debug: false })
+  );
+
+  propertyInspectorClient = new PropertyInspectorClientImpl(
+    new EditorPropertyInspectorWebImpl(editorServerUrl, { debug: false })
+  );
+
+  sourceControlClient = new SourceControlClientImpl(
+    new EditorSourceControlWebImpl(editorServerUrl, {
+      debug: false,
+    })
+  );
+}
 
 /**
  * Eagerly fetches all the resource descriptions on the server

--- a/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
@@ -27,6 +27,13 @@
   const redirectUri = `${document.location.origin}/`;
 
   export const load: Load = async ({ fetch, url }) => {
+    const editorServerUrl =
+      url.searchParams.get("editor-server-url") || undefined;
+    const runtimeServerUrl =
+      url.searchParams.get("runtime-server-url") || undefined;
+
+    initApiClient({ editorServerUrl });
+
     try {
       const { initAuthStatus } = await headlessRun({
         auth: {
@@ -50,6 +57,8 @@
             scopes,
           },
         },
+        editorServerUrl,
+        runtimeServerUrl,
         logLevel,
         async onPreInit() {
           // await initWasmLogger();
@@ -85,6 +94,7 @@
 
 <script lang="ts">
   import "../assets/index.css";
+  import { initApiClient } from "@/api";
 </script>
 
 <slot />

--- a/crates/lgn-web-client/frontend/src/index.ts
+++ b/crates/lgn-web-client/frontend/src/index.ts
@@ -5,6 +5,7 @@ import type { Level as LogLevel } from "./lib/log";
 import userInfo from "./stores/userInfo";
 import { SvelteComponentTyped } from "svelte";
 import grpcWeb from "@improbable-eng/grpc-web";
+import { initApiClient } from "./api";
 
 export class AppComponent extends SvelteComponentTyped<{
   initAuthStatus: InitAuthStatus | null;
@@ -42,6 +43,8 @@ export type Config = {
   logLevel: LogLevel | null;
   /** Hook called before the application start */
   onPreInit?(): Promise<void> | void;
+  editorServerUrl?: string;
+  runtimeServerUrl?: string;
 };
 
 /**
@@ -61,8 +64,12 @@ export async function run({
   rootQuerySelector,
   logLevel,
   onPreInit,
+  editorServerUrl,
+  runtimeServerUrl,
 }: Config): Promise<void> {
   onPreInit && (await onPreInit());
+
+  initApiClient({ editorServerUrl, runtimeServerUrl });
 
   const target = getTarget(rootQuerySelector);
 
@@ -126,6 +133,8 @@ export type HeadlessConfig = {
   logLevel: LogLevel | null;
   /** Hook called before the application start */
   onPreInit?(): Promise<void> | void;
+  editorServerUrl?: string;
+  runtimeServerUrl?: string;
 };
 
 /**
@@ -144,11 +153,15 @@ export async function headlessRun({
   auth: authConfig,
   logLevel,
   onPreInit,
+  editorServerUrl,
+  runtimeServerUrl,
 }: HeadlessConfig): Promise<{
   initAuthStatus: InitAuthStatus | null;
   grpcMetadata: grpcWeb.grpc.Metadata | null;
 }> {
   onPreInit && (await onPreInit());
+
+  initApiClient({ editorServerUrl, runtimeServerUrl });
 
   if (logLevel) {
     log.init();


### PR DESCRIPTION
@jelmansouri should help with testing the deployment 👍 