### PR TITLE
Editor srv drop channel prevent spam

### DIFF
--- a/crates/lgn-ecs/src/system/commands/mod.rs
+++ b/crates/lgn-ecs/src/system/commands/mod.rs
@@ -1,6 +1,6 @@
 mod command_queue;
 
-use std::marker::PhantomData;
+use std::{any, marker::PhantomData};
 
 pub use command_queue::CommandQueue;
 use lgn_tracing::{error, warn};
@@ -736,7 +736,9 @@ where
 {
     fn write(self, world: &mut World) {
         if let Some(mut entity_mut) = world.get_entity_mut(self.entity) {
-            entity_mut.remove::<T>();
+            if entity_mut.remove::<T>().is_none() {
+                warn!("{} couldn't be removed from world, this might cause some tasks to be unnecessarily spawned", any::type_name::<T>());
+            }
         }
     }
 }

--- a/crates/lgn-streamer/src/streamer/mod.rs
+++ b/crates/lgn-streamer/src/streamer/mod.rs
@@ -16,6 +16,7 @@ use lgn_input::{
 };
 use lgn_tracing::{error, info, trace, warn};
 use lgn_window::{WindowCreated, WindowResized, Windows};
+use serde_json::json;
 use webrtc::{
     data_channel::{data_channel_message::DataChannelMessage, RTCDataChannel},
     peer_connection::RTCPeerConnection,
@@ -322,7 +323,8 @@ pub(crate) fn on_render_surface_created_for_window(
             .unwrap();
             render_surface.register_presenter(|| video_stream);
 
-            let _ = video_data_channel.send(&Bytes::from(r#"{"type": "initialized"}"#));
+            let _ =
+                video_data_channel.send(&Bytes::from(json!({ "type": "initialized"}).to_string()));
         }
     }
 }


### PR DESCRIPTION
It seems the reason why we get all the "DataChannel is not opened" is because the RenderSurface removable [here](https://github.com/legion-labs/legion/blob/main/crates/lgn-streamer/src/streamer/mod.rs#L155) (and ultimately [there](https://github.com/legion-labs/legion/blob/main/crates/lgn-ecs/src/world/entity_ref.rs#L220)) doesn't work.

Since the fix may take a bit more time here is a temporary fix that should, at least, prevent the log spamming