### PR TITLE
Data generation for pong/physics: update existing data

### DIFF
--- a/examples/physics/src/main.rs
+++ b/examples/physics/src/main.rs
@@ -11,14 +11,13 @@ use std::{
     fs::OpenOptions,
     io::Write,
     path::{Path, PathBuf},
-    str::FromStr,
     sync::Arc,
 };
 
 use lgn_data_build::DataBuildOptions;
 use lgn_data_compiler::compiler_node::CompilerRegistryOptions;
 use lgn_data_offline::{
-    resource::{Project, ResourceRegistry, ResourceRegistryOptions},
+    resource::{Project, ResourcePathName, ResourceRegistry, ResourceRegistryOptions},
     ResourcePathId,
 };
 use lgn_data_runtime::{
@@ -450,31 +449,53 @@ async fn create_offline_entity(
     components: Vec<Box<dyn Component>>,
     children: Vec<ResourcePathId>,
 ) -> ResourcePathId {
+    let kind = sample_data::offline::Entity::TYPE;
+    let id = resource_id
+        .parse::<ResourceId>()
+        .expect("invalid ResourceId format");
+    let type_id = ResourceTypeAndId { kind, id };
+    let name: ResourcePathName = resource_path.into();
+
     let mut resources = resource_registry.lock().await;
-    let id = ResourceTypeAndId {
-        kind: sample_data::offline::Entity::TYPE,
-        id: ResourceId::from_str(resource_id).unwrap(),
+    let exists = project.exists(id).await;
+    let handle = if exists {
+        project
+            .load_resource(type_id, &mut resources)
+            .expect("failed to load resource")
+    } else {
+        resources
+            .new_resource(kind)
+            .expect("failed to create new resource")
     };
-    let handle = resources.new_resource(id.kind).unwrap();
 
     let entity = handle
         .get_mut::<sample_data::offline::Entity>(&mut resources)
         .unwrap();
+    entity.components.clear();
     entity.components.extend(components.into_iter());
+    entity.children.clear();
     entity.children.extend(children.into_iter());
 
-    project
-        .add_resource_with_id(
-            resource_path.into(),
-            sample_data::offline::Entity::TYPENAME,
-            id.kind,
-            id.id,
-            handle,
-            &mut resources,
-        )
-        .await
-        .unwrap();
-    let path: ResourcePathId = id.into();
+    if exists {
+        project
+            .save_resource(type_id, handle, &mut resources)
+            .await
+            .expect("failed to save resource");
+    } else {
+        project
+            .add_resource_with_id(
+                name,
+                sample_data::offline::Entity::TYPENAME,
+                kind,
+                id,
+                handle,
+                &mut resources,
+            )
+            .await
+            .expect("failed to add new resource");
+    }
+
+    let path: ResourcePathId = type_id.into();
     path.push(sample_data::runtime::Entity::TYPE)
 }
 
@@ -485,16 +506,29 @@ async fn create_offline_model(
     resource_path: &str,
     mesh: Mesh,
 ) -> ResourcePathId {
+    let kind = lgn_graphics_data::offline::Model::TYPE;
+    let id = resource_id
+        .parse::<ResourceId>()
+        .expect("invalid ResourceId format");
+    let type_id = ResourceTypeAndId { kind, id };
+    let name: ResourcePathName = resource_path.into();
+
     let mut resources = resource_registry.lock().await;
-    let id = ResourceTypeAndId {
-        kind: lgn_graphics_data::offline::Model::TYPE,
-        id: ResourceId::from_str(resource_id).unwrap(),
+    let exists = project.exists(id).await;
+    let handle = if exists {
+        project
+            .load_resource(type_id, &mut resources)
+            .expect("failed to load resource")
+    } else {
+        resources
+            .new_resource(kind)
+            .expect("failed to create new resource")
     };
-    let handle = resources.new_resource(id.kind).unwrap();
 
     let model = handle
         .get_mut::<lgn_graphics_data::offline::Model>(&mut resources)
         .unwrap();
+    model.meshes.clear();
     let mesh = lgn_graphics_data::offline::Mesh {
         positions: mesh.positions,
         normals: mesh.normals.unwrap(),
@@ -509,17 +543,25 @@ async fn create_offline_model(
     };
     model.meshes.push(mesh);
 
-    project
-        .add_resource_with_id(
-            resource_path.into(),
-            lgn_graphics_data::offline::Model::TYPENAME,
-            id.kind,
-            id.id,
-            handle,
-            &mut resources,
-        )
-        .await
-        .unwrap();
-    let path: ResourcePathId = id.into();
+    if exists {
+        project
+            .save_resource(type_id, handle, &mut resources)
+            .await
+            .expect("failed to save resource");
+    } else {
+        project
+            .add_resource_with_id(
+                name,
+                lgn_graphics_data::offline::Model::TYPENAME,
+                kind,
+                id,
+                handle,
+                &mut resources,
+            )
+            .await
+            .expect("failed to add new resource");
+    }
+
+    let path: ResourcePathId = type_id.into();
     path.push(lgn_graphics_data::runtime::Model::TYPE)
 }

--- a/examples/pong/src/main.rs
+++ b/examples/pong/src/main.rs
@@ -218,8 +218,8 @@ async fn create_offline_data(
         project,
         resource_registry,
         "5474d00b-cc10-491a-ba56-be2f5b5de22d",
-        Mesh::new_cube(0.5),
         "/scene/models/cube.mod",
+        Mesh::new_cube(0.5),
     )
     .await;
 
@@ -227,8 +227,8 @@ async fn create_offline_data(
         project,
         resource_registry,
         "a05e4c89-e85b-4e03-add4-8767b21c1e55",
-        Mesh::new_sphere(0.25, 16, 16),
         "/scene/models/sphere.mod",
+        Mesh::new_sphere(0.25, 16, 16),
     )
     .await;
 
@@ -257,8 +257,8 @@ async fn create_offline_data(
         project,
         resource_registry,
         "e93151b6-3635-4a30-9f3e-e6052929d85a",
-        ScriptType::Rune,
         "/scene/pad_right_script",
+        ScriptType::Rune,
         r#"
 const MOUSE_DELTA_SCALE = 200.0;
 
@@ -306,8 +306,8 @@ pub fn update(entity, events) {
         project,
         resource_registry,
         "968c4926-ae75-4955-81c8-7b7e395d0d3b",
-        ScriptType::Rune,
         "/scene/pad_left_script",
+        ScriptType::Rune,
         r#"
 const MOUSE_DELTA_SCALE = 200.0;
 
@@ -355,8 +355,8 @@ pub fn update(entity, events) {
         project,
         resource_registry,
         "6ec6db36-6d09-4bb2-b9a8-b85c25e5b2c0",
-        ScriptType::Rune,
         "/scene/ball_script",
+        ScriptType::Rune,
         r#"
 use lgn_math::{normalize2, random};
 
@@ -619,8 +619,8 @@ async fn create_offline_model(
     project: &mut Project,
     resource_registry: &Arc<Mutex<ResourceRegistry>>,
     resource_id: &str,
-    mesh: Mesh,
     resource_path: &str,
+    mesh: Mesh,
 ) -> ResourcePathId {
     let kind = lgn_graphics_data::offline::Model::TYPE;
     let id = resource_id
@@ -686,8 +686,8 @@ async fn create_offline_script(
     project: &mut Project,
     resource_registry: &Arc<Mutex<ResourceRegistry>>,
     resource_id: &str,
-    script_type: ScriptType,
     resource_path: &str,
+    script_type: ScriptType,
     script_text: &str,
 ) -> ResourcePathId {
     let kind = lgn_scripting::offline::Script::TYPE;


### PR DESCRIPTION
Since local source-control is recreated when creating project, cannot assume that project is empty.
Changed logic to update existing resources if they already exist, when generating data for pong and physics examples.