### PR TITLE
occluder fix at high aspect ratios

### DIFF
--- a/crates/lgn-graphics-renderer/gpu/codegen/culling.rn
+++ b/crates/lgn-graphics-renderer/gpu/codegen/culling.rn
@@ -52,8 +52,9 @@ pub fn main(persistent_descriptor_set, frame_descriptor_set, view_descriptor_set
             fields: [
                 #{ name:"first_render_pass", ty:"Uint1" },
                 #{ name:"num_render_passes", ty:"Uint1" },
-                #{ name:"options", ty:"CullingOptions" },
+                #{ name:"hzb_max_lod", ty:"Uint1" },                
                 #{ name:"hzb_pixel_extents", ty:"Float2" },
+                #{ name:"options", ty:"CullingOptions" },
             ]
         },
         #{

--- a/crates/lgn-graphics-renderer/gpu/shaders/culling.hlsl
+++ b/crates/lgn-graphics-renderer/gpu/shaders/culling.hlsl
@@ -8,7 +8,7 @@
 float aabb_max_z(float4 aabb, float2 view_port, float debug_index) {
     float4 aabb_vp = min(aabb * view_port.xyxy, view_port.xyxy);
     float2 size = aabb_vp.zw - aabb_vp.xy;
-    float lod = max(ceil(log2(max(size.x, size.y))) - 1, 0);
+    float lod = clamp(ceil(log2(max(size.x, size.y))) - 1, 0, push_constant.hzb_max_lod);
    
     float4 aabb_ts = float4(aabb_vp.x, view_port.y - aabb_vp.w, aabb_vp.z, view_port.y - aabb_vp.y);
     uint4 iaabb = (uint4)(aabb_ts * exp2(-lod));

--- a/crates/lgn-graphics-renderer/src/egui/egui_pass.rs
+++ b/crates/lgn-graphics-renderer/src/egui/egui_pass.rs
@@ -268,5 +268,6 @@ impl EguiPass {
             cmd_buffer.push_constant(&push_constant_data);
             cmd_buffer.draw_indexed(mesh.indices.len() as u32, 0, 0);
         }
+        cmd_buffer.end_render_pass();
     }
 }

--- a/crates/lgn-graphics-renderer/src/gpu_renderer/hzb_surface.rs
+++ b/crates/lgn-graphics-renderer/src/gpu_renderer/hzb_surface.rs
@@ -43,6 +43,9 @@ impl HzbSurface {
             hzb_height /= 2.0;
         }
 
+        hzb_width = hzb_width.max(4.0);
+        hzb_height = hzb_height.max(4.0);
+
         let mut min_extent = hzb_width.min(hzb_height) as u32;
         let mut mip_count = 1;
         while min_extent != 1 {
@@ -111,6 +114,10 @@ impl HzbSurface {
             self.texture.definition().extents.width as f32,
             self.texture.definition().extents.height as f32,
         )
+    }
+
+    pub fn hzb_max_lod(&self) -> u32 {
+        self.texture.definition().mip_count - 1
     }
 
     pub fn generate_hzb(


### PR DESCRIPTION
Close render pass in UI so it does not crash on resource transitions that occur afterwards 
Clamp HZB size to min 4 by 4 for crash when minimizing sandbox
Clamp hzb mip so we don't sample outside the range (which gives us 0.0 depth and false occlusion)