### PR TITLE
Web clients: Sort imports (finally)

### DIFF
--- a/crates/lgn-editor-gui/frontend/.prettierrc
+++ b/crates/lgn-editor-gui/frontend/.prettierrc
@@ -1,1 +1,5 @@
-{}
+{
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrder": ["^@lgn\\/", "^@\\/", "^\\."]
+}

--- a/crates/lgn-editor-gui/frontend/benchmarks/index.ts
+++ b/crates/lgn-editor-gui/frontend/benchmarks/index.ts
@@ -1,5 +1,4 @@
 import { run } from "./benchmark";
-
 // Import a .bench file here so it can be executed by the `pnpm benchmark` command
 import { bigResourcesSuite, resourcesSuite } from "./lib/hierarchyTree.bench";
 

--- a/crates/lgn-editor-gui/frontend/benchmarks/lib/hierarchyTree.bench.ts
+++ b/crates/lgn-editor-gui/frontend/benchmarks/lib/hierarchyTree.bench.ts
@@ -1,7 +1,7 @@
-import { suite } from "../benchmark";
-
 import { Entries, isEntry } from "@/lib/hierarchyTree";
 import type { Entry } from "@/lib/hierarchyTree";
+
+import { suite } from "../benchmark";
 import resources from "../resources/resourcesResponse.json";
 
 // Dumb polyfill for `getRandomValues`

--- a/crates/lgn-editor-gui/frontend/benchmarks/vite.config.js
+++ b/crates/lgn-editor-gui/frontend/benchmarks/vite.config.js
@@ -1,11 +1,11 @@
 // @ts-check
-
 import { svelte } from "@sveltejs/vite-plugin-svelte";
-import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
-import viteTsProto from "@lgn/vite-plugin-ts-proto";
 import path from "path";
 import { fileURLToPath } from "url";
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import viteTsProto from "@lgn/vite-plugin-ts-proto";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/crates/lgn-editor-gui/frontend/package.json
+++ b/crates/lgn-editor-gui/frontend/package.json
@@ -30,6 +30,7 @@
     "@swc/core": "^1.2.161",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/svelte": "^3.1.0",
+    "@trivago/prettier-plugin-sort-imports": "^3.2.0",
     "@types/color-convert": "^2.0.0",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.16.0",

--- a/crates/lgn-editor-gui/frontend/src/actions/contextMenu.ts
+++ b/crates/lgn-editor-gui/frontend/src/actions/contextMenu.ts
@@ -1,4 +1,5 @@
 import buildContextMenu from "@lgn/web-client/src/actions/contextMenu";
+
 import type { ContextMenuEntryRecord } from "@/stores/contextMenu";
 
 export default buildContextMenu<ContextMenuEntryRecord>();

--- a/crates/lgn-editor-gui/frontend/src/api/index.ts
+++ b/crates/lgn-editor-gui/frontend/src/api/index.ts
@@ -1,23 +1,25 @@
 import type { Observable } from "rxjs";
-import log from "@lgn/web-client/src/lib/log";
+
 import {
-  GrpcWebImpl as EditorResourceBrowserWebImpl,
-  ResourceBrowserClientImpl,
-  ResourceDescription,
-} from "@lgn/proto-editor/dist/resource_browser";
-import {
-  GrpcWebImpl as EditorImpl,
   EditorClientImpl,
+  GrpcWebImpl as EditorImpl,
 } from "@lgn/proto-editor/dist/editor";
 import {
   GrpcWebImpl as EditorPropertyInspectorWebImpl,
   PropertyInspectorClientImpl,
 } from "@lgn/proto-editor/dist/property_inspector";
 import {
+  GrpcWebImpl as EditorResourceBrowserWebImpl,
+  ResourceBrowserClientImpl,
+  ResourceDescription,
+} from "@lgn/proto-editor/dist/resource_browser";
+import {
   GrpcWebImpl as EditorSourceControlWebImpl,
   SourceControlClientImpl,
   UploadRawFileResponse,
 } from "@lgn/proto-editor/dist/source_control";
