### PR TITLE
Editor client: Display currently used urls + Stores with storage

### DIFF
--- a/crates/lgn-analytics-gui/frontend/src/components/Metric/MetricCanvas.svelte
+++ b/crates/lgn-analytics-gui/frontend/src/components/Metric/MetricCanvas.svelte
@@ -2,7 +2,8 @@
   import * as d3 from "d3";
   import type { D3ZoomEvent } from "d3";
   import { onDestroy, onMount } from "svelte";
-  import { Unsubscriber, Writable, get } from "svelte/store";
+  import type { Unsubscriber, Writable } from "svelte/store";
+  import { get } from "svelte/store";
 
   import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
   import log from "@lgn/web-client/src/lib/log";

--- a/crates/lgn-analytics-gui/frontend/src/components/Metric/MetricSelection.svelte
+++ b/crates/lgn-analytics-gui/frontend/src/components/Metric/MetricSelection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
-  import { Unsubscriber, get } from "svelte/store";
+  import type { Unsubscriber } from "svelte/store";
+  import { get } from "svelte/store";
 
   import clickOutside from "@lgn/web-client/src/actions/clickOutside";
 

--- a/crates/lgn-analytics-gui/frontend/src/lib/Metric/MetricStreamer.ts
+++ b/crates/lgn-analytics-gui/frontend/src/lib/Metric/MetricStreamer.ts
@@ -1,5 +1,6 @@
 import Semaphore from "semaphore-async-await";
-import { Writable, get, writable } from "svelte/store";
+import type { Writable } from "svelte/store";
+import { get, writable } from "svelte/store";
 
 import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
 

--- a/crates/lgn-analytics-gui/frontend/src/lib/Misc/LoadingStore.ts
+++ b/crates/lgn-analytics-gui/frontend/src/lib/Misc/LoadingStore.ts
@@ -1,4 +1,5 @@
-import { Writable, writable } from "svelte/store";
+import type { Writable } from "svelte/store";
+import { writable } from "svelte/store";
 
 export const loadingStore = createLoadStore();
 

--- a/crates/lgn-analytics-gui/frontend/tests/index.test.ts
+++ b/crates/lgn-analytics-gui/frontend/tests/index.test.ts
@@ -3,3 +3,5 @@ describe("Truth", () => {
     expect(true).toBe(true);
   });
 });
+
+export {};

--- a/crates/lgn-analytics-gui/frontend/tsconfig.json
+++ b/crates/lgn-analytics-gui/frontend/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "importsNotUsedAsValues": "error",
+    "preserveValueImports": true,
+    "isolatedModules": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noEmit": true,

--- a/crates/lgn-editor-gui/frontend/benchmarks/lib/hierarchyTree.bench.ts
+++ b/crates/lgn-editor-gui/frontend/benchmarks/lib/hierarchyTree.bench.ts
@@ -1,4 +1,5 @@
-import { Entries, ItemBase, isEntry } from "@/lib/hierarchyTree";
+import type { ItemBase } from "@/lib/hierarchyTree";
+import { Entries, isEntry } from "@/lib/hierarchyTree";
 import type { Entry } from "@/lib/hierarchyTree";
 
 import { suite } from "../benchmark";

--- a/crates/lgn-editor-gui/frontend/src/hooks.ts
+++ b/crates/lgn-editor-gui/frontend/src/hooks.ts
@@ -2,7 +2,7 @@
 // We use this file solely to turn our whole app into an SPA
 import type { Handle } from "@sveltejs/kit";
 
-export const handle: Handle = async ({ event, resolve }) =>
+export const handle: Handle = ({ event, resolve }) =>
   resolve(event, {
     ssr: false,
   });

--- a/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" context="module">
   import { goto } from "$app/navigation";
   import type { Load } from "@sveltejs/kit";
+  import { get } from "svelte/store";
 
   import { headlessRun } from "@lgn/web-client";
   import type { NonEmptyArray } from "@lgn/web-client/src/lib/array";
