### PR TITLE
Editor client: Speed up webtrc connection init (+ other player improvements)

### DIFF
--- a/crates/lgn-editor-srv/src/main.rs
+++ b/crates/lgn-editor-srv/src/main.rs
@@ -190,6 +190,7 @@ fn main() {
     let assets_to_load = Vec::<ResourceTypeAndId>::new();
 
     let (trace_events_sender, trace_events_receiver) = mpsc::unbounded_channel();
+
     let telemetry_guard = TelemetryGuardBuilder::default()
         .add_sink(LevelFilter::Info, ChannelSink::new(trace_events_sender))
         .build()

--- a/crates/lgn-web-client/frontend/src/components/panel/ViewportPanel.svelte
+++ b/crates/lgn-web-client/frontend/src/components/panel/ViewportPanel.svelte
@@ -44,7 +44,7 @@
       <div />
     {:else if activeTab.type === "video"}
       {#if activeTab.name === "editor" || activeTab.name === "runtime"}
-        {#key activeTab}
+        {#key activeTab.name}
           <RemoteWindow
             serverType={activeTab.name}
             bind:desiredResolution={desiredVideoResolution}


### PR DESCRIPTION
This PR drastically improves the player performance:
- Much, much faster connection: 40s to 1s on my machine
- Player is more consistent, and more resilient
- Player is not frozen as often
- Loading screen improved (resizing will hide the player again for the time being, until we have a cleaner solution)

Remains:
- Improving ICE candidates exchange
- Fix render surface not being dropped (leading to some drastic slow downs after some refreshes)
- Still noticed the player "freezing" at times (pretty rare)