### PR TITLE
Update webrtc to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8924,9 +8924,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ba0c1cc8a2daa7bbf049e0785c06a0c4a144d466d6d0a7e1bb2f9cade4b759"
+checksum = "27d31ce825629e0a7b91c881d6b0a911cd65a7ebb6325fa94fbbddf1c7486f33"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8944,7 +8944,7 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "stun",
  "thiserror",
  "tokio",

--- a/crates/lgn-streamer/Cargo.toml
+++ b/crates/lgn-streamer/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.13", features = ["full", "tracing"] }
 tonic = "0.6"
-webrtc = "0.3"
+webrtc = "0.4"
 
 [build-dependencies]
 lgn-graphics-cgen = { path = "../lgn-graphics-cgen", version = "0.1.0" }

--- a/crates/lgn-streamer/src/webrtc.rs
+++ b/crates/lgn-streamer/src/webrtc.rs
@@ -61,12 +61,10 @@ impl WebRTCServer {
         let mut registry = Registry::new();
 
         // Use the default set of Interceptors
-        // Function here became async... https://github.com/webrtc-rs/webrtc/pull/146
-        // registry =
-        // webrtc::api::interceptor_registry::register_default_interceptors(registry,
-        // &mut media_engine)?;
-        registry = webrtc::api::interceptor_registry::configure_nack(registry, &mut media_engine);
-        registry = webrtc::api::interceptor_registry::configure_rtcp_reports(registry);
+        registry = webrtc::api::interceptor_registry::register_default_interceptors(
+            registry,
+            &mut media_engine,
+        )?;
 
         // Create the API object with the MediaEngine
         let api = APIBuilder::new()

--- a/deny.toml
+++ b/deny.toml
@@ -207,7 +207,7 @@ skip = [
 # detection. Unlike skip, it also includes the entire tree of transitive 
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinitef
-skip-tree = [{ name = "webrtc", version = "0.3.4" }]
+skip-tree = [{ name = "webrtc", version = "0.4.0" }]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:


### PR DESCRIPTION
# Description

Updating the WebRTC to 0.4
https://github.com/webrtc-rs/webrtc/releases/tag/v0.4.0
Contains the following fix:
* Breaking change: remove unnecessary async call for registering interceptors (by @jelmansouri)

#### Related issue:


## Licensing Agreement
- [X] I license this contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [X] Changes were tested
