### PR TITLE
Timeline: adding 2px darker pixel to spans to increase readability

### DIFF
--- a/crates/lgn-analytics-gui/frontend/src/lib/Timeline/SpanRender.ts
+++ b/crates/lgn-analytics-gui/frontend/src/lib/Timeline/SpanRender.ts
@@ -68,6 +68,13 @@ export function drawSpanTrack(
     ctx.fillRect(beginPixels, offsetY, callWidth, spanPixelHeight);
     ctx.globalAlpha = 1.0;
 
+    if (callWidth >= 16) {
+      ctx.save();
+      ctx.fillStyle = shadeColor(ctx.fillStyle, 1.025);
+      ctx.fillRect(beginPixels, offsetY, 2, spanPixelHeight);
+      ctx.restore();
+    }
+
     if (span.scopeHash != 0) {
       if (callWidth > characterWidth * 5) {
         // const nbChars = Math.floor(callWidth / characterWidth);
@@ -157,4 +164,29 @@ function* getCaptions(
     font: "12px arial",
     skippable: true,
   };
+}
+
+function shadeColor(color: string, decimal: number): string {
+  const base = color.startsWith("#") ? 1 : 0;
+
+  let r = parseInt(color.substring(base, 3), 16);
+  let g = parseInt(color.substring(base + 2, 5), 16);
+  let b = parseInt(color.substring(base + 4, 7), 16);
+
+  r = Math.round(r / decimal);
+  g = Math.round(g / decimal);
+  b = Math.round(b / decimal);
+
+  r = r < 255 ? r : 255;
+  g = g < 255 ? g : 255;
+  b = b < 255 ? b : 255;
+
+  const rr =
+    r.toString(16).length === 1 ? `0${r.toString(16)}` : r.toString(16);
+  const gg =
+    g.toString(16).length === 1 ? `0${g.toString(16)}` : g.toString(16);
+  const bb =
+    b.toString(16).length === 1 ? `0${b.toString(16)}` : b.toString(16);
+
+  return `#${rr}${gg}${bb}`;
 }


### PR DESCRIPTION
Creates a very subtle darker line which shows that we have spans _inside_ spans

![image](https://user-images.githubusercontent.com/98831755/158898439-8f3833b9-e94f-4548-b5af-9c445b95367f.png)
