### PR TITLE
Add a  `--version-override` flag to specify a custom Docker image in `cargo monorepo`

### DIFF
--- a/build/monorepo/src/publish/docker/target.rs
+++ b/build/monorepo/src/publish/docker/target.rs
@@ -123,7 +123,7 @@ impl<'g> DockerPublishTarget<'g> {
 
     fn docker_push(&self, args: &publish::Args) -> Result<()> {
         let mut cmd = Command::new("docker");
-        let docker_image_name = self.docker_image_name()?;
+        let docker_image_name = self.docker_image_name(args)?;
 
         if args.force {
             debug!("`--force` specified: not checking for Docker image existence before pushing");
@@ -290,7 +290,7 @@ impl<'g> DockerPublishTarget<'g> {
         }
 
         let mut cmd = Command::new("docker");
-        let docker_image_name = self.docker_image_name()?;
+        let docker_image_name = self.docker_image_name(args)?;
 
         let docker_root = docker_file
             .parent()
@@ -356,12 +356,17 @@ impl<'g> DockerPublishTarget<'g> {
         }
     }
 
-    fn docker_image_name(&self) -> Result<String> {
+    fn docker_image_name(&self, args: &publish::Args) -> Result<String> {
+        let image_tag = args
+            .version_override
+            .clone()
+            .unwrap_or_else(|| self.package.version().to_string());
+
         Ok(format!(
             "{}/{}:{}",
             self.registry()?,
             self.name(),
-            self.package.version(),
+            image_tag,
         ))
     }
 

--- a/build/monorepo/src/publish/mod.rs
+++ b/build/monorepo/src/publish/mod.rs
@@ -39,6 +39,9 @@ pub struct Args {
     /// Do not run any action that changes any external state
     #[clap(long)]
     dry_run: bool,
+    /// Specify an custom version.
+    #[clap(long)]
+    version_override: Option<String>,
 }
 
 //#[span_fn]
@@ -91,6 +94,7 @@ pub fn run(args: &Args, ctx: &Context) -> Result<()> {
             force: args.force,
             dry_run: args.dry_run,
             update_hash: args.update_hash,
+            version_override: args.version_override.clone(),
         };
         pkg.dist(ctx, &args)?;
     }


### PR DESCRIPTION
Simply adds a new optional `--version-override` option to `cargo monorepo publish` so that one can define a custom version when publishing.