### PR TITLE
Editor client: Prevent resource name overflow in the resource browser/scene explorer

### DIFF
--- a/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/ResourceBrowser.svelte
@@ -590,6 +590,6 @@
   }
 
   .entry-name {
-    @apply w-full h-full;
+    @apply w-full h-full truncate;
   }
 </style>

--- a/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/hierarchyTree/HierarchyTree.svelte
@@ -172,6 +172,6 @@
 
 <style lang="postcss">
   .root {
-    @apply h-full px-2 overflow-y-auto;
+    @apply w-full h-full pl-2 pr-8 overflow-y-auto;
   }
 </style>

--- a/crates/lgn-editor-gui/frontend/src/components/resources/ResourceFilter.svelte
+++ b/crates/lgn-editor-gui/frontend/src/components/resources/ResourceFilter.svelte
@@ -11,7 +11,10 @@
 
   let name = writable("");
 
-  $: debouncedName = debounced(name, 200);
+  /** Debounce filter values update, if null data are synced instantly, `null` by default */
+  export let debouncedMs: number | null = null;
+
+  $: debouncedName = debouncedMs === null ? name : debounced(name, debouncedMs);
 
   $: dispatch("filter", { name: $debouncedName });
 


### PR DESCRIPTION
@TechArtFrank this should prevent the name overflow you noticed in the resource browser 👍 