### PR TITLE
[content-store] Add data-space support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,9 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2"
@@ -2461,6 +2464,12 @@ name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
+name = "duration-string"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65bd8fceb01387287b3502b845588b9bf60e50e0d27392f724e6669385d6ac7"
 
 [[package]]
 name = "dyn-clone"
@@ -4778,10 +4787,12 @@ dependencies = [
  "bytes",
  "bytesize",
  "clap 3.1.6",
+ "duration-string",
  "futures",
  "hex",
  "http",
  "http-body",
+ "http-serde",
  "httptest",
  "hyper",
  "indicatif",

--- a/crates/lgn-content-store-proto/protos/content-store.proto
+++ b/crates/lgn-content-store-proto/protos/content-store.proto
@@ -10,8 +10,9 @@ service ContentStore {
 }
 
 message ResolveAliasRequest {
-  string key_space = 1;
-  string key = 2;
+  string data_space = 1;
+  string key_space = 2;
+  string key = 3;
 }
 
 message ResolveAliasResponse {
@@ -19,9 +20,10 @@ message ResolveAliasResponse {
 }
 
 message RegisterAliasRequest {
-  string key_space = 1;
-  string key = 2;
-  string id = 3;
+  string data_space = 1;
+  string key_space = 2;
+  string key = 3;
+  string id = 4;
 }
 
 message RegisterAliasResponse {
@@ -29,7 +31,8 @@ message RegisterAliasResponse {
 }
 
 message ReadContentRequest {
-  string id = 1;
+  string data_space = 1;
+  string id = 2;
 }
 
 message ReadContentResponse {
@@ -40,7 +43,8 @@ message ReadContentResponse {
 }
 
 message GetContentWriterRequest {
-  string id = 1;
+  string data_space = 1;
+  string id = 2;
 }
 
 message GetContentWriterResponse {
@@ -50,7 +54,8 @@ message GetContentWriterResponse {
 }
 
 message WriteContentRequest {
-  bytes data = 1;
+  string data_space = 1;
+  bytes data = 2;
 }
 
 message WriteContentResponse {

--- a/crates/lgn-content-store2/Cargo.toml
+++ b/crates/lgn-content-store2/Cargo.toml
@@ -41,13 +41,15 @@ aws-sdk-dynamodb = { version = "0.8", optional = true }
 async-trait = "0.1"
 base64 = "0.13"
 blake3 = { version = "1.3", features = ["prefer_intrinsics"] }
-bytesize = "1"
+bytesize = { version = "1", features = ["serde"] }
 byteorder = "1.4.3"
 bytes = "1.1.0"
+duration-string = "0.0.6"
 clap = { version = "3.0", features = ["derive"], optional = true }
 futures = "0.3"
 http = "0.2.6"
 http-body = "0.4"
+http-serde = "1"
 indicatif = { version = "0.16", optional = true }
 itertools = "0.10"
 lgn-online = { path = "../lgn-online", version = "0.1.0" }

--- a/crates/lgn-content-store2/src/bin/server.rs
+++ b/crates/lgn-content-store2/src/bin/server.rs
@@ -5,12 +5,15 @@ use bytesize::ByteSize;
 use clap::Parser;
 use http::{header, Method};
 use lgn_cli_utils::termination_handler::AsyncTerminationHandler;
-use lgn_content_store2::{AwsDynamoDbProvider, AwsS3Provider, GrpcService};
+use lgn_content_store2::{
+    AddressProviderConfig, DataSpace, GrpcProviderSet, GrpcService, ProviderConfig, Result,
+};
 use lgn_content_store_proto::content_store_server::ContentStoreServer;
 use lgn_online::authentication::{jwt::RequestAuthorizer, UserInfo};
 use lgn_telemetry_sink::TelemetryGuardBuilder;
 use lgn_tracing::prelude::*;
-use std::{net::SocketAddr, time::Duration};
+use serde::Deserialize;
+use std::{collections::HashMap, net::SocketAddr, time::Duration};
 use tonic::transport::Server;
 use tower_http::{
     auth::RequireAuthorizationLayer,
@@ -32,15 +35,51 @@ struct Args {
         help = "The list of origins that are allowed to make requests, for CORS"
     )]
     origins: Vec<http::HeaderValue>,
+}
 
-    #[clap(long, default_value = "128KiB")]
+#[derive(Debug, Clone, Deserialize)]
+struct Config {
+    providers: HashMap<DataSpace, ProviderSetConfig>,
+}
+
+impl Config {
+    async fn instantiate_providers(&self) -> Result<HashMap<DataSpace, GrpcProviderSet>> {
+        let mut result = HashMap::new();
+
+        for (data_space, provider_set_config) in &self.providers {
+            let provider_set = provider_set_config.instantiate().await?;
+            result.insert(data_space.clone(), provider_set);
+        }
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ProviderSetConfig {
+    provider: ProviderConfig,
+    address_provider: AddressProviderConfig,
+
+    #[serde(default = "ProviderSetConfig::default_size_threshold")]
     size_treshold: ByteSize,
+}
 
-    #[clap(long, default_value = "s3://legionlabs-content-store/")]
-    s3_bucket: String,
+impl ProviderSetConfig {
+    fn default_size_threshold() -> ByteSize {
+        "128KiB".parse().unwrap()
+    }
 
-    #[clap(long, default_value = "legionlabs-content-store")]
-    dynamodb_table_name: String,
+    async fn instantiate(&self) -> Result<GrpcProviderSet> {
+        Ok(GrpcProviderSet {
+            provider: self.provider.instantiate().await?,
+            address_provider: self.address_provider.instantiate().await?,
+            size_threshold: self
+                .size_treshold
+                .as_u64()
+                .try_into()
+                .expect("size_threshold is too large"),
+        })
+    }
 }
 
 #[tokio::main]
@@ -56,6 +95,9 @@ async fn main() -> anyhow::Result<()> {
         .build();
 
     async_span_scope!("lgn-content-store-srv::main");
+
+    let config: Config = lgn_config::get("content_store.server")?
+        .ok_or_else(|| anyhow::anyhow!("no configuration was found for `content_store.server`"))?;
 
     let cors = CorsLayer::new()
         .allow_origin(Origin::list(args.origins))
@@ -94,21 +136,26 @@ async fn main() -> anyhow::Result<()> {
 
     let mut server = Server::builder().accept_http1(true).layer(layer);
 
-    // Hardcode AWS providers for now.
-    info!("Using AWS S3 bucket: {}", args.s3_bucket);
-    info!("Using AWS DynamoDB table: {}", args.dynamodb_table_name);
+    let providers = config.instantiate_providers().await?;
 
-    let aws_s3_url = args.s3_bucket.parse().unwrap();
-    let aws_s3_provider = AwsS3Provider::new(aws_s3_url).await;
-    let aws_dynamo_db_provider = AwsDynamoDbProvider::new(args.dynamodb_table_name).await;
-    let grpc_service = GrpcService::new(
-        aws_dynamo_db_provider,
-        aws_s3_provider,
-        args.size_treshold
-            .as_u64()
-            .try_into()
-            .expect("size_treshold is too big"),
-    );
+    if providers.is_empty() {
+        return Err(anyhow::anyhow!("no providers were configured"));
+    }
+
+    info!("Now listing configured {} provider(s)...", providers.len());
+
+    for (i, (data_space, provider_set)) in providers.iter().enumerate() {
+        info!(
+            "{}: {} - provider: {} - address provider: {} - size threshold: {}",
+            i,
+            data_space,
+            provider_set.provider,
+            provider_set.address_provider,
+            provider_set.size_threshold
+        );
+    }
+
+    let grpc_service = GrpcService::new(providers);
 
     let service = ContentStoreServer::new(grpc_service);
     let server = server.add_service(tonic_web::enable(service));

--- a/crates/lgn-content-store2/src/data_space.rs
+++ b/crates/lgn-content-store2/src/data_space.rs
@@ -1,0 +1,70 @@
+use std::{fmt::Display, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct DataSpace(String);
+
+impl Display for DataSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for DataSpace {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            Self::PERSISTENT => Ok(Self::persistent()),
+            Self::VOLATILE => Ok(Self::volatile()),
+            _ => Err(Error::InvalidDataSpace(s.to_string())),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DataSpace {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl DataSpace {
+    const PERSISTENT: &'static str = "persistent";
+    const VOLATILE: &'static str = "volatile";
+
+    pub fn persistent() -> Self {
+        Self(Self::PERSISTENT.to_string())
+    }
+
+    pub fn volatile() -> Self {
+        Self(Self::VOLATILE.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::DataSpace;
+
+    #[test]
+    fn test_deserialize_data_space() {
+        let data_space = serde_json::from_value(json!("persistent")).unwrap();
+
+        assert_eq!(DataSpace::persistent(), data_space);
+
+        let data_space = serde_json::from_value(json!("volatile")).unwrap();
+
+        assert_eq!(DataSpace::volatile(), data_space);
+
+        assert!(serde_json::from_value::<DataSpace>(json!("invalid")).is_err());
+    }
+}

--- a/crates/lgn-content-store2/src/errors.rs
+++ b/crates/lgn-content-store2/src/errors.rs
@@ -17,6 +17,8 @@ pub enum Error {
     InvalidHashAlgorithm,
     #[error("invalid chunk index")]
     InvalidChunkIndex(#[source] anyhow::Error),
+    #[error("invalid data space: {0}")]
+    InvalidDataSpace(String),
     #[error("the content was not found")]
     NotFound,
     #[error("the content already exists")]

--- a/crates/lgn-content-store2/src/lib.rs
+++ b/crates/lgn-content-store2/src/lib.rs
@@ -5,6 +5,7 @@ mod buf_utils;
 mod chunk_identifier;
 mod chunker;
 mod config;
+mod data_space;
 mod errors;
 mod identifier;
 mod providers;
@@ -12,7 +13,11 @@ mod traits;
 
 pub use chunk_identifier::ChunkIdentifier;
 pub use chunker::{ChunkIndex, Chunker};
-pub use config::{Config, LocalProviderConfig, ProviderConfig, RedisProviderConfig};
+pub use config::{
+    AddressProviderConfig, AwsDynamoDbProviderConfig, AwsS3ProviderConfig, Config,
+    LocalProviderConfig, LruProviderConfig, ProviderConfig, RedisProviderConfig,
+};
+pub use data_space::DataSpace;
 pub use errors::{Error, Result};
 pub use identifier::{HashAlgorithm, Identifier};
 pub use providers::*;

--- a/crates/lgn-content-store2/src/providers/aws_dynamodb.rs
+++ b/crates/lgn-content-store2/src/providers/aws_dynamodb.rs
@@ -3,6 +3,7 @@ use aws_sdk_dynamodb::model::AttributeValue;
 use aws_sdk_dynamodb::types::Blob;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Display,
     io::{Cursor, Write},
 };
 
@@ -138,6 +139,12 @@ impl AwsDynamoDbProvider {
             )
             .into()),
         }
+    }
+}
+
+impl Display for AwsDynamoDbProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AWS DynamoDB (table: {})", self.table_name)
     }
 }
 

--- a/crates/lgn-content-store2/src/providers/aws_s3.rs
+++ b/crates/lgn-content-store2/src/providers/aws_s3.rs
@@ -120,6 +120,18 @@ impl AwsS3Provider {
     }
 }
 
+impl Display for AwsS3Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "AWS S3 (bucket: {}, root: {}, signed URLs validity duration: {})",
+            self.url.bucket_name,
+            self.url.root,
+            duration_string::DurationString::from(self.validity_duration)
+        )
+    }
+}
+
 #[pin_project]
 #[derive(Debug)]
 struct ByteStreamReader(#[pin] aws_sdk_s3::types::ByteStream);

--- a/crates/lgn-content-store2/src/providers/cache.rs
+++ b/crates/lgn-content-store2/src/providers/cache.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::min,
     collections::{BTreeMap, BTreeSet},
+    fmt::Display,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -27,6 +28,12 @@ impl<Remote, Local> CachingProvider<Remote, Local> {
     /// backing remote and local providers.
     pub fn new(remote: Remote, local: Local) -> Self {
         Self { remote, local }
+    }
+}
+
+impl<Remote: Display, Local: Display> Display for CachingProvider<Remote, Local> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} cached by {}", self.remote, self.local)
     }
 }
 

--- a/crates/lgn-content-store2/src/providers/local.rs
+++ b/crates/lgn-content-store2/src/providers/local.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Display,
     io::Write,
     path::PathBuf,
 };
@@ -38,6 +39,12 @@ impl LocalProvider {
         let mut enc = base64::write::EncoderStringWriter::new(base64::URL_SAFE_NO_PAD);
         enc.write_all(key.as_bytes())?;
         Ok(enc.into_inner())
+    }
+}
+
+impl Display for LocalProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "local (root: {})", self.0.display())
     }
 }
 