@@ -11,6 +12,7 @@
   } from "@lgn/web-client/src/stores/workspace";
 
   import { initApiClient } from "@/api";
+  import { initAllActiveScenesStream } from "@/orchestrators/allActiveScenes";
   import { initMessageStream } from "@/orchestrators/selection";
   import contextMenu, {
     resourceBrowserItemContextMenuId,
@@ -20,6 +22,7 @@
     sceneExplorerItemContextMenuId,
     sceneExplorerItemEntries,
   } from "@/stores/contextMenu";
+  import devSettings from "@/stores/devSettings";
   import { initLogStream } from "@/stores/log";
   import { initStagedResourcesStream } from "@/stores/stagedResources";
   import tabPayloads from "@/stores/tabPayloads";
@@ -49,27 +52,18 @@
 
   export const load: Load = async ({ fetch, url }) => {
     const editorServerUrlKey = "editor-server-url";
-    const editorRuntimerUrlKey = "editor-runtime-url";
+    const runtimeServerUrlKey = "editor-runtime-url";
 
-    if (url.searchParams.has(editorServerUrlKey)) {
-      sessionStorage.setItem(
-        editorServerUrlKey,
-        url.searchParams.get(editorServerUrlKey) as string
-      );
-    }
+    devSettings.update((devSettings) => ({
+      ...devSettings,
+      editorServerUrl:
+        url.searchParams.get(editorServerUrlKey) || devSettings.editorServerUrl,
+      runtimeServerUrl:
+        url.searchParams.get(runtimeServerUrlKey) ||
+        devSettings.runtimeServerUrl,
+    }));
 
-    if (url.searchParams.has(editorRuntimerUrlKey)) {
-      sessionStorage.setItem(
-        editorRuntimerUrlKey,
-        url.searchParams.get(editorRuntimerUrlKey) as string
-      );
-    }
-
-    const editorServerUrl =
-      sessionStorage.getItem(editorServerUrlKey) || undefined;
-
-    const runtimeServerUrl =
-      sessionStorage.getItem(editorRuntimerUrlKey) || undefined;
+    const { editorServerUrl, runtimeServerUrl } = get(devSettings);
 
     initApiClient({ editorServerUrl, runtimeServerUrl });
 
@@ -192,7 +186,6 @@
   import { onMount } from "svelte";
 
   import AuthModal from "@/components/AuthModal.svelte";
-  import { initAllActiveScenesStream } from "@/orchestrators/allActiveScenes";
   import authStatus from "@/stores/authStatus";
   import modal from "@/stores/modal";
 

--- a/crates/lgn-editor-gui/frontend/src/routes/index.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/index.svelte
@@ -21,6 +21,7 @@
   import { currentResource } from "@/orchestrators/currentResource";
   import { currentResourceDescriptionEntry } from "@/orchestrators/resourceBrowserEntries";
   import contextMenu from "@/stores/contextMenu";
+  import devSettings from "@/stores/devSettings";
   import modal from "@/stores/modal";
   import notifications from "@/stores/notifications";
   import { stagedResources, syncFromMain } from "@/stores/stagedResources";
@@ -51,7 +52,7 @@
 <Notifications store={notifications} />
 
 <div class="root">
-  <TopBar />
+  <TopBar devSettings={$devSettings} />
   <div class="content-wrapper" class:tauri={window.__TAURI_METADATA__}>
     <div class="content">
       <div class="secondary-contents">
@@ -92,7 +93,7 @@
       </div>
     </div>
   </div>
-  <StatusBar stagedResources={$stagedResources || []} {syncFromMain} />
+  <StatusBar {syncFromMain} stagedResources={$stagedResources || []} />
 </div>
 
 <style lang="postcss">

--- a/crates/lgn-editor-gui/frontend/src/stores/devSettings.ts
+++ b/crates/lgn-editor-gui/frontend/src/stores/devSettings.ts
@@ -1,0 +1,6 @@
+import { createDevSettingsStore } from "@lgn/web-client/src/stores/devSettings";
+
+export default createDevSettingsStore("dev-settings", {
+  editorServerUrl: "http://[::1]:50051",
+  runtimeServerUrl: "http://[::1]:50052",
+});

--- a/crates/lgn-editor-gui/frontend/tests/components/propertyGrid/PropertyGrid.test.ts
+++ b/crates/lgn-editor-gui/frontend/tests/components/propertyGrid/PropertyGrid.test.ts
@@ -2,7 +2,8 @@ import { cleanup } from "@testing-library/svelte";
 import { render } from "@testing-library/svelte";
 
 import PropertyGrid from "@/components/propertyGrid/PropertyGrid.svelte";
-import { ResourceProperty, formatProperties } from "@/lib/propertyGrid";
+import type { ResourceProperty } from "@/lib/propertyGrid";
+import { formatProperties } from "@/lib/propertyGrid";
 import currentResource from "@/orchestrators/currentResource";
 import properties from "@/resources/propertiesResponse.json";
 

--- a/crates/lgn-editor-gui/frontend/tests/index.test.ts
+++ b/crates/lgn-editor-gui/frontend/tests/index.test.ts
@@ -3,3 +3,5 @@ describe("Truth", () => {
     expect(true).toBe(true);
   });
 });
