### PR TITLE
Update to latest nvenc-sys to use versioned .so files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5727,7 +5727,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 [[package]]
 name = "nvenc-sys"
 version = "0.1.0"
-source = "git+https://github.com/legion-labs/nvenc-sys?rev=f6a4fe275016e1ffee1e09523463ca09ce9bb4b8#f6a4fe275016e1ffee1e09523463ca09ce9bb4b8"
+source = "git+https://github.com/legion-labs/nvenc-sys?rev=996be4ceac8112e14ae127adcf8c699bcc1618f5#996be4ceac8112e14ae127adcf8c699bcc1618f5"
 
 [[package]]
 name = "oauth2"

--- a/crates/lgn-codec-api/Cargo.toml
+++ b/crates/lgn-codec-api/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 lgn-tracing = { path = "../lgn-tracing", version = "0.1.0" }
 lgn-graphics-api = { path = "../lgn-graphics-api", version = "0.1.0" }
 ash = { version = ">= 0.33", features = ["linked"] }
-nvenc-sys = { git = "https://github.com/legion-labs/nvenc-sys", rev = "f6a4fe275016e1ffee1e09523463ca09ce9bb4b8", features = [
+nvenc-sys = { git = "https://github.com/legion-labs/nvenc-sys", rev = "996be4ceac8112e14ae127adcf8c699bcc1618f5", features = [
     "cuda",
 ] }
 libloading = "0.7"


### PR DESCRIPTION
## Description
<!--
New feature, bug fix, or improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
-->

Looking into a better way of building a docker image that needs the gpu without downloading the drivers.
It turns out that most of the libraries are already mapped when NVIDIA_DRIVER_CAPABILITIES compute,graphics,video,utility is set.
But we need to load the libraries using their versioned name.

### Related issue:
<!--
- [ ] #...
-->

### Check list

- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [X] Changes were tested

### Licensing Agreement

- [X I license this contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.
