### PR TITLE
[source-control] Added a method to list repositories

### DIFF
--- a/crates/lgn-source-control-proto/protos/source-control.proto
+++ b/crates/lgn-source-control-proto/protos/source-control.proto
@@ -8,6 +8,7 @@ service SourceControl {
   rpc RepositoryExists(RepositoryExistsRequest) returns (RepositoryExistsResponse) {};
   rpc CreateRepository(CreateRepositoryRequest) returns (CreateRepositoryResponse) {};
   rpc DestroyRepository(DestroyRepositoryRequest) returns (DestroyRepositoryResponse) {};
+  rpc ListRepositories(ListRepositoriesRequest) returns (ListRepositoriesResponse) {};
 
   // Index operations.
   rpc RegisterWorkspace(RegisterWorkspaceRequest) returns (RegisterWorkspaceResponse) {};
@@ -52,6 +53,12 @@ message DestroyRepositoryRequest {
 
 message DestroyRepositoryResponse {
   bool does_not_exist = 1;
+}
+
+message ListRepositoriesRequest {}
+
+message ListRepositoriesResponse {
+  repeated string repository_names = 1;
 }
 
 message RegisterWorkspaceRequest {

--- a/crates/lgn-source-control/src/bin/cli.rs
+++ b/crates/lgn-source-control/src/bin/cli.rs
@@ -54,6 +54,9 @@ enum Commands {
         /// The index URL.
         repository_name: RepositoryName,
     },
+    /// ListRepositories.
+    #[clap(name = "list-repositories")]
+    ListRepositories {},
     /// Initializes a workspace and populates it with the latest version of the main branch
     #[clap(name = "init-workspace", alias = "init")]
     InitWorkspace {
@@ -299,6 +302,26 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(Error::RepositoryDoesNotExist { repository_name }) => {
                     println!("The repository `{}` does not exist", repository_name);
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
+
+            Ok(())
+        }
+        Commands::ListRepositories {} => {
+            match repository_index.list_repositories().await {
+                Ok(repository_names) => {
+                    if repository_names.is_empty() {
+                        println!("No repositories found.");
+                    } else {
+                        println!("Listing {} repositorie(s):", repository_names.len());
+
+                        for repository_name in repository_names {
+                            println!("- {}", repository_name);
+                        }
+                    }
                 }
                 Err(e) => {
                     return Err(e.into());

--- a/crates/lgn-source-control/src/bin/server.rs
+++ b/crates/lgn-source-control/src/bin/server.rs
@@ -23,9 +23,10 @@ use lgn_source_control_proto::{
     DestroyRepositoryResponse, GetBranchRequest, GetBranchResponse, GetLockRequest,
     GetLockResponse, GetTreeRequest, GetTreeResponse, InsertBranchRequest, InsertBranchResponse,
     ListBranchesRequest, ListBranchesResponse, ListCommitsRequest, ListCommitsResponse,
-    ListLocksRequest, ListLocksResponse, LockRequest, LockResponse, RegisterWorkspaceRequest,
-    RegisterWorkspaceResponse, RepositoryExistsRequest, RepositoryExistsResponse, SaveTreeRequest,
-    SaveTreeResponse, UnlockRequest, UnlockResponse, UpdateBranchRequest, UpdateBranchResponse,
+    ListLocksRequest, ListLocksResponse, ListRepositoriesRequest, ListRepositoriesResponse,
+    LockRequest, LockResponse, RegisterWorkspaceRequest, RegisterWorkspaceResponse,
+    RepositoryExistsRequest, RepositoryExistsResponse, SaveTreeRequest, SaveTreeResponse,
+    UnlockRequest, UnlockResponse, UpdateBranchRequest, UpdateBranchResponse,
 };
 use lgn_telemetry_sink::TelemetryGuardBuilder;
 use lgn_tracing::{debug, info, warn, LevelFilter};
@@ -160,6 +161,24 @@ impl SourceControl for Service {
             }
             Err(e) => Err(tonic::Status::unknown(e.to_string())),
         }
+    }
+
+    async fn list_repositories(
+        &self,
+        _request: tonic::Request<ListRepositoriesRequest>,
+    ) -> Result<tonic::Response<ListRepositoriesResponse>, tonic::Status> {
+        let repository_names = self
+            .repository_index
+            .list_repositories()
+            .await
+            .map_err(|err| tonic::Status::unknown(err.to_string()))?
+            .into_iter()
+            .map(|repository_name| repository_name.to_string())
+            .collect();
+
+        Ok(tonic::Response::new(ListRepositoriesResponse {
+            repository_names,
+        }))
     }
 
     async fn register_workspace(

--- a/crates/lgn-source-control/src/index/grpc.rs
+++ b/crates/lgn-source-control/src/index/grpc.rs
@@ -9,8 +9,8 @@ use lgn_source_control_proto::{
     source_control_client::SourceControlClient, CommitToBranchRequest, CountLocksRequest,
     CreateRepositoryRequest, DestroyRepositoryRequest, GetBranchRequest, GetLockRequest,
     GetTreeRequest, InsertBranchRequest, ListBranchesRequest, ListCommitsRequest, ListLocksRequest,
-    LockRequest, RegisterWorkspaceRequest, RepositoryExistsRequest, SaveTreeRequest, UnlockRequest,
-    UpdateBranchRequest,
+    ListRepositoriesRequest, LockRequest, RegisterWorkspaceRequest, RepositoryExistsRequest,
+    SaveTreeRequest, UnlockRequest, UpdateBranchRequest,
 };
 
 use crate::{
@@ -121,6 +121,24 @@ where
             repository_name.clone(),
             self.client.clone(),
         )))
+    }
+
+    async fn list_repositories(&self) -> Result<Vec<RepositoryName>> {
+        async_span_scope!("GrpcRepositoryIndex::list_repositories");
+
+        let resp = self
+            .client
+            .lock()
+            .await
+            .list_repositories(ListRepositoriesRequest {})
+            .await
+            .map_other_err("failed to list repositories".to_string())?
+            .into_inner();
+
+        resp.repository_names
+            .into_iter()
+            .map(|repository_name| repository_name.parse())
+            .collect()
     }
 }
 

--- a/crates/lgn-source-control/src/index/local.rs
+++ b/crates/lgn-source-control/src/index/local.rs
@@ -53,7 +53,7 @@ impl LocalRepositoryIndex {
 #[async_trait]
 impl RepositoryIndex for LocalRepositoryIndex {
     async fn create_repository(&self, repository_name: RepositoryName) -> Result<Box<dyn Index>> {
-        async_span_scope!("RepositoryIndex::create_repository");
+        async_span_scope!("LocalRepositoryIndex::create_repository");
 
         let inner_index = self
             .inner_repository_index
@@ -66,7 +66,7 @@ impl RepositoryIndex for LocalRepositoryIndex {
     }
 
     async fn destroy_repository(&self, repository_name: RepositoryName) -> Result<()> {
-        async_span_scope!("RepositoryIndex::destroy_repository");
+        async_span_scope!("LocalRepositoryIndex::destroy_repository");
 
         self.inner_repository_index
             .destroy_repository(repository_name)
@@ -74,7 +74,7 @@ impl RepositoryIndex for LocalRepositoryIndex {
     }
 
     async fn load_repository(&self, repository_name: RepositoryName) -> Result<Box<dyn Index>> {
-        async_span_scope!("RepositoryIndex::load_repository");
+        async_span_scope!("LocalRepositoryIndex::load_repository");
 
         let inner_index = self
             .inner_repository_index
@@ -84,6 +84,12 @@ impl RepositoryIndex for LocalRepositoryIndex {
         let index = LocalIndex::new(inner_index);
 
         Ok(Box::new(index))
+    }
+
+    async fn list_repositories(&self) -> Result<Vec<RepositoryName>> {
+        async_span_scope!("LocalRepositoryIndex::list_repositories");
+
+        self.inner_repository_index.list_repositories().await
     }
 }
 

--- a/crates/lgn-source-control/src/index/mod.rs
+++ b/crates/lgn-source-control/src/index/mod.rs
@@ -48,6 +48,7 @@ pub trait RepositoryIndex: Send + Sync {
     async fn create_repository(&self, repository_name: RepositoryName) -> Result<Box<dyn Index>>;
     async fn destroy_repository(&self, repository_name: RepositoryName) -> Result<()>;
     async fn load_repository(&self, repository_name: RepositoryName) -> Result<Box<dyn Index>>;
+    async fn list_repositories(&self) -> Result<Vec<RepositoryName>>;
 
     async fn ensure_repository(&self, repository_name: RepositoryName) -> Result<Box<dyn Index>> {
         info!("Ensuring that repository `{}` exists...", repository_name);
@@ -125,6 +126,10 @@ impl<T: RepositoryIndex + ?Sized> RepositoryIndex for Box<T> {
     async fn load_repository(&self, repository_name: RepositoryName) -> Result<Box<dyn Index>> {
         self.as_ref().load_repository(repository_name).await
     }
+
+    async fn list_repositories(&self) -> Result<Vec<RepositoryName>> {
+        self.as_ref().list_repositories().await
+    }
 }
 
 #[async_trait]
@@ -139,6 +144,10 @@ impl<T: RepositoryIndex> RepositoryIndex for &T {
 
     async fn load_repository(&self, repository_name: RepositoryName) -> Result<Box<dyn Index>> {
         (**self).load_repository(repository_name).await
+    }
+
+    async fn list_repositories(&self) -> Result<Vec<RepositoryName>> {
+        (**self).list_repositories().await
     }
 }
 

--- a/crates/lgn-source-control/tests/integration_tests.rs
+++ b/crates/lgn-source-control/tests/integration_tests.rs
@@ -2,6 +2,7 @@ mod common;
 
 #[allow(clippy::wildcard_imports)]
 use common::*;
+use itertools::Itertools;
 
 use std::path::Path;
 
@@ -943,7 +944,7 @@ async fn test_multiple_repositories() {
 
     let workspace_root2 = tempfile::tempdir().expect("failed to create temp dir");
     let config = WorkspaceConfig::new(
-        repository_name,
+        repository_name.clone(),
         WorkspaceRegistration::new_with_current_user(),
     );
 
@@ -960,6 +961,16 @@ async fn test_multiple_repositories() {
 
     workspace_commit!(ws1, "Added some fruits");
     workspace_commit!(ws2, "Added some fruits");
+
+    let repository_names = repository_index.list_repositories().await.unwrap();
+
+    assert_eq!(
+        repository_names,
+        vec!["default".parse().unwrap(), repository_name]
+            .into_iter()
+            .sorted()
+            .collect::<Vec<RepositoryName>>(),
+    );
 
     cleanup_test_workspace_and_index!(repository_index, ws2);
     cleanup_test_workspace_and_index!(repository_index, ws1);


### PR DESCRIPTION
This PR adds a `list-repositories` to the source-control CLI (`lsc`) that lists the repositories in alphanumerical order.

![image](https://user-images.githubusercontent.com/585131/162235520-4ce8871a-7a27-43ab-a766-5720d3909275.png)
