### PR TITLE
Remove warning related to no token cache on first login

### DIFF
--- a/crates/lgn-online/src/authentication/errors.rs
+++ b/crates/lgn-online/src/authentication/errors.rs
@@ -11,6 +11,8 @@ pub enum Error {
     InteractiveProcess(std::io::Error),
     #[error("internal error: {0}")]
     Internal(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
     #[error("configuration error: {0}")]
     Config(#[from] lgn_config::Error),
     #[error(transparent)]


### PR DESCRIPTION
When authenticating a warning was always logged about the token cache file not being found. 
That flow is considered as normal for the first login since the file will be created at that time.

That PR aims to remove that warning.