--- a/crates/lgn-content-store2/src/providers/lru.rs
+++ b/crates/lgn-content-store2/src/providers/lru.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Display,
     sync::Arc,
 };
 
@@ -17,6 +18,7 @@ use crate::{
 pub struct LruProvider {
     content_map: Arc<Mutex<LruCache<Identifier, Vec<u8>>>>,
     alias_map: Arc<Mutex<LruCache<(String, String), Identifier>>>,
+    size: usize,
 }
 
 impl LruProvider {
@@ -26,7 +28,14 @@ impl LruProvider {
         Self {
             content_map: Arc::new(Mutex::new(LruCache::new(size))),
             alias_map: Arc::new(Mutex::new(LruCache::new(size))),
+            size,
         }
+    }
+}
+
+impl Display for LruProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "lru (size: {})", self.size)
     }
 }
 

--- a/crates/lgn-content-store2/src/providers/memory.rs
+++ b/crates/lgn-content-store2/src/providers/memory.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::Display,
     sync::Arc,
 };
 
@@ -23,6 +24,12 @@ impl MemoryProvider {
     /// process memory.
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+impl Display for MemoryProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "in-memory")
     }
 }
 

--- a/crates/lgn-content-store2/src/providers/mod.rs
+++ b/crates/lgn-content-store2/src/providers/mod.rs
@@ -27,7 +27,7 @@ pub use aws_dynamodb::AwsDynamoDbProvider;
 #[cfg(feature = "aws")]
 pub use aws_s3::{AwsS3Provider, AwsS3Url};
 pub use cache::CachingProvider;
