### PR TITLE
Editor client scene explorer QOL improvements

### DIFF
--- a/crates/lgn-editor-gui/frontend/src/assets/index.css
+++ b/crates/lgn-editor-gui/frontend/src/assets/index.css
@@ -14,7 +14,7 @@ body {
 
 /* Customize scrollbar on Chrome, Safari, Edge */
 *::-webkit-scrollbar {
-  @apply w-2.5;
+  @apply w-2.5 h-2.5;
 }
 
 *::-webkit-scrollbar-track {
@@ -22,7 +22,11 @@ body {
 }
 
 *::-webkit-scrollbar-thumb {
-  @apply bg-gray-500 hover:bg-gray-400 transition-all;
+  @apply bg-gray-500 hover:bg-gray-400 opacity-0 duration-150 transition-colors;
+}
+
+.thin-scrollbar::-webkit-scrollbar {
+  @apply w-1 h-1;
 }
 
 /* Firefox doesn't seem to allow scrollbar customization */

--- a/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
@@ -3,6 +3,7 @@
 
   import type { ResourceDescription } from "@lgn/proto-editor/dist/resource_browser";
   import { UploadStatus } from "@lgn/proto-editor/dist/source_control";
+  import HighlightedText from "@lgn/web-client/src/components/HighlightedText.svelte";
   import { Panel, PanelHeader } from "@lgn/web-client/src/components/panel";
   import { displayError } from "@lgn/web-client/src/lib/errors";
   import { readFile } from "@lgn/web-client/src/lib/files";
@@ -23,6 +24,7 @@
     streamFileUpload,
   } from "@/api";
   import { resourceDragAndDropType } from "@/constants";
+  import { Entries } from "@/lib/hierarchyTree";
   import type { Entry } from "@/lib/hierarchyTree";
   import { isEntry } from "@/lib/hierarchyTree";
   import { components, join } from "@/lib/path";
@@ -32,6 +34,7 @@
   import { iconFor } from "@/lib/resourceBrowser";
   import { fetchAllActiveScenes } from "@/orchestrators/allActiveScenes";
   import {
+    allResources,
     allResourcesLoading,
     fetchAllResources,
   } from "@/orchestrators/allResources";
@@ -43,6 +46,7 @@
     currentResourceDescriptionEntry,
     currentlyRenameResourceEntry,
     resourceEntries,
+    resourceEntriesfilters,
   } from "@/orchestrators/resourceBrowserEntries";
   import type { ContextMenuEntryRecord } from "@/stores/contextMenu";
   import {
@@ -71,6 +75,19 @@
   $: if ($files) {
     uploadFiles();
   }
+
+  $: filteredResourceEntries =
+    $allResources && $resourceEntriesfilters.name
+      ? Entries.fromArray(
+          $allResources.filter((resource) =>
+            $resourceEntriesfilters.name
+              ? resource.path
+                  .toLowerCase()
+                  .includes($resourceEntriesfilters.name.toLowerCase())
+              : true
+          )
+        )
+      : null;
 
   async function saveEditedResourceProperty({
     detail: { entry, newName },
@@ -223,7 +240,7 @@
   }
 
   function filter({ detail: { name } }: CustomEvent<{ name: string }>) {
-    return fetchAllResources(name);
+    $resourceEntriesfilters.name = name;
   }
 
   async function handleContextMenuEvents({
@@ -487,11 +504,11 @@
       {#if !$resourceEntries.isEmpty()}
         <HierarchyTree
           id="resource-browser"
-          itemContextMenu={resourceBrowserItemContextMenuId}
           renamable
           reorderable
           deletable
           draggable={resourceDragAndDropType}
+          displayedEntries={filteredResourceEntries || $resourceEntries}
           on:select={selectResource}
           on:nameEdited={saveEditedResourceProperty}
           on:moved={moveEntry}
@@ -502,16 +519,33 @@
           bind:highlightedEntry={$currentResourceDescriptionEntry}
           bind:this={resourceHierarchyTree}
         >
-          <div class="w-full h-full" slot="icon" let:entry>
-            <Icon class="w-full h-full" icon={iconFor(entry)} />
-          </div>
           <div
-            class="item"
-            slot="name"
+            class="entry"
+            slot="entry"
+            use:contextMenu={resourceBrowserItemContextMenuId}
             let:entry
-            title={isEntry(entry) ? entry.item.path : null}
+            let:isHighlighted
           >
-            {entry.name}
+            <div
+              class="entry-icon"
+              class:text-gray-400={!isHighlighted}
+              class:text-orange-700={isHighlighted}
+            >
+              <Icon class="w-full h-full" icon={iconFor(entry)} />
+            </div>
+            <div
+              class="entry-name"
+              title={isEntry(entry) ? entry.item.path : null}
+            >
+              {#if $resourceEntriesfilters.name}
+                <HighlightedText
+                  text={entry.name}
+                  pattern={$resourceEntriesfilters.name}
+                />
+              {:else}
+                {entry.name}
+              {/if}
+            </div>
           </div>
         </HierarchyTree>
       {/if}
@@ -528,7 +562,15 @@
     @apply flex-1 overflow-auto;
   }
 
-  .item {
-    @apply h-full w-full;
+  .entry {
+    @apply flex flex-row w-full h-full space-x-1;
+  }
+
+  .entry-icon {
+    @apply w-6 h-6;
+  }
+
+  .entry-name {
+    @apply w-full h-full;
   }
 </style>

--- a/crates/lgn-editor-gui/frontend/src/components/SceneExplorer.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/SceneExplorer.svelte
@@ -7,6 +7,7 @@
   import type { ContextMenuEvent } from "@lgn/web-client/src/types/contextMenu";
   import { filterContextMenuEvents } from "@lgn/web-client/src/types/contextMenu";
 
+  import contextMenu from "@/actions/contextMenu";
   import { closeScene } from "@/api";
   import { resourceDragAndDropType } from "@/constants";
   import type { Entry } from "@/lib/hierarchyTree";
@@ -76,22 +77,28 @@
   {#if !$sceneEntries.isEmpty()}
     <HierarchyTree
       id="scene-explorer"
-      itemContextMenu={sceneExplorerItemContextMenuId}
       draggable={resourceDragAndDropType}
       on:select={selectResource}
       bind:entries={$sceneEntries}
       bind:highlightedEntry={$currentSceneDescriptionEntry}
     >
-      <div class="w-full h-full" slot="icon" let:entry>
-        <Icon class="w-full h-full" icon={iconFor(entry)} />
-      </div>
       <div
-        class="item"
-        slot="name"
+        class="entry"
+        slot="entry"
+        use:contextMenu={sceneExplorerItemContextMenuId}
         let:entry
-        title={isEntry(entry) ? entry.item.path : null}
+        let:isHighlighted
       >
-        {entry.name}
+        <div
+          class="entry-icon"
+          class:text-gray-400={!isHighlighted}
+          class:text-orange-700={isHighlighted}
+        >
+          <Icon class="w-full h-full" icon={iconFor(entry)} />
+        </div>
+        <div class="entry-name" title={isEntry(entry) ? entry.item.path : null}>
+          {entry.name}
+        </div>
       </div>
     </HierarchyTree>
   {/if}
@@ -100,5 +107,17 @@
 <style lang="postcss">
   .root {
     @apply h-full break-all;
+  }
+
+  .entry {
+    @apply flex flex-row w-full h-full space-x-1;
+  }
+
+  .entry-icon {
+    @apply w-6 h-6;
+  }
+
+  .entry-name {
+    @apply w-full h-full;
   }
 </style>

--- a/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
@@ -13,8 +13,7 @@
   type Item = $$Generic<ItemBase>;
 
   type $$Slots = {
-    name: { entry: Entry<Item | symbol> };
-    icon: { entry: Entry<Item> };
+    entry: { entry: Entry<Item | symbol>; isHighlighted: boolean };
   };
 
   const dispatch = createEventDispatcher<{
@@ -32,11 +31,12 @@
 
   export let entries: Entries<Item>;
 
+  /** Overrides the default displayed entries, helpful when filtering */
+  export let displayedEntries: Entries<Item> = entries;
+
   export let highlightedEntry: Entry<Item> | null = null;
 
   export let currentlyRenameEntry: Entry<Item> | null = null;
-
-  export let itemContextMenu: string | null = null;
 
   /** Enables entry renaming */
   export let renamable = false;
@@ -148,12 +148,11 @@
   }}
   bind:this={hierarchyTree}
 >
-  {#each entries.entries as entry (isEntry(entry) ? entry.item.id : entry.item)}
+  {#each displayedEntries.entries as entry (isEntry(entry) ? entry.item.id : entry.item)}
     <HierarchyTreeItem
       {id}
       {entry}
       {highlightedEntry}
-      {itemContextMenu}
       {reorderable}
       {draggable}
       index={entry.index}
@@ -164,11 +163,8 @@
       on:nameEdited={setName}
       on:moved
     >
-      <svelte:fragment slot="icon" let:entry>
-        <slot name="icon" {entry} />
-      </svelte:fragment>
-      <svelte:fragment slot="name" let:entry>
-        <slot name="name" {entry} />
+      <svelte:fragment slot="entry" let:entry let:isHighlighted>
+        <slot name="entry" {entry} {isHighlighted} />
       </svelte:fragment>
     </HierarchyTreeItem>
   {/each}

--- a/crates/lgn-editor-gui/frontend/src/components/resources/ResourceFilter.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/resources/ResourceFilter.svelte
@@ -1,49 +1,41 @@
 <script lang="ts">
   import Icon from "@iconify/svelte";
   import { createEventDispatcher } from "svelte";
+  import { writable } from "svelte/store";
 
-  import Button from "@lgn/web-client/src/components/Button.svelte";
+  import { debounced } from "@lgn/web-client/src/lib/store";
 
   import TextInput from "@/components/inputs/TextInput.svelte";
 
   const dispatch = createEventDispatcher<{ filter: { name: string } }>();
 
-  let name = "";
+  let name = writable("");
+
+  $: debouncedName = debounced(name, 200);
+
+  $: dispatch("filter", { name: $debouncedName });
 
   function resetname() {
-    name = "";
-
-    dispatch("filter", { name });
-  }
-
-  function submit(event: Event /* SubmitEvent */) {
-    event.preventDefault();
-
-    dispatch("filter", { name });
+    $name = "";
   }
 </script>
 
-<form class="root" on:submit={submit}>
-  <div class="flex-grow">
-    <TextInput
-      bind:value={name}
-      size="default"
-      fluid
-      placeholder="Resource Name"
-    >
-      <div class="clear" slot="rightExtension" on:click={resetname}>
-        <Icon icon="ic:baseline-close" title="Reset filter" />
-      </div>
-    </TextInput>
-  </div>
-  <div class="flex-shrink">
-    <Button type="submit">Search</Button>
-  </div>
-</form>
+<div class="root">
+  <TextInput
+    bind:value={$name}
+    size="default"
+    fluid
+    placeholder="Resource Name"
+  >
+    <div class="clear" slot="rightExtension" on:click={resetname}>
+      <Icon icon="ic:baseline-close" title="Reset filter" />
+    </div>
+  </TextInput>
+</div>
 
 <style lang="postcss">
   .root {
-    @apply flex items-center h-10 w-full space-x-1 justify-end py-1 px-2;
+    @apply flex items-center h-10 w-full justify-end py-1 px-2;
   }
 
   .clear {

--- a/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/hierarchyTree.ts
@@ -175,7 +175,7 @@ export class Entries<Item extends ItemBase> {
   /**
    * Filters `Entries` based on a predicate.
    */
-  filter(pred: (entry: Entry<Item | symbol>) => boolean): this {
+  filter(pred: (entry: Entry<Item | symbol>) => boolean): Entries<Item> {
     function filter(entries: Entry<Item | symbol>[]): Entry<Item | symbol>[] {
       return entries.reduce((acc, entry) => {
         if (!pred(entry)) {
@@ -198,13 +198,15 @@ export class Entries<Item extends ItemBase> {
       }, [] as Entry<Item | symbol>[]);
     }
 
-    this.entries = filter(this.entries);
+    const filteredEntries = Entries.empty<Item>();
 
-    this.recalculateSize();
+    filteredEntries.entries = filter(this.entries);
 
-    this.#setIndices();
+    filteredEntries.#sort();
 
-    return this;
+    filteredEntries.recalculateSize();
+
+    return filteredEntries;
   }
 
   /**
@@ -312,7 +314,7 @@ export class Entries<Item extends ItemBase> {
     return null;
   }
 
-  remove(removedEntry: Entry<Item>): this {
+  remove(removedEntry: Entry<Item>): Entries<Item> {
     return this.filter((entry) =>
       isEntry(entry) ? entry.item.id !== removedEntry.item.id : true
     );

--- a/crates/lgn-editor-gui/frontend/src/lib/resourceBrowser.ts
+++ b/crates/lgn-editor-gui/frontend/src/lib/resourceBrowser.ts
@@ -99,7 +99,11 @@ export function createResourcePathId(
   return result;
 }
 
-export function iconFor(entry: Entry<ResourceDescription>) {
+export function iconFor(entry: Entry<ResourceDescription | symbol>) {
+  if (typeof entry.item === "symbol") {
+    return "ic:baseline-folder-open";
+  }
+
   switch (entry.item.type) {
     case "entity": {
       return "ic:outline-token";

--- a/crates/lgn-editor-gui/frontend/src/orchestrators/resourceBrowserEntries.ts
+++ b/crates/lgn-editor-gui/frontend/src/orchestrators/resourceBrowserEntries.ts
@@ -1,4 +1,4 @@
-import { derived } from "svelte/store";
+import { derived, writable } from "svelte/store";
 
 import { allResources } from "./allResources";
 import { deriveHierarchyTreeOrchestrator } from "./hierarchyTree";
@@ -14,3 +14,11 @@ export const {
   currentEntry: currentResourceDescriptionEntry,
   entries: resourceEntries,
 } = resourceBrowserEntriesOrchestrator;
+
+export type ResourceEntriesFilters = {
+  name: string | null;
+};
+
+export const resourceEntriesfilters = writable<ResourceEntriesFilters>({
+  name: null,
+});

--- a/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
+++ b/crates/lgn-editor-gui/frontend/src/routes/__layout.svelte
@@ -253,9 +253,6 @@
       allActiveScenesSubscription();
     };
   });
-
-  $: console.log($tabPayloads);
-  $: console.log($workspace);
 </script>
 
 <slot />

--- a/crates/lgn-runtime-gui/frontend/src/assets/index.css
+++ b/crates/lgn-runtime-gui/frontend/src/assets/index.css
@@ -14,7 +14,7 @@ body {
 
 /* Customize scrollbar on Chrome, Safari, Edge */
 *::-webkit-scrollbar {
-  @apply w-3;
+  @apply w-2.5 h-2.5;
 }
 
 *::-webkit-scrollbar-track {
@@ -22,7 +22,11 @@ body {
 }
 
 *::-webkit-scrollbar-thumb {
-  @apply bg-gray-500 hover:bg-gray-400 transition-all;
+  @apply bg-gray-500 hover:bg-gray-400 opacity-0 duration-150 transition-colors;
+}
+
+.thin-scrollbar::-webkit-scrollbar {
+  @apply w-1 h-1;
 }
 
 /* Firefox doesn't seem to allow scrollbar customization */

--- a/crates/lgn-web-client/frontend/src/components/ContextMenu.svelte
+++ b/crates/lgn-web-client/frontend/src/components/ContextMenu.svelte
@@ -163,14 +163,16 @@ export default buildContextMenu<ContextMenuEntryRecord>();
       throw new Error("`window` object not attached to `event`");
     }
 
-    const entriesNb = entries.filter((entry) => entry.type === "item").length;
+    const entriesLength = entries.filter(
+      (entry) => entry.type === "item"
+    ).length;
 
     const separatorsNb = entries.filter(
       (entry) => entry.type === "separator"
     ).length;
 
     const heightPx =
-      entriesNb * entryHeightPx + separatorsNb * separatorHeightPx;
+      entriesLength * entryHeightPx + separatorsNb * separatorHeightPx;
 
     const x =
       view.innerWidth - clientX <= widthPx

--- a/crates/lgn-web-client/frontend/src/components/HighlightedText.svelte
+++ b/crates/lgn-web-client/frontend/src/components/HighlightedText.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  export let text: string;
+
+  export let pattern: RegExp | string;
+
+  $: patternRegExp =
+    pattern instanceof RegExp ? pattern : new RegExp(`(${pattern})`, "i");
+
+  $: highlightedTextParts = text.split(patternRegExp);
+</script>
+
+<div>
+  {#each highlightedTextParts as part, index}
+    {#if index % 2 === 0}
+      {part}
+    {:else}
+      <mark class="highlighted-text">{part}</mark>
+    {/if}
+  {/each}
+</div>
+
+<style lang="postcss">
+  .highlighted-text {
+    @apply bg-orange-700 text-black font-bold;
+  }
+</style>

--- a/crates/lgn-web-client/frontend/src/components/panel/Panel.svelte
+++ b/crates/lgn-web-client/frontend/src/components/panel/Panel.svelte
@@ -16,6 +16,8 @@
 
   let isFocused = false;
 
+  let tabsContainer: HTMLDivElement | null = null;
+
   function focus() {
     isFocused = true;
   }
@@ -23,10 +25,24 @@
   function blur() {
     isFocused = false;
   }
+
+  function scroll(event: WheelEvent) {
+    if (!tabsContainer) {
+      return;
+    }
+
+    event.preventDefault();
+
+    tabsContainer.scrollLeft += event.deltaY;
+  }
 </script>
 
 <div class="root">
-  <div class="tabs-container">
+  <div
+    class="tabs-container thin-scrollbar"
+    on:wheel={scroll}
+    bind:this={tabsContainer}
+  >
     <div class="tabs">
       {#each tabs as tab, index (key(tab, index))}
         <div
@@ -79,8 +95,7 @@
   }
 
   .tabs-container {
-    /* TODO: Instead of hiding the overflow we should display it properly */
-    @apply flex flex-row flex-shrink-0 h-8 overflow-hidden;
+    @apply flex flex-row flex-shrink-0 h-8 overflow-x-auto;
   }
 
   .tabs {


### PR DESCRIPTION
Unfortunately most of the code in this pr is (hopefully) temporary. We filter on the client side, and rely on the fetched resources to display the scenes. Pretty eager to fix that 😄 

- [x] Tabs are scrollable

https://user-images.githubusercontent.com/94377405/162038179-be4b3f9e-9a8c-42ee-a203-cc44c092ab93.mp4

- [x] Better looking hierarchy tree

<img src="https://user-images.githubusercontent.com/94377405/162058494-d955c60d-006d-4ff4-af4c-50da1091cab0.png" width="250" />

- [x] Isolate search to the resource browser and improve UI/UX

<img src="https://user-images.githubusercontent.com/94377405/162072757-34f110cc-9bef-4d26-bbb6-ff3d67fde059.png" width="250" />

