### PR TITLE
Editor server: Broadcast events and logs

### DIFF
--- a/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
@@ -21,7 +21,7 @@
     currentResource,
     fetchCurrentResourceDescription,
   } from "@/orchestrators/currentResource";
-  import { components, extension, join } from "@/lib/path";
+  import { components, join } from "@/lib/path";
   import notifications from "@/stores/notifications";
   import type { Entries, Entry } from "@/lib/hierarchyTree";
   import { isEntry } from "@/lib/hierarchyTree";

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/currentResource.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/currentResource.ts
@@ -15,19 +15,19 @@ const currentResourceOrchestrator: CurrentResourceOrchestrator =
 export const { data: currentResource, error: currentResourceError } =
   currentResourceOrchestrator;
 
-export function fetchCurrentResourceDescription(
+export async function fetchCurrentResourceDescription(
   id: string,
   { notifySelection = true }: { notifySelection?: boolean } = {}
-) {
+): Promise<void> {
   // Ignore folder without id
   if (!id) {
     return;
   }
 
   try {
-    currentResourceOrchestrator.run(() => {
+    await currentResourceOrchestrator.run(async () => {
       if (notifySelection) {
-        updateSelection(id);
+        await updateSelection(id);
       }
 
       return getResourceProperties(id);

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/selection.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/selection.ts
@@ -1,0 +1,52 @@
+// This orchestrator manipulates several stores related to the current selection(s),
+// that is, the element(s) selected in the viewport/resource browser/scene explorer.
+//
+// This orchestrator doesn't own any stores.
+
+import { get } from "svelte/store";
+import { initMessageStream as initMessageStreamApi } from "@/api";
+import {
+  resourceEntries,
+  currentResourceDescriptionEntry,
+} from "./resourceBrowserEntries";
+import { MessageType } from "@lgn/proto-editor/dist/editor";
+import { fetchCurrentResourceDescription } from "@/orchestrators/currentResource";
+import { isEntry } from "@/lib/hierarchyTree";
+
+export async function initMessageStream() {
+  const messageStream = await initMessageStreamApi();
+
+  messageStream.subscribe(({ lagging, message }) => {
+    if (typeof lagging === "number") {
+      // TODO: Handle lagging messages
+
+      return;
+    }
+
+    if (message) {
+      switch (message.msgType) {
+        case MessageType.SelectionChanged: {
+          const resourceIds: string[] = JSON.parse(message.payload);
+
+          // TODO: Catch error
+          // TODO: Support multi-select (remove slice)
+          if (!resourceIds.length) {
+            currentResourceDescriptionEntry.set(null);
+
+            return;
+          }
+
+          fetchCurrentResourceDescription(resourceIds[0], {
+            notifySelection: false,
+          });
+
+          const selectedEntry = get(resourceEntries).find(
+            (entry) => isEntry(entry) && resourceIds.includes(entry.item.id)
+          );
+
+          currentResourceDescriptionEntry.set(selectedEntry);
+        }
+      }
+    }
+  });
+}

--- a/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
@@ -10,13 +10,9 @@
   import { goto } from "$app/navigation";
   import "@/workers/editorWorker";
   import { initStagedResourcesStream } from "@/stores/stagedResources";
-  import { get } from "svelte/store";
-  import { initApiClient, initMessageStream } from "@/api";
+  import { initApiClient } from "@/api";
   import { initLogStream } from "@/stores/log";
-  import {
-    resourceEntries,
-    currentResourceDescriptionEntry,
-  } from "@/orchestrators/resourceBrowserEntries";
+  import { initMessageStream } from "@/orchestrators/selection";
 
   const logLevel = "warn";
 
@@ -77,31 +73,9 @@
           // TODO: When using routing we may want to cancel the returned subscription
           initLogStream();
 
-          const messageStream = await initMessageStream();
-
-          messageStream.subscribe((logEntry) => {
-            if (logEntry.msgType == MessageType.SelectionChanged) {
-              const resourceIds: string[] = JSON.parse(logEntry.payload);
-
-              // TODO: Catch error
-              // TODO: Support multi-select (remove slice)
-              if (!resourceIds.length) {
-                currentResourceDescriptionEntry.set(null);
-              } else {
-                fetchCurrentResourceDescription(resourceIds[0], {
-                  notifySelection: false,
-                });
-                const selectedEntry = get(resourceEntries).find(
-                  (entry) =>
-                    isEntry(entry) && resourceIds.includes(entry.item.id)
-                );
-
-                currentResourceDescriptionEntry.set(selectedEntry);
-              }
-            }
-          });
-
-          // Defaulting to "trace" if the severity cannot be converted from the level
+          // Fire and forget stream init
+          // TODO: When using routing we may want to cancel the returned subscription
+          initMessageStream();
 
           // Fire and forget stream init
           // TODO: When using routing we may want to cancel the returned subscription
@@ -137,9 +111,6 @@
 
 <script lang="ts">
   import "../assets/index.css";
-  import { MessageType } from "@lgn/proto-editor/dist/editor";
-  import { fetchCurrentResourceDescription } from "@/orchestrators/currentResource";
-  import { isEntry } from "@/lib/hierarchyTree";
 </script>
 
 <slot />

--- a/crates/lgn-editor-proto/protos/editor.proto
+++ b/crates/lgn-editor-proto/protos/editor.proto
@@ -34,18 +34,32 @@ enum Level {
   TRACE = 4;
 }
 
-message InitLogStreamResponse {
+message TraceEvent {
   Level level = 1;
   int64 time = 2;
   string target = 3;
   string message = 4;
 }
 
+message InitLogStreamResponse {
+  oneof response {
+    TraceEvent trace_event = 1;
+    uint64 lagging = 2;
+  }
+}
+
 message InitMessageStreamRequest {}
 
 enum MessageType { SelectionChanged = 0; }
 
-message InitMessageStreamResponse {
+message Message {
   MessageType msg_type = 1;
   string payload = 2;
+}
+
+message InitMessageStreamResponse {
+  oneof response {
+    Message message = 1;
+    uint64 lagging = 2;
+  }
 }

--- a/crates/lgn-editor-srv/src/broadcast_sink.rs
+++ b/crates/lgn-editor-srv/src/broadcast_sink.rs
@@ -1,4 +1,4 @@
-//! A generic [`EventSink`] that accepts an [`mpsc::Sender<TraceEvent>`]
+//! A generic [`EventSink`] that accepts an [`broadcast::Sender<TraceEvent>`]
 //! that will be used to send [`TraceEvent`] messages.
 
 use core::fmt;
@@ -11,9 +11,9 @@ use lgn_tracing::{
     spans::{ThreadBlock, ThreadStream},
     Level, ProcessInfo,
 };
-use tokio::sync::mpsc;
+use tokio::sync::broadcast;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TraceEvent {
     Startup(ProcessInfo),
     Shutdown,
@@ -31,12 +31,12 @@ pub enum TraceEvent {
     ProcessThreadBlock(Arc<ThreadBlock>),
 }
 
-pub struct ChannelSink {
-    sender: mpsc::UnboundedSender<TraceEvent>,
+pub struct BroadcastSink {
+    sender: broadcast::Sender<TraceEvent>,
 }
 
-impl ChannelSink {
-    pub fn new(sender: mpsc::UnboundedSender<TraceEvent>) -> Self {
+impl BroadcastSink {
+    pub fn new(sender: broadcast::Sender<TraceEvent>) -> Self {
         Self { sender }
     }
 
@@ -47,7 +47,7 @@ impl ChannelSink {
     }
 }
 
-impl EventSink for ChannelSink {
+impl EventSink for BroadcastSink {
     fn on_startup(&self, process_info: ProcessInfo) {
         self.send(TraceEvent::Startup(process_info));
     }

--- a/crates/lgn-editor-srv/src/plugin.rs
+++ b/crates/lgn-editor-srv/src/plugin.rs
@@ -22,7 +22,7 @@ use lgn_input::{
 use lgn_scene_plugin::ActiveScenes;
 use lgn_tracing::{error, info, warn};
 use lgn_transform::components::Transform;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{broadcast, Mutex};
 
 use crate::grpc::TraceEventsReceiver;
 use crate::grpc::{SelectionEvent, SelectionEventsReceiver};
@@ -35,8 +35,7 @@ pub struct EditorPlugin;
 
 impl Plugin for EditorPlugin {
     fn build(&self, app: &mut App) {
-        let (selection_events_sender, selection_events_receiver) =
-            mpsc::unbounded_channel::<SelectionEvent>();
+        let (selection_events_sender, selection_events_receiver) = broadcast::channel(1_000);
         let selection_events_receiver: SelectionEventsReceiver = selection_events_receiver.into();
 
         app
@@ -78,7 +77,7 @@ impl EditorPlugin {
         selection_manager: Res<'_, Arc<SelectionManager>>,
         picking_manager: Res<'_, PickingManager>,
         active_scenes: Res<'_, ActiveScenes>,
-        event_sender: Res<'_, mpsc::UnboundedSender<SelectionEvent>>,
+        event_sender: Res<'_, broadcast::Sender<SelectionEvent>>,
     ) {
         if let Some(selection) = selection_manager.update() {
             // Convert the SelectionManager offlineId to RuntimeId


### PR DESCRIPTION
Allows for multiple client subscribing to the logs/events.

[Lagging](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#lagging) is handled server side and a message is dispatch when the streams are lagging. The client doesn't let the user know for now (mostly a UX issue) 