### PR TITLE
integrated PR #4224 from Bevy

### DIFF
--- a/crates/lgn-ecs/src/lib.rs
+++ b/crates/lgn-ecs/src/lib.rs
@@ -42,6 +42,7 @@ pub mod prelude {
         system::{
             Commands, In, IntoChainSystem, IntoExclusiveSystem, IntoSystem, Local, NonSend,
             NonSendMut, Query, QuerySet, RemovedComponents, Res, ResMut, System,
+            SystemParamFunction,
         },
         world::{FromWorld, Mut, World},
     };

--- a/crates/lgn-ecs/src/schedule/stage.rs
+++ b/crates/lgn-ecs/src/schedule/stage.rs
@@ -1606,15 +1606,25 @@ mod tests {
     fn ambiguity_detection() {
         use super::{find_ambiguities, SystemContainer};
 
-        fn find_ambiguities_first_labels(
+        fn find_ambiguities_first_str_labels(
             systems: &[impl SystemContainer],
         ) -> Vec<(BoxedSystemLabel, BoxedSystemLabel)> {
             find_ambiguities(systems)
                 .drain(..)
                 .map(|(index_a, index_b, _conflicts)| {
                     (
-                        systems[index_a].labels()[0].clone(),
-                        systems[index_b].labels()[0].clone(),
+                        systems[index_a]
+                            .labels()
+                            .iter()
+                            .find(|a| (&***a).type_id() == std::any::TypeId::of::<&str>())
+                            .unwrap()
+                            .clone(),
+                        systems[index_b]
+                            .labels()
+                            .iter()
+                            .find(|a| (&***a).type_id() == std::any::TypeId::of::<&str>())
+                            .unwrap()
+                            .clone(),
                     )
                 })
                 .collect()
@@ -1644,7 +1654,7 @@ mod tests {
             .with_system(component.label("4"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("4")))
                 || ambiguities.contains(&(Box::new("4"), Box::new("1")))
@@ -1659,7 +1669,7 @@ mod tests {
             .with_system(resource.label("4"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("4")))
                 || ambiguities.contains(&(Box::new("4"), Box::new("1")))
@@ -1684,7 +1694,7 @@ mod tests {
             .with_system(resource.label("4"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("0"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("0")))
@@ -1703,7 +1713,7 @@ mod tests {
             .with_system(resource.label("4").in_ambiguity_set("a"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("0"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("0")))
@@ -1716,7 +1726,7 @@ mod tests {
             .with_system(component.label("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("0"), Box::new("1")))
                 || ambiguities.contains(&(Box::new("1"), Box::new("0")))
@@ -1729,7 +1739,7 @@ mod tests {
             .with_system(component.label("2").after("0"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1743,7 +1753,7 @@ mod tests {
             .with_system(component.label("3").after("1").after("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1757,7 +1767,7 @@ mod tests {
             .with_system(component.label("3").after("1").after("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert_eq!(ambiguities.len(), 0);
 
         let mut stage = SystemStage::parallel()
@@ -1767,7 +1777,7 @@ mod tests {
             .with_system(component.label("3").after("1").after("2"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1797,7 +1807,7 @@ mod tests {
             );
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("2")))
                 || ambiguities.contains(&(Box::new("2"), Box::new("1")))
@@ -1847,7 +1857,7 @@ mod tests {
             );
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert_eq!(ambiguities.len(), 0);
 
         let mut stage = SystemStage::parallel()
@@ -1878,7 +1888,7 @@ mod tests {
             );
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.parallel);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.parallel);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("4")))
                 || ambiguities.contains(&(Box::new("4"), Box::new("1")))
@@ -1912,7 +1922,7 @@ mod tests {
             .with_system(empty.exclusive_system().label("6").after("2").after("5"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.exclusive_at_start);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.exclusive_at_start);
         assert!(
             ambiguities.contains(&(Box::new("1"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("1")))
@@ -1949,7 +1959,7 @@ mod tests {
             .with_system(empty.exclusive_system().label("6").after("2").after("5"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.exclusive_at_start);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.exclusive_at_start);
         assert!(
             ambiguities.contains(&(Box::new("2"), Box::new("3")))
                 || ambiguities.contains(&(Box::new("3"), Box::new("2")))
@@ -1975,7 +1985,7 @@ mod tests {
             .with_system(empty.exclusive_system().label("3").in_ambiguity_set("a"));
         stage.initialize_systems(&mut world);
         stage.rebuild_orders_and_dependencies();
-        let ambiguities = find_ambiguities_first_labels(&stage.exclusive_at_start);
+        let ambiguities = find_ambiguities_first_str_labels(&stage.exclusive_at_start);
         assert_eq!(ambiguities.len(), 0);
     }
 

--- a/crates/lgn-ecs/src/schedule/system_descriptor.rs
+++ b/crates/lgn-ecs/src/schedule/system_descriptor.rs
@@ -3,7 +3,10 @@ use crate::{
         AmbiguitySetLabel, BoxedAmbiguitySetLabel, BoxedSystemLabel, IntoRunCriteria,
         RunCriteriaDescriptorOrLabel, SystemLabel,
     },
-    system::{BoxedSystem, ExclusiveSystem, ExclusiveSystemCoerced, ExclusiveSystemFn, IntoSystem},
+    system::{
+        AsSystemLabel, BoxedSystem, ExclusiveSystem, ExclusiveSystemCoerced, ExclusiveSystemFn,
+        IntoSystem,
+    },
 };
 
 /// Encapsulates a system and information on when it run in a `SystemStage`.
@@ -106,9 +109,9 @@ pub struct ParallelSystemDescriptor {
 
 fn new_parallel_descriptor(system: BoxedSystem<(), ()>) -> ParallelSystemDescriptor {
     ParallelSystemDescriptor {
+        labels: system.default_labels(),
         system,
         run_criteria: None,
-        labels: Vec::new(),
         before: Vec::new(),
         after: Vec::new(),
         ambiguity_sets: Vec::new(),
@@ -129,10 +132,10 @@ pub trait ParallelSystemDescriptorCoercion<Params> {
 
     /// Specifies that the system should run before systems with the given
     /// label.
-    fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
+    fn before<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor;
 
     /// Specifies that the system should run after systems with the given label.
-    fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor;
+    fn after<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor;
 
     /// Specifies that the system is exempt from execution order ambiguity
     /// detection with other systems in this set.
@@ -153,13 +156,13 @@ impl ParallelSystemDescriptorCoercion<()> for ParallelSystemDescriptor {
         self
     }
 
-    fn before(mut self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        self.before.push(Box::new(label));
+    fn before<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
+        self.before.push(Box::new(label.as_system_label()));
         self
     }
 
-    fn after(mut self, label: impl SystemLabel) -> ParallelSystemDescriptor {
-        self.after.push(Box::new(label));
+    fn after<Marker>(mut self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
+        self.after.push(Box::new(label.as_system_label()));
         self
     }
 
@@ -185,11 +188,11 @@ where
         new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).label(label)
     }
 
-    fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn before<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).before(label)
     }
 
-    fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn after<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(Box::new(IntoSystem::into_system(self))).after(label)
     }
 
@@ -210,11 +213,11 @@ impl ParallelSystemDescriptorCoercion<()> for BoxedSystem<(), ()> {
         new_parallel_descriptor(self).label(label)
     }
 
-    fn before(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn before<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(self).before(label)
     }
 
-    fn after(self, label: impl SystemLabel) -> ParallelSystemDescriptor {
+    fn after<Marker>(self, label: impl AsSystemLabel<Marker>) -> ParallelSystemDescriptor {
         new_parallel_descriptor(self).after(label)
     }
 

--- a/crates/lgn-ecs/src/system/function_system.rs
+++ b/crates/lgn-ecs/src/system/function_system.rs
@@ -1,6 +1,6 @@
 #![allow(unsafe_code)]
 
-use std::{borrow::Cow, marker::PhantomData};
+use std::{borrow::Cow, fmt::Debug, hash::Hash, marker::PhantomData};
 
 use lgn_ecs_macros::all_tuples;
 
@@ -8,6 +8,7 @@ use crate::{
     archetype::{Archetype, ArchetypeComponentId, ArchetypeGeneration, ArchetypeId},
     component::ComponentId,
     query::{Access, FilteredAccessSet},
+    schedule::SystemLabel,
     system::{
         check_system_change_tick, ReadOnlySystemParamFetch, System, SystemParam, SystemParamFetch,
         SystemParamState,
@@ -435,6 +436,47 @@ where
             self.system_meta.name.as_ref(),
         );
     }
+    fn default_labels(&self) -> Vec<Box<dyn SystemLabel>> {
+        vec![Box::new(self.func.as_system_label())]
+    }
+}
+
+/// A [`SystemLabel`] that was automatically generated for a system on the basis of its `TypeId`.
+pub struct SystemTypeIdLabel<T: 'static>(PhantomData<fn() -> T>);
+
+impl<T> Debug for SystemTypeIdLabel<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SystemTypeIdLabel")
+            .field(&std::any::type_name::<T>())
+            .finish()
+    }
+}
+impl<T> Hash for SystemTypeIdLabel<T> {
+    fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {
+        // All SystemTypeIds of a given type are the same.
+    }
+}
+impl<T> Clone for SystemTypeIdLabel<T> {
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Copy for SystemTypeIdLabel<T> {}
+
+impl<T> PartialEq for SystemTypeIdLabel<T> {
+    #[inline]
+    fn eq(&self, _other: &Self) -> bool {
+        // All labels of a given type are equal, as they will all have the same type id
+        true
+    }
+}
+impl<T> Eq for SystemTypeIdLabel<T> {}
+
+impl<T> SystemLabel for SystemTypeIdLabel<T> {
+    fn dyn_clone(&self) -> Box<dyn SystemLabel> {
+        Box::new(*self)
+    }
 }
 
 /// A trait implemented for all functions that can be used as [`System`]s.
@@ -504,3 +546,28 @@ macro_rules! impl_system_function {
 }
 
 all_tuples!(impl_system_function, 0, 16, F);
+
+/// Used to implicitly convert systems to their default labels. For example, it will convert
+/// "system functions" to their [`SystemTypeIdLabel`].
+pub trait AsSystemLabel<Marker> {
+    type SystemLabel: SystemLabel;
+    fn as_system_label(&self) -> Self::SystemLabel;
+}
+
+impl<In, Out, Param: SystemParam, Marker, T: SystemParamFunction<In, Out, Param, Marker>>
+    AsSystemLabel<(In, Out, Param, Marker)> for T
+{
+    type SystemLabel = SystemTypeIdLabel<Self>;
+
+    fn as_system_label(&self) -> Self::SystemLabel {
+        SystemTypeIdLabel(PhantomData::<fn() -> Self>)
+    }
+}
+
+impl<T: SystemLabel + Clone> AsSystemLabel<()> for T {
+    type SystemLabel = T;
+
+    fn as_system_label(&self) -> Self::SystemLabel {
+        self.clone()
+    }
+}

--- a/crates/lgn-ecs/src/system/system.rs
+++ b/crates/lgn-ecs/src/system/system.rs
@@ -6,6 +6,7 @@ use crate::{
     archetype::{Archetype, ArchetypeComponentId},
     component::ComponentId,
     query::Access,
+    schedule::SystemLabel,
     world::World,
 };
 
@@ -59,6 +60,10 @@ pub trait System: Send + Sync + 'static {
     /// Initialize the system.
     fn initialize(&mut self, _world: &mut World);
     fn check_change_tick(&mut self, change_tick: u32);
+    /// The default labels for the system
+    fn default_labels(&self) -> Vec<Box<dyn SystemLabel>> {
+        Vec::new()
+    }
 }
 
 /// A convenience type alias for a boxed [`System`] trait object.


### PR DESCRIPTION
Systems are auto-labelled, so that we can now write:
// ordering two systems without manually defining labels
app
  .add_system(update_velocity)
  .add_system(movement.after(update_velocity))

see https://github.com/bevyengine/bevy/pull/4224