+
+export {};

--- a/crates/lgn-editor-gui/frontend/tsconfig.json
+++ b/crates/lgn-editor-gui/frontend/tsconfig.json
@@ -4,7 +4,6 @@
     "importsNotUsedAsValues": "error",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "isolatedModules": false,
     "noEmit": true,
     "allowJs": true,
     "checkJs": true,

--- a/crates/lgn-runtime-gui/frontend/tests/index.test.ts
+++ b/crates/lgn-runtime-gui/frontend/tests/index.test.ts
@@ -3,3 +3,5 @@ describe("Truth", () => {
     expect(true).toBe(true);
   });
 });
+
+export {};

--- a/crates/lgn-runtime-gui/frontend/tsconfig.json
+++ b/crates/lgn-runtime-gui/frontend/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "importsNotUsedAsValues": "error",
+    "preserveValueImports": true,
+    "isolatedModules": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noEmit": true,

--- a/crates/lgn-web-client/frontend/package.json
+++ b/crates/lgn-web-client/frontend/package.json
@@ -43,6 +43,7 @@
     "svelte-check": "^2.4.6",
     "svelte-preprocess": "^4.10.4",
     "tailwindcss": "^3.0.23",
+    "type-fest": "^2.12.2",
     "typescript": "^4.6.3",
     "vite": "^2.8.6",
     "vitest": "^0.7.12"

--- a/crates/lgn-web-client/frontend/src/actions/remoteWindowInputs/index.ts
+++ b/crates/lgn-web-client/frontend/src/actions/remoteWindowInputs/index.ts
@@ -1,5 +1,6 @@
 import log from "../../lib/log";
-import { KeyCode, fromBrowserKey as keyCodeFromBrowserKey } from "./keys";
+import type { KeyCode } from "./keys";
+import { fromBrowserKey as keyCodeFromBrowserKey } from "./keys";
 
 const logLabel = "remote window inputs";
 

--- a/crates/lgn-web-client/frontend/src/components/ContextMenu.svelte
+++ b/crates/lgn-web-client/frontend/src/components/ContextMenu.svelte
@@ -121,7 +121,8 @@ export default buildContextMenu<ContextMenuEntryRecord>();
   import { sleep } from "../lib/promises";
   import type { Position } from "../lib/types";
   import type { ContextMenuStore } from "../stores/contextMenu";
-  import { Entry, ItemEntry, buildCustomEvent } from "../types/contextMenu";
+  import type { Entry, ItemEntry } from "../types/contextMenu";
+  import { buildCustomEvent } from "../types/contextMenu";
 
   const entryHeightRem = 2.5;
 

