### PR TITLE
Web clients: Add basics helpers and env for i18n/l10n

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -24,6 +24,8 @@
         // Iconify autocompletion
         "antfu.iconify",
         // Spell check extension
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        // Fluent/I18n syntax highlighting (used in web clients)
+        "macabeus.vscode-fluent"
     ]
 }

--- a/crates/lgn-editor-gui/frontend/package.json
+++ b/crates/lgn-editor-gui/frontend/package.json
@@ -54,6 +54,8 @@
     "vitest": "^0.6.3"
   },
   "dependencies": {
+    "@fluent/bundle": "^0.17.1",
+    "@fluent/langneg": "^0.6.1",
     "@iconify/svelte": "^2.1.2",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@lgn/proto-editor": "^0.1.0",

--- a/crates/lgn-editor-gui/frontend/src/assets/locales/en-US/example.ftl
+++ b/crates/lgn-editor-gui/frontend/src/assets/locales/en-US/example.ftl
@@ -1,0 +1,13 @@
+# Simple things are simple.
+hello-user = Hello, {$userName}!
+
+# Complex things are possible.
+shared-photos =
+    {$userName} {$photoCount ->
+        [one] added a new photo
+       *[other] added {$photoCount} new photos
+    } to {$userGender ->
+        [male] his stream
+        [female] her stream
+       *[other] their stream
+    }.

--- a/crates/lgn-editor-gui/frontend/src/assets/locales/fr-CA/example.ftl
+++ b/crates/lgn-editor-gui/frontend/src/assets/locales/fr-CA/example.ftl
@@ -1,0 +1,10 @@
+# Simple things are simple.
+hello-user = Allô {$userName}!
+
+# Complex things are possible.
+shared-photos =
+    {$userName} {$photoCount ->
+        [0] n'a ajouté aucune nouvelle photo
+        [one] a ajouté une nouvelle photo
+       *[other] a ajouté {$photoCount} nouvelles photos
+    } à son album.

--- a/crates/lgn-editor-gui/frontend/src/components/LocalizationExample.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/LocalizationExample.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import Select from "./inputs/Select.svelte";
+  import TextInput from "./inputs/TextInput.svelte";
+  import NumberInput from "./inputs/NumberInput.svelte";
+  import { availableLocales, locale, t } from "@/stores/l10n";
+
+  let userName = "Foo";
+
+  let photoCount = 0;
+
+  let userGender = "other";
+</script>
+
+<div class="bg-gray-700 h-full w-full flex flex-col px-2 space-y-2">
+  <div>
+    {$t("hello-user", { userName })}
+  </div>
+
+  <div>
+    {$t("shared-photos", { userName, photoCount: photoCount || 0, userGender })}
+  </div>
+
+  <Select
+    on:select={({ detail: newLocale }) =>
+      newLocale && ($locale = newLocale.value)}
+    value={{ item: $locale, value: $locale }}
+    options={$availableLocales.map((locale) => ({
+      item: locale,
+      value: locale,
+    }))}
+  >
+    <div slot="option" let:option>{option.item}</div>
+  </Select>
+
+  <TextInput bind:value={userName} />
+
+  <NumberInput min={0} noArrow bind:value={photoCount} />
+
+  <Select
+    on:select={({ detail: newUserGender }) =>
+      newUserGender && (userGender = newUserGender.value)}
+    value={{ item: userGender, value: userGender }}
+    options={["female", "non-binary", "male", "other"].map((gender) => ({
+      item: gender,
+      value: gender,
+    }))}
+  >
+    <div slot="option" let:option>{option.item}</div>
+  </Select>
+</div>

--- a/crates/lgn-editor-gui/frontend/src/stores/l10n.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/l10n.ts
@@ -1,0 +1,50 @@
+import { FluentBundle, FluentResource } from "@fluent/bundle";
+export type {
+  TranslateValue,
+  TranslateStore,
+} from "@lgn/web-client/src/stores/translate";
+import { createTranslateStore } from "@lgn/web-client/src/stores/translate";
+export type {
+  BundlesValue,
+  BundlesStore,
+  AvailableLocalesValue,
+  AvailableLocalesStore,
+} from "@lgn/web-client/src/stores/bundles";
+import {
+  createAvailableLocalesStore,
+  createBundlesStore,
+} from "@lgn/web-client/src/stores/bundles";
+export type {
+  LocaleValue,
+  LocaleStore,
+} from "@lgn/web-client/src/stores/locale";
+import { createLocaleStore } from "@lgn/web-client/src/stores/locale";
+import en from "@/assets/locales/en-US/example.ftl?raw";
+import fr from "@/assets/locales/fr-CA/example.ftl?raw";
+
+export const bundles = createBundlesStore();
+
+// TODO: Automatically import from folder and import only the required locale
+const enBundle = new FluentBundle(["en-US", "en"]);
+
+enBundle.addResource(new FluentResource(en));
+
+for (const locale of enBundle.locales) {
+  bundles.add(locale, enBundle);
+}
+
+const frBundle = new FluentBundle(["fr-CA", "fr"]);
+
+frBundle.addResource(new FluentResource(fr));
+
+for (const locale of frBundle.locales) {
+  bundles.add(locale, frBundle);
+}
+
+export const availableLocales = createAvailableLocalesStore(bundles);
+
+export const locale = createLocaleStore(availableLocales, {
+  defaultLocale: "en-US",
+});
+
+export const t = createTranslateStore(locale, bundles);

--- a/crates/lgn-web-client/frontend/package.json
+++ b/crates/lgn-web-client/frontend/package.json
@@ -47,6 +47,8 @@
     "vitest": "^0.6.3"
   },
   "dependencies": {
+    "@fluent/bundle": "^0.17.1",
+    "@fluent/langneg": "^0.6.1",
     "@iconify/svelte": "^2.1.2",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@lgn/proto-streaming": "^0.1.0",

--- a/crates/lgn-web-client/frontend/src/lib/store.ts
+++ b/crates/lgn-web-client/frontend/src/lib/store.ts
@@ -125,15 +125,15 @@ export function throttled<Value>(
 ): Readable<Value> {
   let lastTime: number | undefined;
 
-  return derived(store, (value, set) => {
+  return derived(store, ($value, set) => {
     const now = Date.now();
 
     if (!lastTime || now - lastTime > time) {
-      set(value);
+      set($value);
       lastTime = now;
     } else {
       const timeoutId = setTimeout(() => {
-        set(value);
+        set($value);
       }, time);
 
       return () => clearTimeout(timeoutId);

--- a/crates/lgn-web-client/frontend/src/orchestrators/viewport.ts
+++ b/crates/lgn-web-client/frontend/src/orchestrators/viewport.ts
@@ -36,7 +36,7 @@ export type AddViewportConfig = {
 };
 
 export type ViewportOrchestrator = {
-  viewportStore: MapStore<Viewport>;
+  viewportStore: MapStore<symbol, Viewport>;
   activeViewportStore: Writable<Viewport | null>;
   add(key: symbol, viewport: Viewport, { focus }: AddViewportConfig): void;
   addAllViewport(...viewportList: [key: symbol, value: Viewport][]): void;

--- a/crates/lgn-web-client/frontend/src/stores/bundles.ts
+++ b/crates/lgn-web-client/frontend/src/stores/bundles.ts
@@ -1,0 +1,24 @@
+import type { FluentBundle } from "@fluent/bundle";
+import { derived, Readable } from "svelte/store";
+import type { MapStore, MapValue } from "./map";
+import { createMapStore } from "./map";
+
+export type BundlesValue = MapValue<string, FluentBundle>;
+
+export type BundlesStore = MapStore<string, FluentBundle>;
+
+export function createBundlesStore(
+  initialBundles?: Map<string, FluentBundle>
+): BundlesStore {
+  return createMapStore(initialBundles);
+}
+
+export type AvailableLocalesValue = string[];
+
+export type AvailableLocalesStore = Readable<AvailableLocalesValue>;
+
+export function createAvailableLocalesStore(
+  bundles: BundlesStore
+): AvailableLocalesStore {
+  return derived(bundles, ($bundles) => Array.from($bundles.keys()));
+}

--- a/crates/lgn-web-client/frontend/src/stores/locale.ts
+++ b/crates/lgn-web-client/frontend/src/stores/locale.ts
@@ -1,0 +1,67 @@
+import { negotiateLanguages } from "@fluent/langneg";
+import { derived, get, Updater, Writable } from "svelte/store";
+import { writable } from "svelte/store";
+import type { AvailableLocalesStore, BundlesStore } from "./bundles";
+
+export type LocaleValue = string;
+
+export type LocaleStore = Writable<LocaleValue>;
+
+/**
+ * Stores the locale used by the user.
+ * Uses the [Fluent algorithm](https://github.com/projectfluent/fluent.js/tree/master/fluent-langneg)
+ * to decide which locale to use.
+ *
+ * Since the store is writable the locale can be set.
+ * But _only known locales will be accepted_.
+ * If the set locale is unknown, no changes are done.
+ *
+ * If you don't want to rely on any sort of algorithm,
+ * you can create a simple store on your end like follows:
+ *
+ * ```ts
+ * const localeStore = writable("xx-XX");
+ * ```
+ */
+export function createLocaleStore(
+  availableLocales: AvailableLocalesStore,
+  {
+    defaultLocale,
+    requestedLocales = navigator.languages,
+  }: {
+    defaultLocale: string;
+    /** Locales that the user wants to use, defaults to `navigator.languages` */
+    requestedLocales?: readonly string[];
+  }
+): LocaleStore {
+  const exposedStore = derived(
+    availableLocales,
+    ($availableLocales) =>
+      negotiateLanguages(requestedLocales, $availableLocales, {
+        defaultLocale: defaultLocale,
+        strategy: "lookup",
+      })[0] || defaultLocale
+  );
+
+  const store = writable(get(exposedStore));
+
+  return {
+    ...store,
+    set(locale) {
+      if (get(availableLocales).includes(locale)) {
+        store.set(locale);
+      }
+    },
+    update(f: Updater<string>) {
+      store.update((locale) => {
+        const desiredLocale = f(locale);
+
+        if (!get(availableLocales).includes(locale)) {
+          return locale;
+        }
+
+        return desiredLocale;
+      });
+    },
+  };
+}

--- a/crates/lgn-web-client/frontend/src/stores/map.ts
+++ b/crates/lgn-web-client/frontend/src/stores/map.ts
@@ -3,25 +3,25 @@ import { writable } from "svelte/store";
 
 // TODO: Also create a map orchestrator, i.e. a map of store (as opposed to a "store of map")
 
-export type MapValue<Value> = Map<symbol, Value>;
+export type MapValue<Key, Value> = Map<Key, Value>;
 
-export type MapStore<Value> = Writable<MapValue<Value>> & {
-  add(key: symbol, value: Value): void;
-  addAll(...values: [key: symbol, value: Value][]): void;
-  remove(key: symbol): boolean;
-  replace(key: symbol, value: Value): void;
-  updateAt(key: symbol, f: (value: Value) => Value): void;
+export type MapStore<Key, Value> = Writable<MapValue<Key, Value>> & {
+  add(key: Key, value: Value): void;
+  addAll(...values: [key: Key, value: Value][]): void;
+  remove(key: Key): boolean;
+  replace(key: Key, value: Value): void;
+  updateAt(key: Key, f: (value: Value) => Value): void;
   empty(): void;
 };
 
 /**
  * Simple store that contains a map.
  */
-export function createMapStore<Value>(
-  initialValue = new Map<symbol, Value>()
-): MapStore<Value> {
+export function createMapStore<Key, Value>(
+  initialValue = new Map<Key, Value>()
+): MapStore<Key, Value> {
   return {
-    ...writable<Map<symbol, Value>>(initialValue),
+    ...writable<Map<Key, Value>>(initialValue),
 
     /**
      * Adds a new value to the map if the provided key is not present yet.

--- a/crates/lgn-web-client/frontend/src/stores/translate.ts
+++ b/crates/lgn-web-client/frontend/src/stores/translate.ts
@@ -1,0 +1,38 @@
+import { derived, Readable } from "svelte/store";
+import type { FluentBundle, FluentVariable } from "@fluent/bundle";
+import type { LocaleStore } from "./locale";
+import type { BundlesStore } from "./bundles";
+
+export type TranslateValue = (
+  id: string,
+  args?: Record<string, FluentVariable> | null
+) => void;
+
+export type TranslateStore = Readable<TranslateValue>;
+
+// TODO: Add errors support
+function translate(
+  locale: string,
+  bundles: Map<string, FluentBundle>,
+  id: string,
+  args?: Record<string, FluentVariable> | null
+) {
+  const bundle = bundles.get(locale);
+
+  if (!bundle) {
+    return "";
+  }
+
+  const message = bundle.getMessage(id);
+
+  return message?.value ? bundle.formatPattern(message.value, args) : "";
+}
+
+export function createTranslateStore(
+  locale: LocaleStore,
+  bundles: BundlesStore
+): TranslateStore {
+  return derived([locale, bundles], ([$locale, $bundles]) =>
+    translate.bind(null, $locale, $bundles)
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,8 @@ importers:
 
   crates/lgn-editor-gui/frontend:
     specifiers:
+      '@fluent/bundle': ^0.17.1
+      '@fluent/langneg': ^0.6.1
       '@iconify/svelte': ^2.1.2
       '@improbable-eng/grpc-web': ^0.15.0
       '@lgn/proto-editor': ^0.1.0
@@ -182,6 +184,8 @@ importers:
       vite-tsconfig-paths: ^3.4.1
       vitest: ^0.6.3
     dependencies:
+      '@fluent/bundle': 0.17.1
+      '@fluent/langneg': 0.6.1
       '@iconify/svelte': 2.1.2
       '@improbable-eng/grpc-web': 0.15.0_google-protobuf@3.19.4
       '@lgn/proto-editor': link:../../lgn-editor-proto
@@ -425,6 +429,8 @@ importers:
 
   crates/lgn-web-client/frontend:
     specifiers:
+      '@fluent/bundle': ^0.17.1
+      '@fluent/langneg': ^0.6.1
       '@iconify/svelte': ^2.1.2
       '@improbable-eng/grpc-web': ^0.15.0
       '@lgn/proto-streaming': ^0.1.0
@@ -465,6 +471,8 @@ importers:
       vite: ^2.8.6
       vitest: ^0.6.3
     dependencies:
+      '@fluent/bundle': 0.17.1
+      '@fluent/langneg': 0.6.1
       '@iconify/svelte': 2.1.2
       '@improbable-eng/grpc-web': 0.15.0_google-protobuf@3.19.4
       '@lgn/proto-streaming': link:../../lgn-streaming-proto
@@ -903,6 +911,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@fluent/bundle/0.17.1:
+    resolution: {integrity: sha512-CRFNT9QcSFAeFDneTF59eyv3JXFGhIIN4boUO2y22YmsuuKLyDk+N1I/NQUYz9Ab63e6V7T6vItoZIG/2oOOuw==}
+    engines: {node: '>=12.0.0', npm: '>=7.0.0'}
+    dev: false
+
+  /@fluent/langneg/0.6.1:
+    resolution: {integrity: sha512-BlP1MNHEtTRKd2Mq/twrFtHIzIBK4snG3t3dKAE1OR6RPOlxt7fzx7Q4jQvBrMPkm6OTg0u6d0ZrcH9XkSvINQ==}
+    engines: {node: '>=12.0.0', npm: '>=7.0.0'}
+    dev: false
 
   /@humanwhocodes/config-array/0.9.5:
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}


### PR DESCRIPTION
## Summary

Basic support for l10n which include:
- Locales (en-US, fr-CA, etc..)
- Bundles (i.e. dictionaries of ids/values)
- Dynamic translation (via the simple `$t(...)` store function)

All of the above are dynamic and reactive, which means we can easily change the locale at runtime, or load any dictionary when needed.

Messages themselves are written in [Fluent](https://projectfluent.org/) and can be accessed in the code as follows:

The implementation is inspired by https://www.npmjs.com/package/fluent-vue, except that the bundles have to be written outside the components.

## Example

```svelte
<script>
  let someArg = "default value";
</script>

<div>
  {$t("my-message", { someArg })}
</div>

<input bind:value={someArg} />
```

## Pros

- Once setup, the contributors can a new locale/dictionary in "src/assets/locales" and it should just work from there.
- We can move away from Fluent at any time as the api is flexible and abstract enough.
- L10n not I18n, we target a proper localization not just a clumsy word for word translation

## Concerns and improvements

- Performance could be an issue with the `$t` store function as the functions are built again and again on each changes. In many case, and since local change is low frequency it should be fine though
- For now I load all the dictionaries at once, we should load only the required one(s) on the fly to save some space in memory
- It's easy to "break" a message, if there's a typo in the message id, or if an argument is missing. Unfortunately it seems there is no way to validate at compile time that everything's ok with Fluent (notice that any other solution would have a similar problem).
- I would love to make this work with https://github.com/lokalise/i18n-ally