+import log from "@lgn/web-client/src/lib/log";
+
 import { formatProperties } from "../lib/propertyGrid";
 import type {
   ResourcePropertyWithValue,

--- a/crates/lgn-editor-gui/frontend/src/components/AuthModal.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/AuthModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
   import Button from "@lgn/web-client/src/components/Button.svelte";
+  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
 
   export let authorizationUrl: string;
 

--- a/crates/lgn-editor-gui/frontend/src/components/ExtraPanel.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/ExtraPanel.svelte
@@ -4,8 +4,9 @@ Contains all the "extra" panels like Log or Source Control.
 -->
 <script lang="ts">
   import { Panel } from "@lgn/web-client/src/components/panel";
-  import LocalChanges from "./localChanges/LocalChanges.svelte";
+
   import Log from "./Log.svelte";
+  import LocalChanges from "./localChanges/LocalChanges.svelte";
 
   const tabs = [
     { type: "sourceControl", title: "My Local Changes" } as const,

--- a/crates/lgn-editor-gui/frontend/src/components/LocalizationExample.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/LocalizationExample.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import { availableLocales, locale, t } from "@/stores/l10n";
+
+  import NumberInput from "./inputs/NumberInput.svelte";
   import Select from "./inputs/Select.svelte";
   import TextInput from "./inputs/TextInput.svelte";
-  import NumberInput from "./inputs/NumberInput.svelte";
-  import { availableLocales, locale, t } from "@/stores/l10n";
 
   let userName = "Foo";
 

--- a/crates/lgn-editor-gui/frontend/src/components/Log.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/Log.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import { buffer, logEntries } from "@/stores/log";
+  import { writable } from "svelte/store";
+
   import type { ScrollStatus } from "@lgn/web-client/src/components/Log.svelte";
   import Log from "@lgn/web-client/src/components/Log.svelte";
-  import { writable } from "svelte/store";
+
+  import { buffer, logEntries } from "@/stores/log";
 
   const scrollStatus = writable<ScrollStatus | null>(null);
 </script>

--- a/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+  import Icon from "@iconify/svelte";
+
   import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
+  import { UploadStatus } from "@lgn/proto-editor/dist/source_control";
   import { Panel, PanelHeader } from "@lgn/web-client/src/components/panel";
-  import HierarchyTree from "./hierarchyTree/HierarchyTree.svelte";
-  import ResourceFilter from "./resources/ResourceFilter.svelte";
+  import { readFile } from "@lgn/web-client/src/lib/files";
+  import log from "@lgn/web-client/src/lib/log";
+  import { createFilesStore } from "@lgn/web-client/src/stores/files";
+  import { autoClose, select } from "@lgn/web-client/src/types/contextMenu";
+  import type { Event as ContextMenuActionEvent } from "@lgn/web-client/src/types/contextMenu";
+
   import contextMenu from "@/actions/contextMenu";
   import {
     cloneResource,
@@ -16,29 +23,25 @@
     reparentResources,
     streamFileUpload,
   } from "@/api";
-  import allResources from "@/stores/allResources";
+  import type { Entries, Entry } from "@/lib/hierarchyTree";
+  import { isEntry } from "@/lib/hierarchyTree";
+  import { components, join } from "@/lib/path";
+  import { formatProperties } from "@/lib/propertyGrid";
+  import type { ResourceProperty } from "@/lib/propertyGrid";
+  import type { BagResourceProperty } from "@/lib/propertyGrid";
+  import { iconFor } from "@/lib/resourceBrowser";
   import {
     currentResource,
     fetchCurrentResourceDescription,
   } from "@/orchestrators/currentResource";
-  import { components, join } from "@/lib/path";
-  import notifications from "@/stores/notifications";
-  import type { Entries, Entry } from "@/lib/hierarchyTree";
-  import { isEntry } from "@/lib/hierarchyTree";
-  import log from "@lgn/web-client/src/lib/log";
-  import { createFilesStore } from "@lgn/web-client/src/stores/files";
-  import { UploadStatus } from "@lgn/proto-editor/dist/source_control";
-  import { readFile } from "@lgn/web-client/src/lib/files";
-  import { formatProperties } from "@/lib/propertyGrid";
-  import type { ResourceProperty } from "@/lib/propertyGrid";
-  import type { BagResourceProperty } from "@/lib/propertyGrid";
-  import { autoClose, select } from "@lgn/web-client/src/types/contextMenu";
-  import type { Event as ContextMenuActionEvent } from "@lgn/web-client/src/types/contextMenu";
+  import allResources from "@/stores/allResources";
   import type { ContextMenuEntryRecord } from "@/stores/contextMenu";
   import modal from "@/stores/modal";
+  import notifications from "@/stores/notifications";
+
+  import HierarchyTree from "./hierarchyTree/HierarchyTree.svelte";
   import CreateResourceModal from "./resources/CreateResourceModal.svelte";
-  import Icon from "@iconify/svelte";
-  import { iconFor } from "@/lib/resourceBrowser";
+  import ResourceFilter from "./resources/ResourceFilter.svelte";
 
   const createResourceModalId = Symbol.for("create-resource-modal");
 

--- a/crates/lgn-editor-gui/frontend/src/components/SceneExplorer.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/SceneExplorer.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import { fetchCurrentResourceDescription } from "@/orchestrators/currentResource";
+  import { createEventDispatcher } from "svelte";
+
   import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
   import Panel from "@lgn/web-client/src/components/panel/Panel.svelte";
   import PanelList from "@lgn/web-client/src/components/panel/PanelList.svelte";
+
   import type { Entries } from "@/lib/hierarchyTree";
-  import { createEventDispatcher } from "svelte";
+  import { fetchCurrentResourceDescription } from "@/orchestrators/currentResource";
 
   const dispatch = createEventDispatcher<{
     currentResourceDescriptionChange: ResourceDescription;

--- a/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import { Entries, isEntry } from "@/lib/hierarchyTree";
-  import type { Entry } from "@/lib/hierarchyTree";
+
   import keyboardNavigation from "@lgn/web-client/src/actions/keyboardNavigation";
   import { createKeyboardNavigationStore } from "@lgn/web-client/src/stores/keyboardNavigation";
+
+  import { Entries, isEntry } from "@/lib/hierarchyTree";
+  import type { Entry } from "@/lib/hierarchyTree";
+
   import HierarchyTreeItem from "./HierarchyTreeItem.svelte";
 
   type Item = $$Generic<{ id: string; path: string }>;

--- a/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTreeItem.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTreeItem.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
+  import Icon from "@iconify/svelte";
+  import { createEventDispatcher } from "svelte";
+
+  import {
+    draggable as draggableAction,
+    dropzone as dropzoneAction,
+    isDragging,
+  } from "@lgn/web-client/src/actions/dnd";
+  import { keyboardNavigationItem as keyboardNavigationItemAction } from "@lgn/web-client/src/actions/keyboardNavigation";
+  import { nullable as nullableAction } from "@lgn/web-client/src/lib/action";
+
+  import contextMenuAction from "@/actions/contextMenu";
   import { isEntry } from "@/lib/hierarchyTree";
   import type { Entry } from "@/lib/hierarchyTree";
-  import { createEventDispatcher } from "svelte";
   import { extension } from "@/lib/path";
-  import Icon from "@iconify/svelte";
-  import { keyboardNavigationItem as keyboardNavigationItemAction } from "@lgn/web-client/src/actions/keyboardNavigation";
-  import contextMenuAction from "@/actions/contextMenu";
+
   import TextInput from "../inputs/TextInput.svelte";
-  import {
-    isDragging,
-    dropzone as dropzoneAction,
-    draggable as draggableAction,
-  } from "@lgn/web-client/src/actions/dnd";
-  import { nullable as nullableAction } from "@lgn/web-client/src/lib/action";
 
   type Item = $$Generic<{ id: string }>;
 

--- a/crates/lgn-editor-gui/frontend/src/components/inputs/ColorPicker.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/inputs/ColorPicker.svelte
@@ -12,8 +12,9 @@ It also supports manual RGBA edition with 4 different inputs.
 -->
 <script lang="ts">
   // TODO: We could split this component into several components (Hue, SaturationValue, RGBA, etc...)
-
   import colorConvert from "color-convert";
+  import { createEventDispatcher } from "svelte";
+
   import {
     colorSetFromHsv,
     colorSetFromRgba,
@@ -22,8 +23,8 @@ It also supports manual RGBA edition with 4 different inputs.
     rgbaToColorString,
   } from "@/lib/colors";
   import type { ColorSet, Rgba } from "@/lib/colors";
+
   import NumberInput from "./NumberInput.svelte";
-  import { createEventDispatcher } from "svelte";
 
   const dispatch = createEventDispatcher<{ change: ColorSet }>();
 

--- a/crates/lgn-editor-gui/frontend/src/components/inputs/Select.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/inputs/Select.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import Icon from "@iconify/svelte";
+  import { createEventDispatcher } from "svelte";
+
   import clickOutside from "@lgn/web-client/src/actions/clickOutside";
   import keyboardNavigation, {
-    keyboardNavigationItem,
     keyboardNavigationContainer,
+    keyboardNavigationItem,
   } from "@lgn/web-client/src/actions/keyboardNavigation";
   import { createKeyboardNavigationStore } from "@lgn/web-client/src/stores/keyboardNavigation";
 

--- a/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChanges.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChanges.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { PanelHeader } from "@lgn/web-client/src/components/panel";
+
   import {
     stagedResources,
     stagedResourcesMode,
   } from "@/stores/stagedResources";
-  import { PanelHeader } from "@lgn/web-client/src/components/panel";
+
   import LocalChangesGrid from "./LocalChangesGrid.svelte";
   import LocalChangesHeader from "./LocalChangesHeader.svelte";
   import LocalChangesList from "./LocalChangesList.svelte";

--- a/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesGrid.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesGrid.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { fileName } from "@/lib/path";
   import { StagedResource_ChangeType as ChangeType } from "@lgn/proto-editor/dist/source_control";
   import type { StagedResource } from "@lgn/proto-editor/dist/source_control";
+
+  import { fileName } from "@/lib/path";
+
   import FileIcon from "../FileIcon.svelte";
 
   export let stagedResources: StagedResource[];

--- a/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesHeader.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesHeader.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import Icon from "@iconify/svelte";
+
+  import Button from "@lgn/web-client/src/components/Button.svelte";
+
   import modal from "@/stores/modal";
   import {
     stagedResources,
-    syncFromMain,
     stagedResourcesMode,
+    syncFromMain,
   } from "@/stores/stagedResources";
-  import Icon from "@iconify/svelte";
-  import Button from "@lgn/web-client/src/components/Button.svelte";
+
   import LocalChangesModal from "./LocalChangesModal.svelte";
 
   function openLocalChangesModal() {

--- a/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesList.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesList.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { fileName } from "@/lib/path";
   import { StagedResource_ChangeType as ChangeType } from "@lgn/proto-editor/dist/source_control";
   import type { StagedResource } from "@lgn/proto-editor/dist/source_control";
+
+  import { fileName } from "@/lib/path";
 
   export let stagedResources: StagedResource[];
 

--- a/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesModal.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/localChanges/LocalChangesModal.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
-  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
+  import Icon from "@iconify/svelte";
+
   import Button from "@lgn/web-client/src/components/Button.svelte";
+  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
+
   import {
     stagedResources,
+    stagedResourcesMode,
     submitToMain,
     syncFromMain,
-    stagedResourcesMode,
   } from "@/stores/stagedResources";
-  import LocalChangesGrid from "./LocalChangesGrid.svelte";
-  import Icon from "@iconify/svelte";
-  import LocalChangesList from "./LocalChangesList.svelte";
+
   import TextArea from "../inputs/TextArea.svelte";
+  import LocalChangesGrid from "./LocalChangesGrid.svelte";
+  import LocalChangesList from "./LocalChangesList.svelte";
 
   export let close: () => void;
 

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyBag.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyBag.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  import log from "@lgn/web-client/src/lib/log";
+
   import type { PropertyUpdate } from "@/api";
   import {
     propertyIsDynComponent,
@@ -7,10 +11,9 @@
     propertyIsVec,
   } from "@/lib/propertyGrid";
   import type { BagResourceProperty } from "@/lib/propertyGrid";
-  import modal from "@/stores/modal";
   import { currentResource } from "@/orchestrators/currentResource";
-  import { createEventDispatcher } from "svelte";
-  import log from "@lgn/web-client/src/lib/log";
+  import modal from "@/stores/modal";
+
   import Checkbox from "../inputs/Checkbox.svelte";
   import PropertyContainer from "./PropertyContainer.svelte";
   import type {

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyContainer.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyContainer.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
   import type { PropertyUpdate } from "@/api";
   import { propertyIsBag } from "@/lib/propertyGrid";
   import type {
     BagResourceProperty,
     ResourceProperty,
   } from "@/lib/propertyGrid";
-  import { createEventDispatcher } from "svelte";
+
   import PropertyBag from "./PropertyBag.svelte";
   import PropertyUnit from "./PropertyUnit.svelte";
   import type {

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyGrid.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyGrid.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
+  import log from "@lgn/web-client/src/lib/log";
+
   import {
-    updateResourceProperties,
-    removeVectorSubProperty as removeVectorSubPropertyApi,
     addPropertyInPropertyVector as addPropertyInPropertyVectorApi,
+    removeVectorSubProperty as removeVectorSubPropertyApi,
+    updateResourceProperties,
   } from "@/api";
   import type { PropertyUpdate } from "@/api";
+  import CreateComponentModal from "@/components/resources/CreateComponentModal.svelte";
   import { propertyIsDynComponent, propertyIsGroup } from "@/lib/propertyGrid";
   import {
     currentResource,
     currentResourceError,
   } from "@/orchestrators/currentResource";
-  import log from "@lgn/web-client/src/lib/log";
-  import PropertyContainer from "./PropertyContainer.svelte";
-  import CreateComponentModal from "@/components/resources/CreateComponentModal.svelte";
   import modal from "@/stores/modal";
+
+  import PropertyContainer from "./PropertyContainer.svelte";
   import type {
     AddVectorSubPropertyEvent,
     RemoveVectorSubPropertyEvent,

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyInput.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyInput.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  import log from "@lgn/web-client/src/lib/log";
+
   import type { PropertyUpdate } from "@/api";
   import {
     propertyIsBoolean,
     propertyIsColor,
+    propertyIsEnum,
     propertyIsNumber,
     propertyIsOption,
     propertyIsQuat,
-    propertyIsSpeed,
-    propertyIsScript,
-    propertyIsString,
     propertyIsResourcePathId,
-    propertyIsEnum,
+    propertyIsScript,
+    propertyIsSpeed,
+    propertyIsString,
     propertyIsVec,
     propertyIsVec3,
   } from "@/lib/propertyGrid";
@@ -19,19 +23,18 @@
     ResourceProperty,
   } from "@/lib/propertyGrid";
   import { currentResource } from "@/orchestrators/currentResource";
-  import log from "@lgn/web-client/src/lib/log";
-  import { createEventDispatcher } from "svelte";
+
+  import PropertyInputOption from "./PropertyInputOption.svelte";
   import BooleanProperty from "./properties/BooleanProperty.svelte";
   import ColorProperty from "./properties/ColorProperty.svelte";
+  import EnumProperty from "./properties/EnumProperty.svelte";
   import NumberProperty from "./properties/NumberProperty.svelte";
   import QuatProperty from "./properties/QuatProperty.svelte";
+  import ResourcePathIdProperty from "./properties/ResourcePathIdProperty.svelte";
   import ScriptProperty from "./properties/ScriptProperty.svelte";
   import SpeedProperty from "./properties/SpeedProperty.svelte";
   import StringProperty from "./properties/StringProperty.svelte";
   import Vec3Property from "./properties/Vec3Property.svelte";
-  import ResourcePathIdProperty from "./properties/ResourcePathIdProperty.svelte";
-  import EnumProperty from "./properties/EnumProperty.svelte";
-  import PropertyInputOption from "./PropertyInputOption.svelte";
   import type { RemoveVectorSubPropertyEvent } from "./types";
 
   const dispatch = createEventDispatcher<{

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyInputOption.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyInputOption.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
   import type { PropertyUpdate } from "@/api";
   import {
     buildDefaultPrimitiveProperty,
@@ -7,7 +9,7 @@
     ptypeBelongsToPrimitive,
   } from "@/lib/propertyGrid";
   import type { OptionResourceProperty } from "@/lib/propertyGrid";
-  import { createEventDispatcher } from "svelte";
+
   import Checkbox from "../inputs/Checkbox.svelte";
   import PropertyInput from "./PropertyInput.svelte";
 

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyUnit.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/PropertyUnit.svelte
@@ -4,6 +4,7 @@
     BagResourceProperty,
     ResourceProperty,
   } from "@/lib/propertyGrid";
+
   import PropertyInput from "./PropertyInput.svelte";
   import type { RemoveVectorSubPropertyEvent } from "./types";
 

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/ColorProperty.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/ColorProperty.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
+
   import clickOutside from "@lgn/web-client/src/actions/clickOutside";
-  import { colorSetFromHex } from "@/lib/colors";
-  import type { ColorSet } from "@/lib/colors";
+
   import ColorPicker from "@/components/inputs/ColorPicker.svelte";
   import TextInput from "@/components/inputs/TextInput.svelte";
+  import { colorSetFromHex } from "@/lib/colors";
+  import type { ColorSet } from "@/lib/colors";
 
   const dispatch = createEventDispatcher<{
     input: number;

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/EnumProperty.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/EnumProperty.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
+
   import Select from "../../inputs/Select.svelte";
 
   const dispatch = createEventDispatcher<{

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/QuatProperty.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/QuatProperty.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
+
   import type { Quat } from "@/lib/propertyGrid";
+
   import NumberInput from "../../inputs/NumberInput.svelte";
 
   const dispatch = createEventDispatcher<{ input: Quat }>();

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/ScriptProperty.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/ScriptProperty.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import Button from "@lgn/web-client/src/components/Button.svelte";
-  import viewportOrchestrator from "@/orchestrators/viewport";
   import { createEventDispatcher } from "svelte";
+
+  import Button from "@lgn/web-client/src/components/Button.svelte";
+
+  import viewportOrchestrator from "@/orchestrators/viewport";
 
   const dispatch = createEventDispatcher<{ input: string }>();
 

--- a/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/Vec3Property.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/propertyGrid/properties/Vec3Property.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
+
   import type { Vec3 } from "@/lib/propertyGrid";
+
   import NumberInput from "../../inputs/NumberInput.svelte";
 
   const dispatch = createEventDispatcher<{ input: Vec3 }>();

--- a/crates/lgn-editor-gui/frontend/src/components/resources/CreateComponentModal.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/resources/CreateComponentModal.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-  import { addPropertyInPropertyVector as addPropertyInPropertyVectorApi } from "@/api";
   import { form as createForm, field } from "svelte-forms";
   import { required } from "svelte-forms/validators";
-  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
-  import Button from "@lgn/web-client/src/components/Button.svelte";
-  import { createAsyncStoreOrchestrator } from "@lgn/web-client/src/orchestrators/async";
-  import Select from "../inputs/Select.svelte";
-  import { getAvailableComponentTypes } from "@/api";
+
   import type { GetAvailableDynTraitsResponse } from "@lgn/proto-editor/dist/property_inspector";
+  import Button from "@lgn/web-client/src/components/Button.svelte";
+  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
+  import { createAsyncStoreOrchestrator } from "@lgn/web-client/src/orchestrators/async";
+
+  import { addPropertyInPropertyVector as addPropertyInPropertyVectorApi } from "@/api";
+  import { getAvailableComponentTypes } from "@/api";
+
   import Field from "../Field.svelte";
+  import Select from "../inputs/Select.svelte";
 
   const createComponentStore = createAsyncStoreOrchestrator();
 

--- a/crates/lgn-editor-gui/frontend/src/components/resources/CreateResourceModal.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/resources/CreateResourceModal.svelte
@@ -1,23 +1,26 @@
 <script lang="ts">
   import { form as createForm, field } from "svelte-forms";
   import { required } from "svelte-forms/validators";
-  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
-  import Button from "@lgn/web-client/src/components/Button.svelte";
-  import { createAsyncStoreOrchestrator } from "@lgn/web-client/src/orchestrators/async";
-  import Select from "../inputs/Select.svelte";
-  import TextInput from "../inputs/TextInput.svelte";
-  import {
-    getResourceTypes,
-    createResource as createResourceApi,
-    getAllResources,
-  } from "@/api";
+
   import type {
     GetResourceTypeNamesResponse,
     ResourceDescription,
   } from "@lgn/proto-editor/dist/resource_browser";
-  import allResourcesStore from "@/stores/allResources";
-  import Field from "../Field.svelte";
+  import Button from "@lgn/web-client/src/components/Button.svelte";
+  import Modal from "@lgn/web-client/src/components/modal/Modal.svelte";
   import log from "@lgn/web-client/src/lib/log";
+  import { createAsyncStoreOrchestrator } from "@lgn/web-client/src/orchestrators/async";
+
+  import {
+    createResource as createResourceApi,
+    getAllResources,
+    getResourceTypes,
+  } from "@/api";
+  import allResourcesStore from "@/stores/allResources";
+
+  import Field from "../Field.svelte";
+  import Select from "../inputs/Select.svelte";
+  import TextInput from "../inputs/TextInput.svelte";
 
   const createResourceStore = createAsyncStoreOrchestrator();
 

--- a/crates/lgn-editor-gui/frontend/src/components/resources/ResourceFilter.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/resources/ResourceFilter.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import TextInput from "@/components/inputs/TextInput.svelte";
-  import Button from "@lgn/web-client/src/components/Button.svelte";
-  import { createEventDispatcher } from "svelte";
   import Icon from "@iconify/svelte";
+  import { createEventDispatcher } from "svelte";
+
+  import Button from "@lgn/web-client/src/components/Button.svelte";
+
+  import TextInput from "@/components/inputs/TextInput.svelte";
 
   const dispatch = createEventDispatcher<{ filter: { name: string } }>();
 

--- a/crates/lgn-editor-gui/frontend/src/hooks.ts
+++ b/crates/lgn-editor-gui/frontend/src/hooks.ts
@@ -1,6 +1,5 @@
 // See https://kit.svelte.dev/docs/hooks for more
 // We use this file solely to turn our whole app into an SPA
-
 import type { Handle } from "@sveltejs/kit";
 
 export const handle: Handle = async ({ event, resolve }) =>

--- a/crates/lgn-editor-gui/frontend/src/lib/colors.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/colors.ts
@@ -1,6 +1,5 @@
 // TODO: We could add value validations even though
 // `color-convert` seems to handle invalid values very well
-
 import colorConvert from "color-convert";
 
 // r: 0 ~ 255, g: 0 ~ 255, b: 0 ~ 255, a: 0 ~ 255

--- a/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
@@ -1,4 +1,5 @@
 import { v4 as uuid } from "uuid";
+
 import { components } from "./path";
 
 export type Entry<Item> = {

--- a/crates/lgn-editor-gui/frontend/src/lib/propertyGrid.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/propertyGrid.ts
@@ -1,7 +1,7 @@
 // TODO: Use the `ResourceDescription` from resource_property.proto instead (?)
 import type {
-  ResourceDescription,
   ResourceProperty as RawResourceProperty,
+  ResourceDescription,
 } from "@lgn/proto-editor/dist/property_inspector";
 import type { NonEmptyArray } from "@lgn/web-client/src/lib/array";
 import { filterMap } from "@lgn/web-client/src/lib/array";

--- a/crates/lgn-editor-gui/frontend/src/lib/resourceBrowser.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/resourceBrowser.ts
@@ -1,4 +1,5 @@
 import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
+
 import type { Entry } from "./hierarchyTree";
 
 export function iconFor(entry: Entry<ResourceDescription>) {

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/currentResource.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/currentResource.ts
@@ -1,10 +1,11 @@
-import type { ResourceWithProperties } from "@/lib/propertyGrid";
 import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
+import log from "@lgn/web-client/src/lib/log";
 import type { AsyncOrchestrator } from "@lgn/web-client/src/orchestrators/async";
 import { createAsyncStoreOrchestrator } from "@lgn/web-client/src/orchestrators/async";
-import notifications from "@/stores/notifications";
+
 import { getResourceProperties, updateSelection } from "@/api";
-import log from "@lgn/web-client/src/lib/log";
+import type { ResourceWithProperties } from "@/lib/propertyGrid";
+import notifications from "@/stores/notifications";
 
 export type CurrentResourceOrchestrator =
   AsyncOrchestrator<ResourceWithProperties>;

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/hierarchyTree.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/hierarchyTree.ts
@@ -4,9 +4,9 @@
  *
  * It could also contain an array of id pointing to the currently expanded entries in the tree.
  */
-
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
+
 import type { Entry } from "@/lib/hierarchyTree";
 import { Entries } from "@/lib/hierarchyTree";
 

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/resourceBrowserEntries.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/resourceBrowserEntries.ts
@@ -1,4 +1,5 @@
 import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
+
 import { createHierarchyTreeOrchestrator } from "./hierarchyTree";
 
 export const resourceBrowserEntriesOrchestrator =

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/selection.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/selection.ts
@@ -2,16 +2,18 @@
 // that is, the element(s) selected in the viewport/resource browser/scene explorer.
 //
 // This orchestrator doesn't own any stores.
-
 import { get } from "svelte/store";
-import { initMessageStream as initMessageStreamApi } from "@/api";
-import {
-  resourceEntries,
-  currentResourceDescriptionEntry,
-} from "./resourceBrowserEntries";
+
 import { MessageType } from "@lgn/proto-editor/dist/editor";
-import { fetchCurrentResourceDescription } from "@/orchestrators/currentResource";
+
+import { initMessageStream as initMessageStreamApi } from "@/api";
 import { isEntry } from "@/lib/hierarchyTree";
+import { fetchCurrentResourceDescription } from "@/orchestrators/currentResource";
+
+import {
+  currentResourceDescriptionEntry,
+  resourceEntries,
+} from "./resourceBrowserEntries";
 
 export function initMessageStream() {
   initMessageStreamApi().subscribe(({ lagging, message }) => {

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/viewport.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/viewport.ts
@@ -1,4 +1,5 @@
-export type { ViewportOrchestrator } from "@lgn/web-client/src/orchestrators/viewport";
 import { createViewportOrchestrator } from "@lgn/web-client/src/orchestrators/viewport";
+
+export type { ViewportOrchestrator } from "@lgn/web-client/src/orchestrators/viewport";
 
 export default createViewportOrchestrator();

--- a/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
@@ -1,18 +1,20 @@
 <script lang="ts" context="module">
+  import { goto } from "$app/navigation";
   import type { Load } from "@sveltejs/kit";
+
   import { headlessRun } from "@lgn/web-client";
-  import viewportOrchestrator from "@/orchestrators/viewport";
-  import * as contextMenuEntries from "@/data/contextMenu";
-  import contextMenu from "@/stores/contextMenu";
-  import authStatus from "@/stores/authStatus";
   import type { NonEmptyArray } from "@lgn/web-client/src/lib/array";
   import log from "@lgn/web-client/src/lib/log";
-  import { goto } from "$app/navigation";
-  import "@/workers/editorWorker";
-  import { initStagedResourcesStream } from "@/stores/stagedResources";
+
   import { initApiClient } from "@/api";
-  import { initLogStream } from "@/stores/log";
+  import * as contextMenuEntries from "@/data/contextMenu";
   import { initMessageStream } from "@/orchestrators/selection";
+  import viewportOrchestrator from "@/orchestrators/viewport";
+  import authStatus from "@/stores/authStatus";
+  import contextMenu from "@/stores/contextMenu";
+  import { initLogStream } from "@/stores/log";
+  import { initStagedResourcesStream } from "@/stores/stagedResources";
+  import "@/workers/editorWorker";
 
   const logLevel = "warn";
 

--- a/crates/lgn-editor-gui/frontend/src/routes/index.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/index.svelte
@@ -1,32 +1,34 @@
 <script lang="ts">
-  import { Panel } from "@lgn/web-client/src/components/panel";
+  import { onMount } from "svelte";
+
+  import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
   import ContextMenu from "@lgn/web-client/src/components/ContextMenu.svelte";
   import Notifications from "@lgn/web-client/src/components/Notifications.svelte";
-  import ViewportPanel from "@lgn/web-client/src/components/panel/ViewportPanel.svelte";
-  import ModalContainer from "@lgn/web-client/src/components/modal/ModalContainer.svelte";
-  import TopBar from "@lgn/web-client/src/components/TopBar.svelte";
   import StatusBar from "@lgn/web-client/src/components/StatusBar.svelte";
+  import TopBar from "@lgn/web-client/src/components/TopBar.svelte";
+  import ModalContainer from "@lgn/web-client/src/components/modal/ModalContainer.svelte";
+  import { Panel } from "@lgn/web-client/src/components/panel";
+  import ViewportPanel from "@lgn/web-client/src/components/panel/ViewportPanel.svelte";
+
   import { getAllResources } from "@/api";
+  import AuthModal from "@/components/AuthModal.svelte";
+  import ExtraPanel from "@/components/ExtraPanel.svelte";
+  import ResourceBrowser from "@/components/ResourceBrowser.svelte";
+  import SceneExplorer from "@/components/SceneExplorer.svelte";
   import PropertyGrid from "@/components/propertyGrid/PropertyGrid.svelte";
   import { currentResource } from "@/orchestrators/currentResource";
   import {
     currentResourceDescriptionEntry,
     currentlyRenameResourceEntry,
-    resourceEntries,
     resourceBrowserEntriesOrchestrator,
+    resourceEntries,
   } from "@/orchestrators/resourceBrowserEntries";
-  import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
-  import contextMenu from "@/stores/contextMenu";
-  import allResourcesStore from "@/stores/allResources";
   import viewportOrchestrator from "@/orchestrators/viewport";
-  import { onMount } from "svelte";
+  import allResourcesStore from "@/stores/allResources";
   import authStatus from "@/stores/authStatus";
-  import AuthModal from "@/components/AuthModal.svelte";
-  import notifications from "@/stores/notifications";
-  import SceneExplorer from "@/components/SceneExplorer.svelte";
-  import ResourceBrowser from "@/components/ResourceBrowser.svelte";
+  import contextMenu from "@/stores/contextMenu";
   import modal from "@/stores/modal";
-  import ExtraPanel from "@/components/ExtraPanel.svelte";
+  import notifications from "@/stores/notifications";
   import { stagedResources, syncFromMain } from "@/stores/stagedResources";
 
   const {

--- a/crates/lgn-editor-gui/frontend/src/stores/allResources.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/allResources.ts
@@ -1,6 +1,7 @@
 import type { Writable } from "svelte/store";
-import { createAsyncStoreListOrchestrator } from "@lgn/web-client/src/orchestrators/async";
+
 import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
+import { createAsyncStoreListOrchestrator } from "@lgn/web-client/src/orchestrators/async";
 
 export type AllResourcesValue = ResourceDescription[];
 

--- a/crates/lgn-editor-gui/frontend/src/stores/authStatus.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/authStatus.ts
@@ -1,5 +1,6 @@
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
+
 import type { InitAuthStatus } from "@lgn/web-client/src/lib/auth";
 
 export type AuthStatusValue = InitAuthStatus | null;

--- a/crates/lgn-editor-gui/frontend/src/stores/contextMenu.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/contextMenu.ts
@@ -1,6 +1,7 @@
 import type { Writable } from "svelte/store";
-import { createContextMenuStore } from "@lgn/web-client/src/stores/contextMenu";
+
 import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
+import { createContextMenuStore } from "@lgn/web-client/src/stores/contextMenu";
 
 export type ContextMenuEntryRecord = {
   resource: { item: ResourceDescription | null; name: string };

--- a/crates/lgn-editor-gui/frontend/src/stores/l10n.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/l10n.ts
@@ -1,26 +1,31 @@
 import { FluentBundle, FluentResource } from "@fluent/bundle";
+
+import {
+  createAvailableLocalesStore,
+  createBundlesStore,
+} from "@lgn/web-client/src/stores/bundles";
+import { createLocaleStore } from "@lgn/web-client/src/stores/locale";
+import { createTranslateStore } from "@lgn/web-client/src/stores/translate";
+
+import en from "@/assets/locales/en-US/example.ftl?raw";
+import fr from "@/assets/locales/fr-CA/example.ftl?raw";
+
 export type {
   TranslateValue,
   TranslateStore,
 } from "@lgn/web-client/src/stores/translate";
-import { createTranslateStore } from "@lgn/web-client/src/stores/translate";
+
 export type {
   BundlesValue,
   BundlesStore,
   AvailableLocalesValue,
   AvailableLocalesStore,
 } from "@lgn/web-client/src/stores/bundles";
-import {
-  createAvailableLocalesStore,
-  createBundlesStore,
-} from "@lgn/web-client/src/stores/bundles";
+
 export type {
   LocaleValue,
   LocaleStore,
 } from "@lgn/web-client/src/stores/locale";
-import { createLocaleStore } from "@lgn/web-client/src/stores/locale";
-import en from "@/assets/locales/en-US/example.ftl?raw";
-import fr from "@/assets/locales/fr-CA/example.ftl?raw";
 
 export const bundles = createBundlesStore();
 

--- a/crates/lgn-editor-gui/frontend/src/stores/log.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/log.ts
@@ -1,7 +1,9 @@
 import { derived, get, writable } from "svelte/store";
-import type { LogEntry } from "@lgn/web-client/src/types/log";
+
 import { throttled } from "@lgn/web-client/src/lib/store";
+import type { LogEntry } from "@lgn/web-client/src/types/log";
 import { severityFromLevel } from "@lgn/web-client/src/types/log";
+
 import { initLogStream as initLogStreamApi } from "@/api";
 
 export const buffer = 1_000;

--- a/crates/lgn-editor-gui/frontend/src/stores/modal.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/modal.ts
@@ -1,4 +1,5 @@
-export type { ModalValue, ModalStore } from "@lgn/web-client/src/stores/modal";
 import { createModalStore } from "@lgn/web-client/src/stores/modal";
+
+export type { ModalValue, ModalStore } from "@lgn/web-client/src/stores/modal";
 
 export default createModalStore();

--- a/crates/lgn-editor-gui/frontend/src/stores/notifications.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/notifications.ts
@@ -1,7 +1,8 @@
+import { createNotificationsStore } from "@lgn/web-client/src/stores/notifications";
+
 export type {
   NotificationsValue,
   NotificationsStore,
 } from "@lgn/web-client/src/stores/notifications";
-import { createNotificationsStore } from "@lgn/web-client/src/stores/notifications";
 
 export default createNotificationsStore();

--- a/crates/lgn-editor-gui/frontend/src/stores/stagedResources.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/stagedResources.ts
@@ -1,14 +1,17 @@
 import type { Writable } from "svelte/store";
 import { get, writable } from "svelte/store";
+
 import type { StagedResource } from "@lgn/proto-editor/dist/source_control";
+import log from "@lgn/web-client/src/lib/log";
+
 import {
   commitStagedResources,
   getAllResources,
   getStagedResources,
   syncLatest,
 } from "@/api";
+
 import allResources from "./allResources";
-import log from "@lgn/web-client/src/lib/log";
 
 export type StagedResourcesValue = StagedResource[] | null;
 

--- a/crates/lgn-editor-gui/frontend/src/workers/editorWorker.ts
+++ b/crates/lgn-editor-gui/frontend/src/workers/editorWorker.ts
@@ -1,5 +1,4 @@
 import "monaco-editor/esm/vs/basic-languages/monaco.contribution";
-
 import type { Environment } from "monaco-editor/esm/vs/editor/editor.api";
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 

--- a/crates/lgn-editor-gui/frontend/svelte.config.js
+++ b/crates/lgn-editor-gui/frontend/svelte.config.js
@@ -1,7 +1,7 @@
 // @ts-check
-
 import adapter from "@sveltejs/adapter-static";
 import preprocess from "svelte-preprocess";
+
 import viteConfig from "./vite.config.js";
 
 /** @type {import("@sveltejs/kit").Config} */

--- a/crates/lgn-editor-gui/frontend/tests/components/propertyGrid/PropertyGrid.test.ts
+++ b/crates/lgn-editor-gui/frontend/tests/components/propertyGrid/PropertyGrid.test.ts
@@ -1,9 +1,10 @@
-import currentResource from "@/orchestrators/currentResource";
-import PropertyGrid from "@/components/propertyGrid/PropertyGrid.svelte";
 import { cleanup } from "@testing-library/svelte";
 import { render } from "@testing-library/svelte";
+
+import PropertyGrid from "@/components/propertyGrid/PropertyGrid.svelte";
+import { ResourceProperty, formatProperties } from "@/lib/propertyGrid";
+import currentResource from "@/orchestrators/currentResource";
 import properties from "@/resources/propertiesResponse.json";
-import { formatProperties, ResourceProperty } from "@/lib/propertyGrid";
 
 describe("PropertyGrid", () => {
   afterEach(() => cleanup());

--- a/crates/lgn-editor-gui/frontend/tests/lib/propertyGrid.test.ts
+++ b/crates/lgn-editor-gui/frontend/tests/lib/propertyGrid.test.ts
@@ -10,21 +10,20 @@ import {
   propertyIsBoolean,
   propertyIsColor,
   propertyIsComponent,
+  propertyIsEnum,
   propertyIsGroup,
   propertyIsNumber,
   propertyIsOption,
   propertyIsPrimitive,
   propertyIsQuat,
+  propertyIsResourcePathId,
   propertyIsSpeed,
   propertyIsString,
-  propertyIsResourcePathId,
-  propertyIsEnum,
   propertyIsVec,
   propertyIsVec3,
   ptypeBelongsToPrimitive,
 } from "@/lib/propertyGrid";
 import type { ResourceProperty } from "@/lib/propertyGrid";
-
 import propertiesResponse from "@/resources/propertiesResponse.json";
 
 describe("formatProperties", () => {

--- a/crates/lgn-editor-gui/frontend/tests/setup.ts
+++ b/crates/lgn-editor-gui/frontend/tests/setup.ts
@@ -1,5 +1,5 @@
-import { vi } from "vitest";
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
 
 vi.mock("uuid", () => ({
   v4: () => "same-old-id",

--- a/crates/lgn-editor-gui/frontend/vite.config.js
+++ b/crates/lgn-editor-gui/frontend/vite.config.js
@@ -1,9 +1,10 @@
 // @ts-check
-
-import tsconfigPaths from "vite-tsconfig-paths";
-import viteTsProto from "@lgn/vite-plugin-ts-proto";
-import path from "path";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import path from "path";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import viteTsProto from "@lgn/vite-plugin-ts-proto";
+
 // import viteWasmPack from "@lgn/vite-plugin-wasm";
 
 /** @type {"jsdom"} */

--- a/crates/lgn-runtime-gui/frontend/.prettierrc
+++ b/crates/lgn-runtime-gui/frontend/.prettierrc
@@ -1,1 +1,5 @@
-{}
+{
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrder": ["^@lgn\\/", "^@\\/", "^\\."]
+}

--- a/crates/lgn-runtime-gui/frontend/package.json
+++ b/crates/lgn-runtime-gui/frontend/package.json
@@ -26,6 +26,7 @@
     "@swc/core": "^1.2.161",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/svelte": "^3.1.0",
+    "@trivago/prettier-plugin-sort-imports": "^3.2.0",
     "@types/color-convert": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",

--- a/crates/lgn-runtime-gui/frontend/src/App.svelte
+++ b/crates/lgn-runtime-gui/frontend/src/App.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount } from "svelte";
+
   import type { InitAuthStatus } from "@lgn/web-client/src/lib/auth";
+
   import Home from "@/pages/Home.svelte";
 
   export let initAuthStatus: InitAuthStatus | null;

--- a/crates/lgn-runtime-gui/frontend/src/index.ts
+++ b/crates/lgn-runtime-gui/frontend/src/index.ts
@@ -1,7 +1,8 @@
-import "./assets/index.css";
-
 import { AppComponent, run } from "@lgn/web-client";
+
 import App from "@/App.svelte";
+
+import "./assets/index.css";
 
 const redirectUri = document.location.origin + "/";
 

--- a/crates/lgn-runtime-gui/frontend/src/pages/Home.svelte
+++ b/crates/lgn-runtime-gui/frontend/src/pages/Home.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { Panel } from "@lgn/web-client/src/components/panel";
-  import TopBar from "@lgn/web-client/src/components/TopBar.svelte";
-  import StatusBar from "@lgn/web-client/src/components/StatusBar.svelte";
   import RemoteWindow from "@lgn/web-client/src/components/RemoteWindow.svelte";
+  import StatusBar from "@lgn/web-client/src/components/StatusBar.svelte";
+  import TopBar from "@lgn/web-client/src/components/TopBar.svelte";
+  import { Panel } from "@lgn/web-client/src/components/panel";
   import { Resolution } from "@lgn/web-client/src/lib/types";
 
   let desiredVideoResolution: Resolution | null;

--- a/crates/lgn-runtime-gui/frontend/svelte.config.js
+++ b/crates/lgn-runtime-gui/frontend/svelte.config.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 import preprocess from "svelte-preprocess";
 
 export default {

--- a/crates/lgn-runtime-gui/frontend/vite.config.js
+++ b/crates/lgn-runtime-gui/frontend/vite.config.js
@@ -1,8 +1,8 @@
 // @ts-check
-
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+
 import viteTsProto from "@lgn/vite-plugin-ts-proto";
 
 // https://vitejs.dev/config/

--- a/crates/lgn-web-client/frontend/.prettierrc
+++ b/crates/lgn-web-client/frontend/.prettierrc
@@ -1,1 +1,5 @@
-{}
+{
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrder": ["^@lgn\\/", "^@\\/", "^\\."]
+}

--- a/crates/lgn-web-client/frontend/package.json
+++ b/crates/lgn-web-client/frontend/package.json
@@ -25,6 +25,7 @@
     "@swc/core": "^1.2.161",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/svelte": "^3.1.0",
+    "@trivago/prettier-plugin-sort-imports": "^3.2.0",
     "@types/color-convert": "^2.0.0",
     "@types/estree": "^0.0.51",
     "@typescript-eslint/eslint-plugin": "^5.16.0",

--- a/crates/lgn-web-client/frontend/src/actions/dnd.ts
+++ b/crates/lgn-web-client/frontend/src/actions/dnd.ts
@@ -2,8 +2,8 @@
 // In the future we could use a bigger library
 // or implement our own svelte adapter for
 // https://github.com/react-dnd/react-dnd/tree/main/packages/dnd-core
-
 import { derived, get } from "svelte/store";
+
 import type { ActionReturn } from "../lib/action";
 import type { DndStore } from "../stores/dnd";
 import { createDndStore } from "../stores/dnd";

--- a/crates/lgn-web-client/frontend/src/api/index.ts
+++ b/crates/lgn-web-client/frontend/src/api/index.ts
@@ -2,6 +2,7 @@ import {
   StreamerClientImpl,
   GrpcWebImpl as StreamingGrpcWebImpl,
 } from "@lgn/proto-streaming/dist/streaming";
+
 import { bytesToJson, jsonToBytes } from "../lib/api";
 import log from "../lib/log";
 

--- a/crates/lgn-web-client/frontend/src/components/ContextMenu.svelte
+++ b/crates/lgn-web-client/frontend/src/components/ContextMenu.svelte
@@ -115,12 +115,13 @@ export default buildContextMenu<ContextMenuEntryRecord>();
 -->
 <script lang="ts">
   import { fade } from "svelte/transition";
+
   import clickOutside from "../actions/clickOutside";
   import { remToPx } from "../lib/html";
   import { sleep } from "../lib/promises";
   import type { Position } from "../lib/types";
   import type { ContextMenuStore } from "../stores/contextMenu";
-  import { buildCustomEvent, Entry, ItemEntry } from "../types/contextMenu";
+  import { Entry, ItemEntry, buildCustomEvent } from "../types/contextMenu";
 
   const entryHeightRem = 2.5;
 

--- a/crates/lgn-web-client/frontend/src/components/Log.svelte
+++ b/crates/lgn-web-client/frontend/src/components/Log.svelte
@@ -10,20 +10,21 @@
 
 <script lang="ts">
   import {
-    createEventDispatcher,
     afterUpdate,
     beforeUpdate,
+    createEventDispatcher,
     onMount,
   } from "svelte";
-  import { derived, Writable, writable } from "svelte/store";
   import { FixedSizeList, styleString } from "svelte-window";
   import type {
     ListOnItemsRenderedProps,
     ListOnScrollProps,
   } from "svelte-window";
-  import type { LogEntry } from "../types/log";
+  import { Writable, derived, writable } from "svelte/store";
+
   import { remToPx } from "../lib/html";
   import { debounced, recorded } from "../lib/store";
+  import type { LogEntry } from "../types/log";
 
   const dispatch = createEventDispatcher<{
     /**

--- a/crates/lgn-web-client/frontend/src/components/RemoteWindow.svelte
+++ b/crates/lgn-web-client/frontend/src/components/RemoteWindow.svelte
@@ -1,20 +1,21 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
-  import { debounce, retry } from "../lib/promises";
-  import statusStore from "../stores/statusBarData";
-  import {
-    initializeStream,
-    onReceiveControlMessage,
-    ServerType,
-  } from "../api";
-  import log from "../lib/log";
-  import type { PushableHTMLVideoElement } from "../actions/videoPlayer";
-  import resize from "../actions/resize";
-  import videoPlayer from "../actions/videoPlayer";
+
   import remoteWindowInputs, {
     RemoteWindowInput,
   } from "../actions/remoteWindowInputs";
+  import resize from "../actions/resize";
+  import type { PushableHTMLVideoElement } from "../actions/videoPlayer";
+  import videoPlayer from "../actions/videoPlayer";
+  import {
+    ServerType,
+    initializeStream,
+    onReceiveControlMessage,
+  } from "../api";
+  import log from "../lib/log";
+  import { debounce, retry } from "../lib/promises";
   import type { Resolution } from "../lib/types";
+  import statusStore from "../stores/statusBarData";
 
   const reconnectionTimeout = 1_000;
 

--- a/crates/lgn-web-client/frontend/src/components/ScriptEditor.svelte
+++ b/crates/lgn-web-client/frontend/src/components/ScriptEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy, onMount } from "svelte";
   import type * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+  import { createEventDispatcher, onDestroy, onMount } from "svelte";
+
   import { debounce } from "../lib/promises";
 
   const dispatch = createEventDispatcher<{

--- a/crates/lgn-web-client/frontend/src/components/StatusBar.svelte
+++ b/crates/lgn-web-client/frontend/src/components/StatusBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { StagedResource } from "@lgn/proto-editor/dist/source_control";
+
   import statusStore from "../stores/statusBarData";
   import Button from "./Button.svelte";
   import PingPoint from "./PingPoint.svelte";

--- a/crates/lgn-web-client/frontend/src/components/TopBar.svelte
+++ b/crates/lgn-web-client/frontend/src/components/TopBar.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
+  import Icon from "@iconify/svelte";
+  import { onMount } from "svelte";
+
+  import clickOutside from "../actions/clickOutside";
+  import { UserInfo, authClient } from "../lib/auth";
+  import log from "../lib/log";
+  import userInfo from "../orchestrators/userInfo";
   import topBarMenuStore, {
     Id as TopBarMenuId,
     menus as topBarMenus,
   } from "../stores/topBarMenu";
-  import userInfo from "../orchestrators/userInfo";
-  import log from "../lib/log";
-  import clickOutside from "../actions/clickOutside";
   import BrandLogo from "./BrandLogo.svelte";
-  import { onMount } from "svelte";
-  import Icon from "@iconify/svelte";
-  import { authClient, UserInfo } from "../lib/auth";
 
   const { data: userInfoData } = userInfo;
 

--- a/crates/lgn-web-client/frontend/src/components/modal/ModalContainer.svelte
+++ b/crates/lgn-web-client/frontend/src/components/modal/ModalContainer.svelte
@@ -10,6 +10,7 @@ using the `openModal` function provided by the `lib/modal.ts` module) and open u
 -->
 <script lang="ts">
   import { fade } from "svelte/transition";
+
   import type { ModalStore } from "../../stores/modal";
 
   export let store: ModalStore;

--- a/crates/lgn-web-client/frontend/src/components/panel/PanelList.svelte
+++ b/crates/lgn-web-client/frontend/src/components/panel/PanelList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
+
   import keyboardNavigation, {
     keyboardNavigationItem,
   } from "../../actions/keyboardNavigation";

--- a/crates/lgn-web-client/frontend/src/components/panel/ViewportPanel.svelte
+++ b/crates/lgn-web-client/frontend/src/components/panel/ViewportPanel.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import Icon from "@iconify/svelte";
-  import Panel from "./Panel.svelte";
+
+  import type { Resolution } from "../../lib/types";
+  import type { ViewportOrchestrator } from "../../orchestrators/viewport";
   import RemoteWindow from "../RemoteWindow.svelte";
   import ScriptEditor from "../ScriptEditor.svelte";
-  import type { ViewportOrchestrator } from "../../orchestrators/viewport";
-  import type { Resolution } from "../../lib/types";
+  import Panel from "./Panel.svelte";
 
   /** The global viewport orchestrator */
   export let orchestrator: ViewportOrchestrator;

--- a/crates/lgn-web-client/frontend/src/index.ts
+++ b/crates/lgn-web-client/frontend/src/index.ts
@@ -1,11 +1,12 @@
-import { authClient, initAuth, InitAuthUserConfig } from "./lib/auth";
+import grpcWeb from "@improbable-eng/grpc-web";
+import { SvelteComponentTyped } from "svelte";
+
+import { initApiClient } from "./api";
+import { InitAuthUserConfig, authClient, initAuth } from "./lib/auth";
 import type { InitAuthStatus } from "./lib/auth";
 import log from "./lib/log";
 import type { Level as LogLevel } from "./lib/log";
 import userInfo from "./orchestrators/userInfo";
-import { SvelteComponentTyped } from "svelte";
-import grpcWeb from "@improbable-eng/grpc-web";
-import { initApiClient } from "./api";
 
 export class AppComponent extends SvelteComponentTyped<{
   initAuthStatus: InitAuthStatus | null;

--- a/crates/lgn-web-client/frontend/src/lib/auth.ts
+++ b/crates/lgn-web-client/frontend/src/lib/auth.ts
@@ -1,8 +1,9 @@
+import getPkce from "oauth-pkce";
+
 import userInfo from "../orchestrators/userInfo";
+import type { NonEmptyArray } from "./array";
 import { getCookie, setCookie } from "./cookie";
 import log from "./log";
-import type { NonEmptyArray } from "./array";
-import getPkce from "oauth-pkce";
 
 // https://connect2id.com/products/server/docs/api/token#token-response
 export type ClientTokenSet = {

--- a/crates/lgn-web-client/frontend/src/lib/store.ts
+++ b/crates/lgn-web-client/frontend/src/lib/store.ts
@@ -1,5 +1,5 @@
 import type { Readable } from "svelte/store";
-import { get, derived } from "svelte/store";
+import { derived, get } from "svelte/store";
 
 /**
  * Creates a new store from an existing store, which value is debounced:

--- a/crates/lgn-web-client/frontend/src/orchestrators/viewport.ts
+++ b/crates/lgn-web-client/frontend/src/orchestrators/viewport.ts
@@ -1,5 +1,6 @@
 import type { Writable } from "svelte/store";
 import { get, writable } from "svelte/store";
+
 import type { MapStore } from "../stores/map";
 import { createMapStore } from "../stores/map";
 

--- a/crates/lgn-web-client/frontend/src/stores/bundles.ts
+++ b/crates/lgn-web-client/frontend/src/stores/bundles.ts
@@ -1,5 +1,6 @@
 import type { FluentBundle } from "@fluent/bundle";
-import { derived, Readable } from "svelte/store";
+import { Readable, derived } from "svelte/store";
+
 import type { MapStore, MapValue } from "./map";
 import { createMapStore } from "./map";
 

--- a/crates/lgn-web-client/frontend/src/stores/contextMenu.ts
+++ b/crates/lgn-web-client/frontend/src/stores/contextMenu.ts
@@ -1,5 +1,6 @@
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
+
 import type { Entry } from "../types/contextMenu";
 
 export type ContextMenuValue<Names extends string> = Partial<

--- a/crates/lgn-web-client/frontend/src/stores/dnd.ts
+++ b/crates/lgn-web-client/frontend/src/stores/dnd.ts
@@ -1,5 +1,6 @@
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
+
 import type { Position } from "../lib/types";
 
 export type DndValue<Item = unknown> = {

--- a/crates/lgn-web-client/frontend/src/stores/locale.ts
+++ b/crates/lgn-web-client/frontend/src/stores/locale.ts
@@ -1,6 +1,7 @@
 import { negotiateLanguages } from "@fluent/langneg";
-import { derived, get, Updater, Writable } from "svelte/store";
+import { Updater, Writable, derived, get } from "svelte/store";
 import { writable } from "svelte/store";
+
 import type { AvailableLocalesStore, BundlesStore } from "./bundles";
 
 export type LocaleValue = string;

--- a/crates/lgn-web-client/frontend/src/stores/modal.ts
+++ b/crates/lgn-web-client/frontend/src/stores/modal.ts
@@ -1,5 +1,6 @@
 import { SvelteComponentTyped } from "svelte";
-import { get, Writable, writable } from "svelte/store";
+import { Writable, get, writable } from "svelte/store";
+
 import Prompt from "../components/modal/Prompt.svelte";
 
 export type Payload = Record<string, unknown>;

--- a/crates/lgn-web-client/frontend/src/stores/translate.ts
+++ b/crates/lgn-web-client/frontend/src/stores/translate.ts
@@ -1,7 +1,8 @@
-import { derived, Readable } from "svelte/store";
 import type { FluentBundle, FluentVariable } from "@fluent/bundle";
-import type { LocaleStore } from "./locale";
+import { Readable, derived } from "svelte/store";
+
 import type { BundlesStore } from "./bundles";
+import type { LocaleStore } from "./locale";
 
 export type TranslateValue = (
   id: string,

--- a/crates/lgn-web-client/frontend/svelte.config.js
+++ b/crates/lgn-web-client/frontend/svelte.config.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 import preprocess from "svelte-preprocess";
 
 export default {

--- a/crates/lgn-web-client/frontend/tests/components/TopBar.test.ts
+++ b/crates/lgn-web-client/frontend/tests/components/TopBar.test.ts
@@ -1,5 +1,6 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+
 import TopBar from "../../src/components/TopBar.svelte";
-import { render, fireEvent, cleanup } from "@testing-library/svelte";
 
 describe("TopBar", () => {
   afterEach(() => cleanup());

--- a/crates/lgn-web-client/frontend/vite.config.js
+++ b/crates/lgn-web-client/frontend/vite.config.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,7 @@ importers:
       '@tauri-apps/api': ^1.0.0-rc.2
       '@testing-library/jest-dom': ^5.16.3
       '@testing-library/svelte': ^3.1.0
+      '@trivago/prettier-plugin-sort-imports': ^3.2.0
       '@types/color-convert': ^2.0.0
       '@types/uuid': ^8.3.4
       '@typescript-eslint/eslint-plugin': ^5.16.0
@@ -214,6 +215,7 @@ importers:
       '@swc/core': 1.2.161
       '@testing-library/jest-dom': 5.16.3
       '@testing-library/svelte': 3.1.0_svelte@3.46.4
+      '@trivago/prettier-plugin-sort-imports': 3.2.0_prettier@2.6.1
       '@types/color-convert': 2.0.0
       '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.16.0_4df62b6e125e6f18efee2d013b4a9d80
@@ -272,6 +274,7 @@ importers:
       '@tauri-apps/api': ^1.0.0-rc.2
       '@testing-library/jest-dom': ^5.16.3
       '@testing-library/svelte': ^3.1.0
+      '@trivago/prettier-plugin-sort-imports': ^3.2.0
       '@types/color-convert': ^2.0.0
       '@typescript-eslint/eslint-plugin': ^5.16.0
       '@typescript-eslint/parser': ^5.16.0
@@ -321,6 +324,7 @@ importers:
       '@swc/core': 1.2.161
       '@testing-library/jest-dom': 5.16.3
       '@testing-library/svelte': 3.1.0_svelte@3.46.4
+      '@trivago/prettier-plugin-sort-imports': 3.2.0_prettier@2.6.1
       '@types/color-convert': 2.0.0
       '@typescript-eslint/eslint-plugin': 5.16.0_4df62b6e125e6f18efee2d013b4a9d80
       '@typescript-eslint/parser': 5.16.0_eslint@8.12.0+typescript@4.6.3
@@ -441,6 +445,7 @@ importers:
       '@tauri-apps/api': ^1.0.0-rc.2
       '@testing-library/jest-dom': ^5.16.3
       '@testing-library/svelte': ^3.1.0
+      '@trivago/prettier-plugin-sort-imports': ^3.2.0
       '@types/color-convert': ^2.0.0
       '@types/estree': ^0.0.51
       '@typescript-eslint/eslint-plugin': ^5.16.0
@@ -495,6 +500,7 @@ importers:
       '@swc/core': 1.2.161
       '@testing-library/jest-dom': 5.16.3
       '@testing-library/svelte': 3.1.0_svelte@3.46.4
+      '@trivago/prettier-plugin-sort-imports': 3.2.0_prettier@2.6.1
       '@types/color-convert': 2.0.0
       '@types/estree': 0.0.51
       '@typescript-eslint/eslint-plugin': 5.16.0_4df62b6e125e6f18efee2d013b4a9d80
@@ -561,6 +567,30 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/core/7.13.10:
+    resolution: {integrity: sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.17.3
+      '@babel/helper-compilation-targets': 7.16.7_@babel+core@7.13.10
+      '@babel/helper-module-transforms': 7.16.7
+      '@babel/helpers': 7.17.2
+      '@babel/parser': 7.17.3
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+      convert-source-map: 1.8.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.0
+      lodash: 4.17.21
+      semver: 6.3.0
+      source-map: 0.5.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/core/7.17.5:
     resolution: {integrity: sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==}
     engines: {node: '>=6.9.0'}
@@ -584,6 +614,14 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/generator/7.13.9:
+    resolution: {integrity: sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==}
+    dependencies:
+      '@babel/types': 7.17.0
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    dev: true
+
   /@babel/generator/7.17.3:
     resolution: {integrity: sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==}
     engines: {node: '>=6.9.0'}
@@ -591,6 +629,19 @@ packages:
       '@babel/types': 7.17.0
       jsesc: 2.5.2
       source-map: 0.5.7
+    dev: true
+
+  /@babel/helper-compilation-targets/7.16.7_@babel+core@7.13.10:
+    resolution: {integrity: sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.17.0
+      '@babel/core': 7.13.10
+      '@babel/helper-validator-option': 7.16.7
+      browserslist: 4.20.2
+      semver: 6.3.0
     dev: true
 
   /@babel/helper-compilation-targets/7.16.7_@babel+core@7.17.5:
@@ -708,9 +759,16 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
+  /@babel/parser/7.14.6:
+    resolution: {integrity: sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dev: true
+
   /@babel/parser/7.17.3:
     resolution: {integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.17.5:
@@ -856,6 +914,22 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
+  /@babel/traverse/7.13.0:
+    resolution: {integrity: sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==}
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.17.3
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/parser': 7.17.3
+      '@babel/types': 7.17.0
+      debug: 4.3.4
+      globals: 11.12.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/traverse/7.17.3:
     resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
     engines: {node: '>=6.9.0'}
@@ -868,10 +942,18 @@ packages:
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/parser': 7.17.3
       '@babel/types': 7.17.0
-      debug: 4.3.3
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/types/7.13.0:
+    resolution: {integrity: sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      lodash: 4.17.21
+      to-fast-properties: 2.0.0
     dev: true
 
   /@babel/types/7.17.0:
@@ -1522,6 +1604,23 @@ packages:
   /@tootallnate/once/1.1.2:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /@trivago/prettier-plugin-sort-imports/3.2.0_prettier@2.6.1:
+    resolution: {integrity: sha512-DnwLe+z8t/dZX5xBbYZV1+C5STkyK/P6SSq3Nk6NXlJZsgvDZX2eN4ND7bMFgGV/NL/YChWzcNf6ziGba1ktQQ==}
+    peerDependencies:
+      prettier: 2.x
+    dependencies:
+      '@babel/core': 7.13.10
+      '@babel/generator': 7.13.9
+      '@babel/parser': 7.14.6
+      '@babel/traverse': 7.13.0
+      '@babel/types': 7.13.0
+      javascript-natural-sort: 0.7.1
+      lodash: 4.17.21
+      prettier: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@types/aria-query/4.2.2:
@@ -3955,6 +4054,10 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: true
 
+  /javascript-natural-sort/0.7.1:
+    resolution: {integrity: sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=}
+    dev: true
+
   /jest-changed-files/27.5.1:
     resolution: {integrity: sha512-buBLMiByfWGCoMsLLzGUUSpAmIAGnbR2KJoMN10ziLhOLvP4e0SlypHnAel8iqQXTrcbmfEY9sSqae5sgUsTvw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4482,6 +4585,7 @@ packages:
   /jsesc/2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
+    hasBin: true
     dev: true
 
   /json-parse-even-better-errors/2.3.1:
@@ -4506,6 +4610,7 @@ packages:
   /json5/2.2.0:
     resolution: {integrity: sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==}
     engines: {node: '>=6'}
+    hasBin: true
     dependencies:
       minimist: 1.2.5
     dev: true


### PR DESCRIPTION
Finally grouping and sorting imports using [prettier plugin sort imports](https://github.com/trivago/prettier-plugin-sort-imports).

I'm using Prettier instead of Eslint for this for the following reasons:
- Eslint svelte plugin is not compatible with Eslint sort import plugin (https://github.com/sveltejs/eslint-plugin-svelte3/blob/master/OTHER_PLUGINS.md)
- Conceptually Prettier is our formatter and imports are all related to format, not "code" good practices

