### PR TITLE
Implemented Alias trait for the Content Store

### DIFF
--- a/crates/lgn-content-store-proto/protos/content-store.proto
+++ b/crates/lgn-content-store-proto/protos/content-store.proto
@@ -2,9 +2,30 @@ syntax = "proto3";
 package content_store;
 
 service ContentStore {
+  rpc ResolveAlias(ResolveAliasRequest) returns (ResolveAliasResponse) {};
+  rpc RegisterAlias(RegisterAliasRequest) returns (RegisterAliasResponse) {};
   rpc ReadContent(ReadContentRequest) returns (ReadContentResponse) {};
   rpc GetContentWriter(GetContentWriterRequest) returns (GetContentWriterResponse) {};
   rpc WriteContent(WriteContentRequest) returns (WriteContentResponse) {};
+}
+
+message ResolveAliasRequest {
+  string key_space = 1;
+  string key = 2;
+}
+
+message ResolveAliasResponse {
+  string id = 1;
+}
+
+message RegisterAliasRequest {
+  string key_space = 1;
+  string key = 2;
+  string id = 3;
+}
+
+message RegisterAliasResponse {
+  bool newly_registered = 1;
 }
 
 message ReadContentRequest {

--- a/crates/lgn-content-store2/src/lib.rs
+++ b/crates/lgn-content-store2/src/lib.rs
@@ -19,6 +19,7 @@ pub use errors::{Error, Result};
 pub use identifier::{HashAlgorithm, Identifier};
 pub use providers::*;
 pub use traits::{
+    AliasContentReaderExt, AliasContentWriterExt, AliasProvider, AliasRegisterer, AliasResolver,
     ContentAddressProvider, ContentAddressReader, ContentAddressWriter, ContentAsyncRead,
     ContentAsyncWrite, ContentProvider, ContentReader, ContentReaderExt, ContentWriter,
     ContentWriterExt,

--- a/crates/lgn-content-store2/src/providers/aliaser.rs
+++ b/crates/lgn-content-store2/src/providers/aliaser.rs
@@ -1,0 +1,55 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use async_trait::async_trait;
+
+use crate::{
+    AliasRegisterer, AliasResolver, ContentAsyncRead, ContentAsyncWrite, ContentReader,
+    ContentWriter, Identifier, Result,
+};
+
+/// A struct that makes it easy to create a `ContentProvider` that is also an `AliasProvider`.
+pub struct Aliaser<A, P> {
+    aliaser: A,
+    provider: P,
+}
+
+impl<A, P> Aliaser<A, P> {
+    pub fn new(aliaser: A, provider: P) -> Self {
+        Self { aliaser, provider }
+    }
+}
+
+#[async_trait]
+impl<A: AliasResolver + Send + Sync, P: Send + Sync> AliasResolver for Aliaser<A, P> {
+    async fn resolve_alias(&self, key_space: &str, key: &str) -> Result<Identifier> {
+        self.aliaser.resolve_alias(key_space, key).await
+    }
+}
+
+#[async_trait]
+impl<A: AliasRegisterer + Send + Sync, P: Send + Sync> AliasRegisterer for Aliaser<A, P> {
+    async fn register_alias(&self, key_space: &str, key: &str, id: &Identifier) -> Result<()> {
+        self.aliaser.register_alias(key_space, key, id).await
+    }
+}
+
+#[async_trait]
+impl<A: Send + Sync, P: ContentReader + Send + Sync> ContentReader for Aliaser<A, P> {
+    async fn get_content_reader(&self, id: &Identifier) -> Result<ContentAsyncRead> {
+        self.provider.get_content_reader(id).await
+    }
+
+    async fn get_content_readers<'ids>(
+        &self,
+        ids: &'ids BTreeSet<Identifier>,
+    ) -> Result<BTreeMap<&'ids Identifier, Result<ContentAsyncRead>>> {
+        self.provider.get_content_readers(ids).await
+    }
+}
+
+#[async_trait]
+impl<A: Send + Sync, P: ContentWriter + Send + Sync> ContentWriter for Aliaser<A, P> {
+    async fn get_content_writer(&self, id: &Identifier) -> Result<ContentAsyncWrite> {
+        self.provider.get_content_writer(id).await
+    }
+}

--- a/crates/lgn-content-store2/src/providers/aws_dynamodb.rs
+++ b/crates/lgn-content-store2/src/providers/aws_dynamodb.rs
@@ -3,12 +3,12 @@ use aws_sdk_dynamodb::model::AttributeValue;
 use aws_sdk_dynamodb::types::Blob;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    io::Cursor,
