### PR TITLE
Editor client: Save custom server urls in session storage

### DIFF
--- a/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
@@ -43,10 +43,28 @@
   const redirectUri = `${document.location.origin}/`;
 
   export const load: Load = async ({ fetch, url }) => {
+    const editorServerUrlKey = "editor-server-url";
+    const editorRuntimerUrlKey = "editor-runtime-url";
+
+    if (url.searchParams.has(editorServerUrlKey)) {
+      sessionStorage.setItem(
+        editorServerUrlKey,
+        url.searchParams.get(editorServerUrlKey) as string
+      );
+    }
+
+    if (url.searchParams.has(editorRuntimerUrlKey)) {
+      sessionStorage.setItem(
+        editorRuntimerUrlKey,
+        url.searchParams.get(editorRuntimerUrlKey) as string
+      );
+    }
+
     const editorServerUrl =
-      url.searchParams.get("editor-server-url") || undefined;
+      sessionStorage.getItem(editorServerUrlKey) || undefined;
+
     const runtimeServerUrl =
-      url.searchParams.get("runtime-server-url") || undefined;
+      sessionStorage.getItem(editorRuntimerUrlKey) || undefined;
 
     initApiClient({ editorServerUrl });
 


### PR DESCRIPTION
Closes https://github.com/legion-labs/legion/issues/1329


Uses the [Session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) api under the hood, so that even when the query params are lost (like after logging in for instance), it's preserved. Closing the tab and opening a new one will "burst" the storage.