### PR TITLE
Fix egui window dragging

### DIFF
--- a/crates/lgn-streamer/src/streamer/events.rs
+++ b/crates/lgn-streamer/src/streamer/events.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::bail;
 use lgn_input::{
     keyboard::KeyboardInput,
-    mouse::{MouseButton, MouseButtonInput, MouseMotion, MouseWheel},
+    mouse::{MouseButton, MouseButtonInput, MouseWheel},
     touch::TouchInput,
     ElementState,
 };
@@ -91,6 +91,13 @@ impl From<&MouseButtonInputPayload> for MouseButtonInput {
             pos: *pos,
         }
     }
+}
+
+/// A mouse motion event
+#[derive(Debug, Deserialize)]
+pub struct MouseMotion {
+    pub current: Vec2,
+    pub delta: Vec2,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/lgn-streamer/src/streamer/mod.rs
+++ b/crates/lgn-streamer/src/streamer/mod.rs
@@ -16,7 +16,7 @@ use lgn_input::{
     touch::TouchInput,
 };
 use lgn_tracing::{error, info, trace, warn};
-use lgn_window::{WindowCreated, WindowResized, Windows};
+use lgn_window::{CursorMoved, WindowCreated, WindowId, WindowResized, Windows};
 use serde_json::json;
 use webrtc::{
     data_channel::{data_channel_message::DataChannelMessage, RTCDataChannel},
@@ -215,6 +215,7 @@ pub(crate) fn update_streams(
     mut input_mouse_wheel: EventWriter<'_, '_, MouseWheel>,
     mut input_touch_input: EventWriter<'_, '_, TouchInput>,
     mut input_keyboard_input: EventWriter<'_, '_, KeyboardInput>,
+    mut input_cursor_moved: EventWriter<'_, '_, CursorMoved>,
     mut streamer_windows: ResMut<'_, StreamerWindows>,
     mut window_list: ResMut<'_, Windows>,
     mut created_events: ResMut<'_, Events<WindowCreated>>,
@@ -261,7 +262,13 @@ pub(crate) fn update_streams(
                         input_mouse_button_input.send(mouse_button_input.clone());
                     }
                     Input::MouseMotion(mouse_motion) => {
-                        input_mouse_motion.send(mouse_motion.clone());
+                        input_mouse_motion.send(MouseMotion {
+                            delta: mouse_motion.delta,
+                        });
+                        input_cursor_moved.send(CursorMoved {
+                            id: WindowId::primary(),
+                            position: mouse_motion.current,
+                        });
                     }
                     Input::MouseWheel(mouse_wheel) => {
                         input_mouse_wheel.send(mouse_wheel.clone());

--- a/crates/lgn-web-client/frontend/src/actions/remoteWindowInputs/index.ts
+++ b/crates/lgn-web-client/frontend/src/actions/remoteWindowInputs/index.ts
@@ -52,6 +52,8 @@ export type MouseButtonInput = Type<"MouseButtonInput"> & {
 
 /** Represents a cursor move input, the last known cursor position and the current cursor position are included */
 export type MouseMotion = Type<"MouseMotion"> & {
+  /** The current cursor position */
+  current: Vec2;
   /** The difference between the last known position and the current one */
   delta: Vec2;
 };
@@ -189,6 +191,7 @@ function createEvents(state: State, element: HTMLElement, onInput: Listener) {
 
     const mouseMotion: MouseMotion = {
       type: "MouseMotion",
+      current: currentMousePosition,
       delta: [
         currentMousePosition[0] - previousMousePosition[0],
         currentMousePosition[1] - previousMousePosition[1],


### PR DESCRIPTION
Was missing CursorMoved events from streamed inputs.
Since egui reacts only to CursorMoved, and not MouseMotion, this explains why egui panel were displayed but could not be moved.
Closes #1334 