+    io::{Cursor, Write},
 };
 
 use crate::{
-    traits::get_content_readers_impl, ContentAsyncRead, ContentAsyncWrite, ContentReader,
-    ContentWriter, Error, Identifier, Result,
+    traits::get_content_readers_impl, AliasRegisterer, AliasResolver, ContentAsyncRead,
+    ContentAsyncWrite, ContentReader, ContentWriter, Error, Identifier, Result,
 };
 
 use super::{Uploader, UploaderImpl};
@@ -31,13 +31,58 @@ impl AwsDynamoDbProvider {
         Self { table_name, client }
     }
 
+    fn get_content_id_attr(id: &Identifier) -> AttributeValue {
+        let mut buf = Vec::with_capacity(1 + id.bytes_len());
+        // Identifiers start with a 0x00 byte.
+        buf.push(0);
+        id.write_to(&mut buf).unwrap();
+
+        AttributeValue::B(Blob::new(buf))
+    }
+
+    fn get_alias_id_attr(key_space: &str, key: &str) -> AttributeValue {
+        let mut buf = Vec::with_capacity(1 + key_space.len() + 1 + key.len());
+        // Aliases start with a 0x01 byte.
+        buf.push(1);
+        write!(&mut buf, "{}:{}", key_space, key).unwrap();
+
+        AttributeValue::B(Blob::new(buf))
+    }
+
+    /// Delete the content with the specified identifier.
+    ///
+    /// # Errors
+    ///
+    /// Otherwise, any other error is returned.
+    pub async fn delete_alias(&self, key_space: &str, key: &str) -> Result<()> {
+        let id_attr = Self::get_alias_id_attr(key_space, key);
+
+        match self
+            .client
+            .delete_item()
+            .table_name(&self.table_name)
+            .key("id", id_attr)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) => Err(anyhow::anyhow!(
+                "failed to delete item `{}/{}` from AWS DynamoDB: {}",
+                key_space,
+                key,
+                err
+            )
+            .into()),
+        }
+    }
+
     /// Delete the content with the specified identifier.
     ///
     /// # Errors
     ///
     /// Otherwise, any other error is returned.
     pub async fn delete_content(&self, id: &Identifier) -> Result<()> {
-        let id_attr = AttributeValue::B(Blob::new(id.as_vec()));
+        let id_attr = Self::get_content_id_attr(id);
 
         match self
             .client
@@ -58,7 +103,7 @@ impl AwsDynamoDbProvider {
     }
 
     async fn get_content(&self, id: &Identifier) -> Result<Vec<u8>> {
-        let id_attr = AttributeValue::B(Blob::new(id.as_vec()));
+        let id_attr = Self::get_content_id_attr(id);
 
         match self
             .client
@@ -88,6 +133,77 @@ impl AwsDynamoDbProvider {
             },
             Err(err) => Err(anyhow::anyhow!(
                 "unexpected error while reading item `{}` from AWS DynamoDB: {}",
+                id,
+                err
+            )
+            .into()),
+        }
+    }
+}
+
+#[async_trait]
+impl AliasResolver for AwsDynamoDbProvider {
+    async fn resolve_alias(&self, key_space: &str, key: &str) -> Result<Identifier> {
+        let id_attr = Self::get_alias_id_attr(key_space, key);
+
+        match self
+            .client
+            .get_item()
+            .table_name(&self.table_name)
+            .key("id", id_attr)
+            .send()
+            .await
+        {
+            Ok(output) => match output.item {
+                Some(mut attrs) => match attrs.remove("data") {
+                    Some(data) => match data {
+                        AttributeValue::B(data) => {
+                            Identifier::read_from(std::io::Cursor::new(data.into_inner()))
+                        }
+                        _ => Err(anyhow::anyhow!(
+                            "failed to read item `{}/{}` data with unexpected type from AWS DynamoDB",
+                            key_space, key
+                        )
+                        .into()),
+                    },
+                    None => Err(anyhow::anyhow!(
+                        "failed to read item `{}/{}` data from AWS DynamoDB",
+                        key_space, key
+                    )
+                    .into()),
+                },
+                None => Err(Error::NotFound),
+            },
+            Err(err) => Err(anyhow::anyhow!(
+                "unexpected error while reading item `{}/{}` from AWS DynamoDB: {}",
+                key_space, key,
+                err
+            )
+            .into()),
+        }
+    }
+}
+
+#[async_trait]
+impl AliasRegisterer for AwsDynamoDbProvider {
+    async fn register_alias(&self, key_space: &str, key: &str, id: &Identifier) -> Result<()> {
+        let id_attr = Self::get_alias_id_attr(key_space, key);
+        let data_attr = AttributeValue::B(Blob::new(id.as_vec()));
+
+        match self
+            .client
+            .put_item()
+            .table_name(&self.table_name)
+            .item("id", id_attr)
+            .item("data", data_attr)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) => Err(anyhow::anyhow!(
+                "unexpected error while writing item `{}/{}` as {} to AWS DynamoDB: {}",
+                key_space,
+                key,
                 id,
                 err
             )
@@ -137,7 +253,7 @@ struct DynamoDbUploaderImpl {
 #[async_trait]
 impl UploaderImpl for DynamoDbUploaderImpl {
     async fn upload(self, data: Vec<u8>, id: Identifier) -> Result<()> {
-        let id_attr = AttributeValue::B(Blob::new(id.as_vec()));
+        let id_attr = AwsDynamoDbProvider::get_content_id_attr(&id);
         let data_attr = AttributeValue::B(Blob::new(data));
 
         match self

--- a/crates/lgn-content-store2/src/providers/mod.rs
+++ b/crates/lgn-content-store2/src/providers/mod.rs
@@ -1,3 +1,4 @@
+mod aliaser;
 #[cfg(feature = "aws")]
 mod aws_dynamodb;
 #[cfg(feature = "aws")]
@@ -18,6 +19,7 @@ mod uploader;
 pub use self::lru::LruProvider;
 #[cfg(feature = "redis")]
 pub use self::redis::RedisProvider;
+pub use aliaser::Aliaser;
 #[cfg(feature = "aws")]
 pub use aws_dynamodb::AwsDynamoDbProvider;
 #[cfg(feature = "aws")]

--- a/crates/lgn-content-store2/tests/common/asserts.rs
+++ b/crates/lgn-content-store2/tests/common/asserts.rs
@@ -1,3 +1,16 @@
+macro_rules! assert_alias_not_found {
+    ($provider:expr, $key_space:expr, $key:expr) => {{
+        match $provider.read_alias($key_space, $key).await {
+            Ok(_) => panic!(
+                "alias was found with the specified key `{}/{}`",
+                $key_space, $key
+            ),
+            Err(Error::NotFound {}) => {}
+            Err(err) => panic!("unexpected error: {}", err),
+        };
+    }};
+}
+
 macro_rules! assert_content_not_found {
     ($provider:expr, $id:expr) => {{
         match $provider.read_content(&$id).await {
@@ -5,6 +18,17 @@ macro_rules! assert_content_not_found {
             Err(Error::NotFound {}) => {}
             Err(err) => panic!("unexpected error: {}", err),
         };
+    }};
+}
+
+macro_rules! assert_read_alias {
+    ($provider:expr, $key_space:expr, $key:expr, $expected_content:expr) => {{
+        let content = $provider
+            .read_alias($key_space, $key)
+            .await
+            .expect("failed to read alias");
+
+        assert_eq!(content, $expected_content);
     }};
 }
 
@@ -63,6 +87,16 @@ macro_rules! assert_read_contents {
     }};
 }
 
+macro_rules! assert_write_alias {
+    ($provider:expr, $key_space:expr, $key:expr, $content:expr) => {{
+        #[allow(clippy::string_lit_as_bytes)]
+        $provider
+            .write_alias($key_space, $key, $content)
+            .await
+            .expect("failed to write alias")
+    }};
+}
+
 macro_rules! assert_write_content {
     ($provider:expr, $content:expr) => {{
         #[allow(clippy::string_lit_as_bytes)]
@@ -88,6 +122,6 @@ macro_rules! assert_write_avoided {
 }
 
 pub(crate) use {
-    assert_content_not_found, assert_read_content, assert_read_contents, assert_write_avoided,
-    assert_write_content,
+    assert_alias_not_found, assert_content_not_found, assert_read_alias, assert_read_content,
+    assert_read_contents, assert_write_alias, assert_write_avoided, assert_write_content,
 };


### PR DESCRIPTION
This PR extends the Content Store crate with Alias support (user-chosen Ids that map to data in the Content-Store).

# TLDR

You can now do stuff like:

```rust
let buf: Vec<u8> = provider.read_alias("uuid", "abcd-efgh-...-wxyz")?;
let id: lgn_content_store:Identifier = provider.write_alias("uuid", "abcd-efgh-...-wxyz", &buf);
```

Where `"abcd-efgh-...-wxyz"` is a **user-chosen** ID. The first parameter is a *key-space* used mainly to make sure keys do not collide between several integrators. You can pick whatever value suits you, but keep it the same throughout your systems.

# Details

The new traits `AliasResolver` and `AliasRegisterer` have been implemented in the following providers:

- `MemoryProvider`
- `LruProvider`
- `GrpcProvider`
- `RedisProvider`
- `DynamoDbProvider`
- `CachingProvider`
- `MonitoringProvider`

This makes alias resolution/registration automatically cacheable, just like the data blobs themselves, **using the same infrastructure**.