--- a/crates/lgn-web-client/frontend/src/components/Log.svelte
+++ b/crates/lgn-web-client/frontend/src/components/Log.svelte
@@ -20,7 +20,8 @@
     ListOnItemsRenderedProps,
     ListOnScrollProps,
   } from "svelte-window";
-  import { Writable, derived, writable } from "svelte/store";
+  import type { Writable } from "svelte/store";
+  import { derived, writable } from "svelte/store";
 
   import { remToPx } from "../lib/html";
   import { debounced, recorded } from "../lib/store";

--- a/crates/lgn-web-client/frontend/src/components/RemoteWindow.svelte
+++ b/crates/lgn-web-client/frontend/src/components/RemoteWindow.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
 
-  import remoteWindowInputs, {
-    RemoteWindowInput,
-  } from "../actions/remoteWindowInputs";
+  import type { RemoteWindowInput } from "../actions/remoteWindowInputs";
+  import remoteWindowInputs from "../actions/remoteWindowInputs";
   import resize from "../actions/resize";
   import type { PushableHTMLVideoElement } from "../actions/videoPlayer";
   import videoPlayer from "../actions/videoPlayer";
-  import {
-    ServerType,
-    initializeStream,
-    onReceiveControlMessage,
-  } from "../api";
+  import type { ServerType } from "../api";
+  import { initializeStream, onReceiveControlMessage } from "../api";
   import log from "../lib/log";
   import { debounce, retry } from "../lib/promises";
   import type { Resolution } from "../lib/types";

--- a/crates/lgn-web-client/frontend/src/components/StatusBar.svelte
+++ b/crates/lgn-web-client/frontend/src/components/StatusBar.svelte
@@ -16,9 +16,11 @@
 
 <div class="root">
   <div class="status">
