### PR TITLE
Editor client: Allow for `gltf` file upload

### DIFF
--- a/crates/lgn-editor-srv/src/channel_sink.rs
+++ b/crates/lgn-editor-srv/src/channel_sink.rs
@@ -1,4 +1,4 @@
-//! A generic [`EventSink`] that accepts an [`mpsc::Sender<Log>`]
+//! A generic [`EventSink`] that accepts an [`mpsc::Sender<TraceEvent>`]
 //! that will be used to send [`TraceEvent`] messages.
 
 use core::fmt;

--- a/crates/lgn-editor-srv/src/grpc.rs
+++ b/crates/lgn-editor-srv/src/grpc.rs
@@ -12,7 +12,7 @@ use tonic::{Request, Response, Status};
 
 use crate::channel_sink::TraceEvent;
 
-/// Easy to share, referenced counted version of Tokio's `UnboundedReceiver`.
+/// Easy to share, referenced counted version of Tokio's [`mpsc::UnboundedReceiver`].
 /// Can be cloned safely and will dereference to the internal [`Mutex`].
 pub(crate) struct SharedUnboundedReceiver<T>(pub(crate) Arc<Mutex<mpsc::UnboundedReceiver<T>>>);
 

--- a/crates/lgn-web-client/frontend/src/stores/files.ts
+++ b/crates/lgn-web-client/frontend/src/stores/files.ts
@@ -4,24 +4,33 @@ import { writable } from "svelte/store";
 export type FilesValue = File[] | null;
 
 export type FilesStore = Writable<FilesValue> & {
-  open(config?: { multiple?: boolean; mimeTypes?: string[] }): void;
+  open(config?: {
+    multiple?: boolean;
+    /**
+     * See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers
+     * for a complete list of accepted formats.
+     */
+    fileTypeSpecifiers?: string[];
+  }): void;
 };
 
 export function createFilesStore(): FilesStore {
   return {
     ...writable(null),
 
-    open({ multiple, mimeTypes } = {}) {
+    open({ multiple, fileTypeSpecifiers } = {}) {
       const fileInput = document.createElement("input");
 
       fileInput.type = "file";
       fileInput.multiple = !!multiple;
       fileInput.style.display = "none";
 
-      const mimes = mimeTypes?.join(",");
+      const accept = fileTypeSpecifiers
+        ?.map((fileTypeSpecifier) => fileTypeSpecifier.trim())
+        .join(",");
 
-      if (mimes) {
-        fileInput.accept = mimes;
+      if (accept) {
+        fileInput.accept = accept;
       }
 
       fileInput.addEventListener("change", (event) => {


### PR DESCRIPTION
@smartel-legion I added ".gltf" to the allow list of files that can be uploaded and use the "offline_model" resource type when creating the associated resource.

There is more work to do on the backend as we want to link the uploaded file to the resource (pretty much what we did for pngs). What do you think? Should we add another resource type just for gltf files?