### PR TITLE
Load Offline resource on demand

### DIFF
--- a/crates/lgn-asset-registry/src/asset_to_ecs.rs
+++ b/crates/lgn-asset-registry/src/asset_to_ecs.rs
@@ -42,8 +42,6 @@ where
                         commands.entity(old_entity).despawn();
                     }
                 }
-            } else {
-                info!("Loaded {}: {}", T::TYPENAME, &asset_id.id);
             }
         }
         true
@@ -200,7 +198,7 @@ impl AssetToECS for runtime_data::Entity {
         }
 
         info!(
-            "Loaded {}: {} -> ECS id: {:?}| {}",
+            "Spawned {}: {} -> ECS id: {:?}| {}",
             Self::TYPENAME,
             asset_id.id,
             entity_id,
@@ -226,7 +224,7 @@ impl AssetToECS for runtime_data::Instance {
         };
 
         info!(
-            "Loaded {}: {} -> ECS id: {:?}",
+            "Spawned {}: {} -> ECS id: {:?}",
             Self::TYPENAME,
             asset_id.id,
             entity.id(),
@@ -259,7 +257,7 @@ impl AssetToECS for lgn_graphics_data::runtime::Material {
         ));
 
         info!(
-            "Loaded {}: {} -> ECS id: {:?}",
+            "Spawned {}: {} -> ECS id: {:?}",
             Self::TYPENAME,
             asset_id.id,
             entity.id(),
@@ -302,7 +300,7 @@ impl AssetToECS for lgn_graphics_data::runtime_texture::Texture {
 
         entity.insert(texture_component);
         info!(
-            "Loaded {}: {} -> ECS id: {:?} | width: {}, height: {}, format: {:?}",
+            "Spawned {}: {} -> ECS id: {:?} | width: {}, height: {}, format: {:?}",
             Self::TYPENAME.trim_start_matches("runtime_"),
             asset_id.id,
             entity.id(),
@@ -368,6 +366,12 @@ impl AssetToECS for lgn_graphics_data::runtime::Model {
         };
         entity.insert(model_component);
 
+        info!(
+            "Spawned {}: {} -> ECS id: {:?}",
+            Self::TYPENAME.trim_start_matches("runtime_"),
+            asset_id.id,
+            entity.id(),
+        );
         Some(entity.id())
     }
 }
@@ -388,7 +392,7 @@ impl AssetToECS for lgn_scripting::runtime::Script {
         };
 
         info!(
-            "Loaded {}: {} -> ECS id: {:?} ({} bytes)",
+            "Spawned {}: {} -> ECS id: {:?} ({} bytes)",
             Self::TYPENAME,
             asset_id.id,
             ecs_entity.id(),

--- a/crates/lgn-data-offline/src/resource/path_name.rs
+++ b/crates/lgn-data-offline/src/resource/path_name.rs
@@ -89,10 +89,11 @@ impl ResourcePathName {
             );
             self.0 = format!("/!{}{}", resource_id, new_path);
         } else if let Some(new_parent_id) = new_parent_id {
+            let relative_name = self.0.as_str().rsplit('/').next().unwrap_or("");
             self.0 = format!(
                 "/!{}{}",
                 new_parent_id,
-                new_path.unwrap_or_else(|| "".into())
+                new_path.unwrap_or_else(|| relative_name.into())
             );
         } else if let Some(new_path) = new_path {
             *self = new_path;

--- a/crates/lgn-data-offline/src/resource/resource_handles.rs
+++ b/crates/lgn-data-offline/src/resource/resource_handles.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{btree_map::Entry, BTreeMap};
 
 use lgn_data_runtime::ResourceTypeAndId;
 
@@ -12,6 +12,14 @@ impl ResourceHandles {
     /// Retrieve a `ResourceHandleUntyped` from a `ResourceId`
     pub fn get(&self, resource_id: ResourceTypeAndId) -> Option<&ResourceHandleUntyped> {
         self.0.get(&resource_id)
+    }
+
+    /// Retrieve the internal hashmap entry for a `ResourceId`
+    pub fn entry(
+        &mut self,
+        resource_id: ResourceTypeAndId,
+    ) -> Entry<'_, ResourceTypeAndId, ResourceHandleUntyped> {
+        self.0.entry(resource_id)
     }
 
     /// Insert a `ResourceHandleUntyped`

--- a/crates/lgn-data-runtime/src/asset_loader.rs
+++ b/crates/lgn-data-runtime/src/asset_loader.rs
@@ -11,6 +11,7 @@ use std::{
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use flurry::TryInsertError;
+use lgn_tracing::info;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -262,8 +263,15 @@ impl AssetLoaderIO {
     }
 
     fn load_resource(&self, type_id: ResourceTypeAndId) -> Result<Vec<u8>, AssetRegistryError> {
+        let start = std::time::Instant::now();
         for device in &self.devices {
             if let Some(content) = device.load(type_id) {
+                info!(
+                    "Loaded {:?} {} in {:?}",
+                    type_id,
+                    content.len(),
+                    start.elapsed(),
+                );
                 return Ok(content);
             }
         }
@@ -333,6 +341,7 @@ impl AssetLoaderIO {
         load_id: Option<u32>,
     ) -> Result<(), (HandleUntyped, Option<LoadId>, AssetRegistryError)> {
         let primary_id = primary_handle.id();
+
         if self.loaded_resources.contains(&primary_id)
             || self
                 .processing_list

--- a/crates/lgn-data-transaction/src/array_element_operation.rs
+++ b/crates/lgn-data-transaction/src/array_element_operation.rs
@@ -90,14 +90,11 @@ impl ArrayOperation {
 impl TransactionOperation for ArrayOperation {
     #[allow(unsafe_code)]
     async fn apply_operation(&mut self, ctx: &mut LockContext<'_>) -> Result<(), Error> {
-        let resource_handle = ctx
-            .loaded_resource_handles
-            .get(self.resource_id)
-            .ok_or(Error::InvalidTypeReflection(self.resource_id))?;
+        let resource_handle = ctx.get_or_load(self.resource_id).await?;
 
         let reflection = ctx
             .resource_registry
-            .get_resource_reflection_mut(self.resource_id.kind, resource_handle)
+            .get_resource_reflection_mut(self.resource_id.kind, &resource_handle)
             .ok_or(Error::InvalidTypeReflection(self.resource_id))?;
 
         let array_value = find_property_mut(reflection, self.array_path.as_str())
@@ -222,14 +219,11 @@ impl TransactionOperation for ArrayOperation {
 
     #[allow(unsafe_code)]
     async fn rollback_operation(&self, ctx: &mut LockContext<'_>) -> Result<(), Error> {
-        let handle = ctx
-            .loaded_resource_handles
-            .get(self.resource_id)
-            .ok_or(Error::InvalidResource(self.resource_id))?;
+        let handle = ctx.get_or_load(self.resource_id).await?;
 
         let reflection = ctx
             .resource_registry
-            .get_resource_reflection_mut(self.resource_id.kind, handle)
+            .get_resource_reflection_mut(self.resource_id.kind, &handle)
             .ok_or(Error::InvalidTypeReflection(self.resource_id))?;
 
         let array_value = find_property_mut(reflection, self.array_path.as_str())

--- a/crates/lgn-data-transaction/src/create_resource_operation.rs
+++ b/crates/lgn-data-transaction/src/create_resource_operation.rs
@@ -88,12 +88,11 @@ impl TransactionOperation for CreateResourceOperation {
     }
 
     async fn rollback_operation(&self, ctx: &mut LockContext<'_>) -> Result<(), Error> {
-        if let Some(_handle) = ctx.loaded_resource_handles.remove(self.resource_id) {
-            ctx.project
-                .delete_resource(self.resource_id.id)
-                .await
-                .map_err(|err| Error::Project(self.resource_id, err))?;
-        }
+        ctx.loaded_resource_handles.remove(self.resource_id);
+        ctx.project
+            .delete_resource(self.resource_id.id)
+            .await
+            .map_err(|err| Error::Project(self.resource_id, err))?;
         Ok(())
     }
 }

--- a/crates/lgn-editor-srv/src/source_control_plugin.rs
+++ b/crates/lgn-editor-srv/src/source_control_plugin.rs
@@ -572,7 +572,9 @@ impl SourceControl for SourceControlRPC {
                 .map_err(|err| Status::internal(err.to_string()))?;
         }
 
-        transaction_manager.load_all_resources().await;
+        transaction_manager
+            .load_all_resource_type(&[sample_data::offline::Entity::TYPE])
+            .await;
 
         Ok(Response::new(SyncLatestResponse {}))
     }

--- a/crates/lgn-resource-registry/src/lib.rs
+++ b/crates/lgn-resource-registry/src/lib.rs
@@ -105,17 +105,6 @@ impl ResourceRegistryPlugin {
             )))
         });
 
-        {
-            let async_rt = world
-                .get_resource::<TokioAsyncRuntime>()
-                .expect("async plugin did not provide tokio runtime");
-            let transaction_manager = transaction_manager.clone();
-            async_rt.start_detached(async move {
-                let mut transaction_manager = transaction_manager.lock().await;
-                transaction_manager.load_all_resources().await;
-            });
-        }
-
         world.insert_resource(transaction_manager);
     }
 }


### PR DESCRIPTION
-Disable loading of all resources on Editor-Srv start up.
Only load on-demand, when the Editor request the properties of a resources
-Only reload "runtime_" resource after a resources compilation.