-    {#if $statusStore}
-      {$statusStore}
-    {/if}
+    <div class="status-message">
+      {#if $statusStore}
+        {$statusStore}
+      {/if}
+    </div>
   </div>
   {#if stagedResources}
     <div class="local-changes">
@@ -50,6 +52,10 @@
   }
 
   .status {
+    @apply flex flex-row items-center h-full;
+  }
+
+  .status-message {
     @apply flex flex-row items-center h-full animate-pulse;
   }
 

--- a/crates/lgn-web-client/frontend/src/components/TopBar.svelte
+++ b/crates/lgn-web-client/frontend/src/components/TopBar.svelte
@@ -3,13 +3,13 @@
   import { onMount } from "svelte";
 
   import clickOutside from "../actions/clickOutside";
-  import { UserInfo, authClient } from "../lib/auth";
+  import { authClient } from "../lib/auth";
+  import type { UserInfo } from "../lib/auth";
   import log from "../lib/log";
   import userInfo from "../orchestrators/userInfo";
-  import topBarMenuStore, {
-    Id as TopBarMenuId,
-    menus as topBarMenus,
-  } from "../stores/topBarMenu";
+  import type { DevSettingsValue } from "../stores/devSettings";
+  import type { Id as TopBarMenuId } from "../stores/topBarMenu";
+  import topBarMenuStore, { menus as topBarMenus } from "../stores/topBarMenu";
   import BrandLogo from "./BrandLogo.svelte";
 
   const { data: userInfoData } = userInfo;
@@ -18,6 +18,8 @@
 
   export let documentTitle: string | null = null;
 
+  export let devSettings: DevSettingsValue | null = null;
+
   let topBarHandle: HTMLDivElement | undefined;
 
   let topBarMinimize: HTMLDivElement | undefined;
@@ -25,6 +27,8 @@
   let topBarMaximize: HTMLDivElement | undefined;
 
   let topBarClose: HTMLDivElement | undefined;
+
+  let devSettingsTitle: string | null = null;
 
   onMount(async () => {
     if (!isTauri) {
@@ -109,6 +113,10 @@
       window.location.href = authorizationUrl;
     }
   }
+
+  $: if (devSettings) {
+    devSettingsTitle = `Editor server url: ${devSettings.editorServerUrl}\nRuntime server url: ${devSettings.runtimeServerUrl}`;
+  }
 </script>
 
 <div class="root" class:tauri={isTauri}>
@@ -157,6 +165,15 @@
     </div>
   </div>
   <div class="actions">
+    {#if devSettings}
+      <div class="dev-settings" title={devSettingsTitle}>
+        <Icon
+          class="w-full h-full"
+          icon="ic:baseline-settings"
+          title={devSettingsTitle}
+        />
+      </div>
+    {/if}
     <div
       class="authentication"
       class:cursor-pointer={!$userInfoData}
@@ -242,6 +259,10 @@
 
   .actions {
     @apply flex flex-row h-full justify-end items-center space-x-4;
+  }
+
+  .dev-settings {
+    @apply h-6 w-6;
   }
 
   .authentication {

--- a/crates/lgn-web-client/frontend/src/index.ts
+++ b/crates/lgn-web-client/frontend/src/index.ts
@@ -2,7 +2,8 @@ import grpcWeb from "@improbable-eng/grpc-web";
 import { SvelteComponentTyped } from "svelte";
 
 import { initApiClient } from "./api";
-import { InitAuthUserConfig, authClient, initAuth } from "./lib/auth";
+import type { InitAuthUserConfig } from "./lib/auth";
+import { authClient, initAuth } from "./lib/auth";
 import type { InitAuthStatus } from "./lib/auth";
 import log from "./lib/log";
 import type { Level as LogLevel } from "./lib/log";

--- a/crates/lgn-web-client/frontend/src/lib/storage.ts
+++ b/crates/lgn-web-client/frontend/src/lib/storage.ts
@@ -1,0 +1,184 @@
+import type { JsonValue } from "type-fest";
+
+export interface Storage<Key, Value extends JsonValue> {
+  get(key: Key): Value | null;
+  has(key: Key): boolean;
+  remove(key: Key): boolean;
+  clear(): boolean;
+  set(key: Key, value: Value): boolean;
+  entries(): [Key, Value][];
+}
+
+export class DefaultLocalStorage<Key extends string, Value extends JsonValue>
+  implements Storage<Key, Value>
+{
+  get(key: Key): Value | null {
+    const value = globalThis.localStorage.getItem(key);
+
+    if (value === null) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(value) as Value;
+    } catch {
+      return null;
+    }
+  }
+
+  has(key: Key): boolean {
+    return globalThis.localStorage.getItem(key) !== null;
+  }
+
+  remove(key: Key): boolean {
+    globalThis.localStorage.removeItem(key);
+
+    return !this.has(key);
+  }
+
+  clear(): boolean {
+    globalThis.localStorage.clear();
+
+    return true;
+  }
+
+  set(key: Key, value: Value): boolean {
+    try {
+      globalThis.localStorage.setItem(key, JSON.stringify(value));
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  entries(): [Key, Value][] {
+    const entries: [Key, Value][] = [];
+
+    for (let i = 0; i <= globalThis.localStorage.length; i++) {
+      const key = globalThis.localStorage.key(i);
+
+      if (key !== null) {
+        const value = this.get(key as Key);
+
+        if (value !== null) {
+          entries.push([key as Key, value]);
+        }
+      }
+    }
+
+    return entries;
+  }
+}
+
+export class DefaultSessionStorage<Key extends string, Value extends JsonValue>
+  implements Storage<Key, Value>
+{
+  get(key: Key): Value | null {
+    const value = globalThis.sessionStorage.getItem(key);
+
+    if (value === null) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(value) as Value;
+    } catch {
+      return null;
+    }
+  }
+
+  has(key: Key): boolean {
+    return globalThis.sessionStorage.getItem(key) !== null;
+  }
+
+  remove(key: Key): boolean {
+    globalThis.sessionStorage.removeItem(key);
+
+    return !this.has(key);
+  }
+
+  clear(): boolean {
+    globalThis.sessionStorage.clear();
+
+    return true;
+  }
+
+  set(key: Key, value: Value): boolean {
+    try {
+      globalThis.sessionStorage.setItem(key, JSON.stringify(value));
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  entries(): [Key, Value][] {
+    const entries: [Key, Value][] = [];
+
+    for (let i = 0; i <= globalThis.sessionStorage.length; i++) {
+      const key = globalThis.sessionStorage.key(i);
+
+      if (key !== null) {
+        const value = this.get(key as Key);
+
+        if (value !== null) {
+          entries.push([key as Key, value]);
+        }
+      }
+    }
+
+    return entries;
+  }
+}
+
+export class InMemory<Key extends string, Value extends JsonValue>
+  implements Storage<Key, Value>
+{
+  #record: Record<Key, string> = {} as Record<Key, string>;
+
+  get(key: Key): Value | null {
+    const value = this.#record[key];
+
+    if (value === undefined) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(value) as Value;
+    } catch {
+      return null;
+    }
+  }
+
+  has(key: Key): boolean {
+    return key in this.#record;
+  }
+
+  remove(key: Key): boolean {
+    delete this.#record[key];
+
+    return !this.has(key);
+  }
+
+  clear(): boolean {
+    this.#record = {} as Record<Key, string>;
+
+    return true;
+  }
+
+  set(key: Key, value: Value): boolean {
+    try {
+      this.#record[key] = JSON.stringify(value);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  entries(): [Key, Value][] {
+    return Object.entries(this.#record) as [Key, Value][];
+  }
+}

--- a/crates/lgn-web-client/frontend/src/stores/bundles.ts
+++ b/crates/lgn-web-client/frontend/src/stores/bundles.ts
@@ -1,5 +1,6 @@
 import type { FluentBundle } from "@fluent/bundle";
-import { Readable, derived } from "svelte/store";
+import type { Readable } from "svelte/store";
+import { derived } from "svelte/store";
 
 import type { MapStore, MapValue } from "./map";
 import { createMapStore } from "./map";

--- a/crates/lgn-web-client/frontend/src/stores/devSettings.ts
+++ b/crates/lgn-web-client/frontend/src/stores/devSettings.ts
@@ -1,0 +1,22 @@
+import type { Writable } from "svelte/store";
+
+import { DefaultSessionStorage } from "../lib/storage";
+import { connected } from "../lib/store";
+
+export type DevSettingsValue = {
+  editorServerUrl: string;
+  runtimeServerUrl: string;
+};
+
+export type DevSettingsStore = Writable<DevSettingsValue>;
+
+export function createDevSettingsStore(
+  key: string,
+  defaultValue: DevSettingsValue
+): DevSettingsStore {
+  return connected<string, DevSettingsValue>(
+    new DefaultSessionStorage(),
+    key,
+    defaultValue
+  );
+}

--- a/crates/lgn-web-client/frontend/src/stores/keyboardNavigation.ts
+++ b/crates/lgn-web-client/frontend/src/stores/keyboardNavigation.ts
@@ -1,4 +1,5 @@
-import { Writable, writable } from "svelte/store";
+import type { Writable } from "svelte/store";
+import { writable } from "svelte/store";
 
 export type KeyboardNavigationValue = {
   currentIndex: number | null;

--- a/crates/lgn-web-client/frontend/src/stores/locale.ts
+++ b/crates/lgn-web-client/frontend/src/stores/locale.ts
@@ -1,5 +1,6 @@
 import { negotiateLanguages } from "@fluent/langneg";
-import { Updater, Writable, derived, get } from "svelte/store";
+import type { Updater, Writable } from "svelte/store";
+import { derived, get } from "svelte/store";
 import { writable } from "svelte/store";
 
 import type { AvailableLocalesStore } from "./bundles";

--- a/crates/lgn-web-client/frontend/src/stores/modal.ts
+++ b/crates/lgn-web-client/frontend/src/stores/modal.ts
@@ -1,5 +1,6 @@
 import { SvelteComponentTyped } from "svelte";
-import { Writable, get, writable } from "svelte/store";
+import type { Writable } from "svelte/store";
+import { get, writable } from "svelte/store";
 
 import Prompt from "../components/modal/Prompt.svelte";
 

--- a/crates/lgn-web-client/frontend/src/stores/translate.ts
+++ b/crates/lgn-web-client/frontend/src/stores/translate.ts
@@ -1,5 +1,6 @@
 import type { FluentBundle, FluentVariable } from "@fluent/bundle";
-import { Readable, derived } from "svelte/store";
+import type { Readable } from "svelte/store";
+import { derived } from "svelte/store";
 
 import type { BundlesStore } from "./bundles";
 import type { LocaleStore } from "./locale";

--- a/crates/lgn-web-client/frontend/src/stores/workspace.ts
+++ b/crates/lgn-web-client/frontend/src/stores/workspace.ts
@@ -3,7 +3,8 @@
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
-import { NonEmptyArray, isNonEmpty } from "../lib/array";
+import type { NonEmptyArray } from "../lib/array";
+import { isNonEmpty } from "../lib/array";
 import type { Size } from "../lib/types";
 
 /**

--- a/crates/lgn-web-client/frontend/tests/index.test.ts
+++ b/crates/lgn-web-client/frontend/tests/index.test.ts
@@ -3,3 +3,5 @@ describe("Truth", () => {
     expect(true).toBe(true);
   });
 });
+
+export {};

--- a/crates/lgn-web-client/frontend/tsconfig.json
+++ b/crates/lgn-web-client/frontend/tsconfig.json
@@ -11,6 +11,8 @@
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "importsNotUsedAsValues": "error",
+    "preserveValueImports": true,
+    "isolatedModules": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "types": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,6 +478,7 @@ importers:
       svelte-preprocess: ^4.10.4
       svelte-window: ^1.2.3
       tailwindcss: ^3.0.23
+      type-fest: ^2.12.2
       typescript: ^4.6.3
       vite: ^2.8.6
       vitest: ^0.7.12
@@ -524,6 +525,7 @@ importers:
       svelte-check: 2.4.6_116eeb6b28be41779e5e81ff686c3b09
       svelte-preprocess: 4.10.4_6dacd20700cebaccb0b81c64362d33b1
       tailwindcss: 3.0.23_autoprefixer@10.4.4
+      type-fest: 2.12.2
       typescript: 4.6.3
       vite: 2.8.6
       vitest: 0.7.12_c8@7.11.0
@@ -5996,6 +5998,11 @@ packages:
     resolution: {integrity: sha512-Qe5GRT+n/4GoqCNGGVp5Snapg1Omq3V7irBJB3EaKsp7HWDo5Gv2d/67gfNyV+d5EXD+x/RF5l1h4yJ7qNkcGA==}
     engines: {node: '>=12.20'}
     dev: false
+
+  /type-fest/2.12.2:
+    resolution: {integrity: sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==}
+    engines: {node: '>=12.20'}
+    dev: true
 
   /typedarray-to-buffer/3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}


### PR DESCRIPTION
Add some visual feedback for the dev users (https://github.com/legion-labs/legion/issues/1329) and display the used urls.

While at it I also added a function that creates a "connected" store @timnitsas-legion. It's a rather simple one:

```ts
const store = connected(myStorage, "my-key", myDefaultValue); 
```

And that's it 🙂 

It takes any kind of storage that implements the Storage interface (in memory, local storage, and session storage for now), and will automatically save the changes.