### PR TITLE
Web clients: More reliable cargo m npm check

### DIFF
--- a/.github/workflows/reusable_node_ecosystem.yml
+++ b/.github/workflows/reusable_node_ecosystem.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Npm check
         run: pnpm check
 
+      # TODO: Reactivate script when it's fixed
+      # - name: Npm test
+      #   run: pnpm test
+
   build:
     name: Build
     needs: [check]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6237,6 +6243,7 @@ dependencies = [
  "camino",
  "clap 3.1.6",
  "determinator",
+ "dunce",
  "fs_extra",
  "glob",
  "globset",

--- a/build/monorepo/Cargo.toml
+++ b/build/monorepo/Cargo.toml
@@ -18,6 +18,7 @@ atty = "0.2.14"
 camino = "1.0.7"
 clap = { version = "3.0", features = ["derive"] }
 determinator = "0.7.0"
+dunce = "1.0.2"
 fs_extra = "1.2.0"
 glob = "0.3.0"
 globset = "0.4.8"

--- a/build/monorepo/src/npm/check.rs
+++ b/build/monorepo/src/npm/check.rs
@@ -10,6 +10,13 @@ pub struct Args {
     /// If provided only this npm package is checked
     #[clap(long, short)]
     pub(crate) package: Option<String>,
+    /// Skips the build step, resulting in a faster but
+    /// less reliable check
+    #[clap(long, short)]
+    pub(crate) skip_build: bool,
+    /// First install npm packages
+    #[clap(long)]
+    pub(crate) npm_install: bool,
 }
 
 #[span_fn]
@@ -18,7 +25,16 @@ pub fn run(args: &Args, ctx: &Context) -> Result<()> {
 
     npm_workspace.load_all();
 
-    npm_workspace.check(&args.package)?;
+    if !npm_workspace.is_empty() {
+        if args.npm_install {
+            npm_workspace.install();
+        }
 
+        if !args.skip_build {
+            npm_workspace.build(&args.package, true)?;
+        }
+
+        npm_workspace.check(&args.package)?;
+    }
     Ok(())
 }

--- a/build/monorepo/src/npm/utils.rs
+++ b/build/monorepo/src/npm/utils.rs
@@ -7,7 +7,7 @@ use std::{
     process::Command,
 };
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 use monorepo_base::{action_step, error_step, skip_step};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::Deserialize;
@@ -105,13 +105,6 @@ impl NpmPackage {
     }
 
     pub fn install<P: AsRef<Path>>(&self, package_manager_path: P) {
-        action_step!(
-            "Npm Install",
-            "{} ({})",
-            self.package_json.name,
-            self.path.to_string_lossy()
-        );
-
         let cmd_name = "Install";
 
         self.print_action_step(cmd_name);
@@ -565,8 +558,10 @@ impl<'a> NpmWorkspace<'a> {
         self.packages.is_empty()
     }
 
-    fn root(&self) -> &Utf8Path {
-        self.ctx.workspace_root()
+    fn root(&self) -> Utf8PathBuf {
+        let canonalized_root_path = dunce::canonicalize(self.ctx.workspace_root()).unwrap();
+
+        canonalized_root_path.to_string_lossy().as_ref().into()
     }
 
     fn config(&self) -> &MonorepoConfig {


### PR DESCRIPTION
The "cargo m npm check" command will always run the build first by default, this prevents any false positive/negative results when the check is performed on a stale build. The build can be skipped using the "--skip-build" flag