-pub use grpc::{GrpcProvider, GrpcService};
+pub use grpc::{GrpcProvider, GrpcProviderSet, GrpcService};
 pub use local::LocalProvider;
 pub use memory::MemoryProvider;
 pub use monitor::{MonitorAsyncAdapter, MonitorProvider, TransferCallbacks};

--- a/crates/lgn-content-store2/src/providers/monitor.rs
+++ b/crates/lgn-content-store2/src/providers/monitor.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fmt::Debug,
+    fmt::{Debug, Display},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -34,6 +34,12 @@ pub struct MonitorProvider<Inner> {
     inner: Inner,
     on_download_callbacks: Option<Arc<Box<dyn TransferCallbacks<Identifier>>>>,
     on_upload_callbacks: Option<Arc<Box<dyn TransferCallbacks<Identifier>>>>,
+}
+
+impl<Inner: Display> Display for MonitorProvider<Inner> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "monitoring for {}", self.inner)
+    }
 }
 
 impl<Inner: Clone> Clone for MonitorProvider<Inner> {

--- a/crates/lgn-content-store2/src/providers/small_content.rs
+++ b/crates/lgn-content-store2/src/providers/small_content.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fmt::Debug,
+    fmt::{Debug, Display},
 };
 
 use async_trait::async_trait;
