### PR TITLE
Monorepo: Add --force/--force-npm-build flags to some commands

### DIFF
--- a/build/monorepo/src/build.rs
+++ b/build/monorepo/src/build.rs
@@ -27,6 +27,10 @@ pub struct Args {
     /// even if the --npm-install flag is present
     #[clap(long)]
     pub(crate) skip_npm_build: bool,
+    /// Forces the associated npm package build
+    /// Doesn't work if `--skip-npm-build` is used
+    #[clap(long, short)]
+    pub(crate) force_npm_build: bool,
     /// First install npm packages
     #[clap(long)]
     pub(crate) npm_install: bool,
@@ -79,7 +83,7 @@ pub fn run(mut args: Args, ctx: &Context) -> Result<()> {
                 npm_workspace.install();
             }
 
-            npm_workspace.build(&None)?;
+            npm_workspace.build(&None, args.force_npm_build)?;
         }
     }
 

--- a/build/monorepo/src/npm/build.rs
+++ b/build/monorepo/src/npm/build.rs
@@ -13,6 +13,9 @@ pub struct Args {
     /// If this flag is present the dependencies will be installed
     #[clap(long, short)]
     pub(crate) install: bool,
+    /// Forces the build
+    #[clap(long, short)]
+    pub(crate) force: bool,
 }
 
 #[span_fn]
@@ -25,7 +28,7 @@ pub fn run(args: &Args, ctx: &Context) -> Result<()> {
         npm_workspace.install();
     }
 
-    npm_workspace.build(&args.package)?;
+    npm_workspace.build(&args.package, args.force)?;
 
     Ok(())
 }

--- a/build/monorepo/src/run.rs
+++ b/build/monorepo/src/run.rs
@@ -24,6 +24,10 @@ pub struct Args {
     /// even if the --npm-install flag is present
     #[clap(long)]
     pub(crate) skip_npm_build: bool,
+    /// Forces the associated npm package build
+    /// Doesn't work if `--skip-npm-build` is used
+    #[clap(long, short)]
+    pub(crate) force_npm_build: bool,
     /// First install npm packages
     #[clap(long)]
     pub(crate) npm_install: bool,
@@ -61,7 +65,7 @@ pub fn run(args: &Args, ctx: &Context) -> Result<()> {
                 npm_workspace.install();
             }
 
-            npm_workspace.build(&None)?;
+            npm_workspace.build(&None, args.force_npm_build)?;
         }
     }
 


### PR DESCRIPTION
TL;TD; The new recommended way to run the client in debug mode (if you're not too comfortable with the npm ecosystem) is:

```
cargo m run -p editor-client --npm-install --force-npm-build
```

---

The main pain point currently with the way we handle npm packages in cargo monorepo seems to be the fact we don't properly rebuild the application when needed.

For the time being we only check for the source files and rebuild only if the dist folder is older than the last edited file in src. This means that any changes in proto files or in local dependencies (like @lng/web-client) will trigger a build.

It's worth mentioning there's no incremental/cached compilation in Vite.js (I'm aware of) so it's something we'd have to implement ourselves, one way being to analyze the package.json and look for any dependencies that are in the workspace.

