### PR TITLE
Reduce log level from warn to debug when token expired

### DIFF
--- a/crates/lgn-online/src/authentication/errors.rs
+++ b/crates/lgn-online/src/authentication/errors.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use thiserror::Error;
 use tonic::codegen::StdError;
 
@@ -13,8 +15,8 @@ pub enum Error {
     Internal(String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("token expired error: {0}")]
-    TokenExpired(String),
+    #[error("token expired: exp({exp:?}) < now({now:?})")]
+    TokenExpired { exp: SystemTime, now: SystemTime },
     #[error("configuration error: {0}")]
     Config(#[from] lgn_config::Error),
     #[error(transparent)]

--- a/crates/lgn-online/src/authentication/jwt/validation.rs
+++ b/crates/lgn-online/src/authentication/jwt/validation.rs
@@ -150,10 +150,7 @@ where
                 .ok_or_else(|| Error::Internal("invalid exp".to_string()))?;
 
             if exp + self.leeway < now {
-                return Err(Error::TokenExpired(format!(
-                    "the token has already expired: {:#?} < {:#?}",
-                    exp, now
-                )));
+                return Err(Error::TokenExpired { exp, now });
             }
         }
 

--- a/crates/lgn-online/src/authentication/token_cache.rs
+++ b/crates/lgn-online/src/authentication/token_cache.rs
@@ -158,9 +158,9 @@ where
                                 }
                             }
                             Err(err) => {
-                                if let Error::TokenExpired(err) = err {
+                                if let Error::TokenExpired { .. } = err {
                                     debug!(
-                                        "Cached access token is invalid ({}): refreshing login...",
+                                        "Cached access token has expired ({}): refreshing login...",
                                         err
                                     );
                                 } else {


### PR DESCRIPTION
This PR reduces the log level from `warn` to `debug` when trying to login with an expired token cache as this is considered a normal flow. In that case the token cache will be refreshed.