@@ -29,6 +29,12 @@ impl<Inner> SmallContentProvider<Inner> {
     /// provider using the default identifier size threshold.
     pub fn new(inner: Inner) -> Self {
         Self { inner }
+    }
+}
+
+impl<Inner: Display> Display for SmallContentProvider<Inner> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} + small-content optimization", self.inner)
     }
 }
 

--- a/crates/lgn-content-store2/src/traits.rs
+++ b/crates/lgn-content-store2/src/traits.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Display,
     pin::Pin,
     sync::Arc,
 };
@@ -18,7 +19,7 @@ pub type ContentAsyncWrite = Pin<Box<dyn AsyncWrite + Send>>;
 
 /// ContentReader is a trait for reading content from a content-store.
 #[async_trait]
-pub trait ContentReader {
+pub trait ContentReader: Display {
     /// Returns an async reader that reads the content referenced by the
     /// specified identifier.
     ///
@@ -128,7 +129,7 @@ impl<T: ContentReader> ContentReaderExt for T {}
 
 /// ContentWriter is a trait for writing content to a content-store.
 #[async_trait]
-pub trait ContentWriter {
+pub trait ContentWriter: Display {
     /// Returns an async write to which the content referenced by the specified
     /// specified identifier can be written.
     ///
@@ -208,7 +209,7 @@ impl<T> ContentProvider for T where T: ContentReader + ContentWriter {}
 
 /// Provides addresses for content.
 #[async_trait]
-pub trait ContentAddressReader {
+pub trait ContentAddressReader: Display {
     /// Returns the address of the content referenced by the specified identifier.
     ///
     /// # Errors
@@ -220,7 +221,7 @@ pub trait ContentAddressReader {
 
 /// Provides addresses for content.
 #[async_trait]
-pub trait ContentAddressWriter {
+pub trait ContentAddressWriter: Display {
     /// Returns the address of the content referenced by the specified identifier.
     ///
     /// # Errors

--- a/crates/lgn-content-store2/tests/common/providers.rs
+++ b/crates/lgn-content-store2/tests/common/providers.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc};
 
 use async_trait::async_trait;
 use lgn_content_store2::{ContentAddressReader, ContentAddressWriter, Error, Identifier, Result};
@@ -7,6 +7,12 @@ use tokio::sync::Mutex;
 pub struct FakeContentAddressProvider {
     base_url: String,
     already_exists: Arc<Mutex<bool>>,
+}
+
+impl Display for FakeContentAddressProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "fake provider (base_url: {})", self.base_url)
+    }
 }
 
 impl FakeContentAddressProvider {

--- a/crates/lgn-source-control/src/bin/server.rs
+++ b/crates/lgn-source-control/src/bin/server.rs
@@ -519,7 +519,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let config: Config = lgn_config::get("source_control.server")?
-        .ok_or_else(|| anyhow::anyhow!("no configuration was found for `source-control.server`"))?;
+        .ok_or_else(|| anyhow::anyhow!("no configuration was found for `source_control.server`"))?;
 
     let cors = CorsLayer::new()
         .allow_origin(Origin::list(args.origins))


### PR DESCRIPTION
This PR adds data-space support for the content-store server, allowing us a single content-store server instance to serve virtual data namespaces (or *data-space*).