### PR TITLE
Analytics client: Improve theme handling

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/src/App.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/App.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, setContext } from "svelte";
 
   import type { InitAuthStatus } from "@lgn/web-client/src/lib/auth";
+  import { replaceClassesWith } from "@lgn/web-client/src/lib/html";
+  import { createThemeStore } from "@lgn/web-client/src/stores/theme";
 
   import Graph from "@/components/Graph/Graph.svelte";
   import { Route, Router } from "@/lib/navigator";
@@ -13,11 +15,21 @@
   import Header from "./components/Misc/Header.svelte";
   import LoadingBar from "./components/Misc/LoadingBar.svelte";
   import TimelineRenderer from "./components/Timeline/Timeline.svelte";
+  import { themeContextKey, themeStorageKey } from "./constants";
 
   export let initAuthStatus: InitAuthStatus | null;
 
-  // TODO: Here we can control the UI and display a modal à la GitHub
+  // TODO: Set default theme to dark when it's mature enough
+  const theme = createThemeStore(themeStorageKey, "light");
+
+  setContext(themeContextKey, theme);
+
+  // TODO: Here we can control the UI and display a modal like in the Editor
   onMount(() => {
+    const unsubscribe = theme.subscribe(({ name }) => {
+      replaceClassesWith(document.body, `theme-${name}`);
+    });
+
     if (initAuthStatus) {
       switch (initAuthStatus.type) {
         case "error": {
@@ -25,14 +37,10 @@
         }
       }
     }
+
+    return unsubscribe;
   });
 </script>
-
-<svelte:head>
-  <style>
-    @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap");
-  </style>
-</svelte:head>
 
 <LoadingBar />
 <div class="pt-2 pb-4 antialiased">

--- a/npm-pkgs/lgn-analytics-gui/src/assets/index.css
+++ b/npm-pkgs/lgn-analytics-gui/src/assets/index.css
@@ -1,12 +1,17 @@
+@import "./theme.css";
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  @apply bg-skin-900;
   font-family: "Inter", Arial, sans-serif;
+  color: rgb(var(--text-default));
+  background-color: rgb(var(--background-default));
 }
 
 :root {
+  /** TODO: Use a tailwind config instead */
   --thread-item-length: 170px;
 }

--- a/npm-pkgs/lgn-analytics-gui/src/assets/theme.css
+++ b/npm-pkgs/lgn-analytics-gui/src/assets/theme.css
@@ -1,32 +1,63 @@
-:root {
-  --color-primary-700: #fc4d0f;
-  --color-primary-800: #e7440a;
-  --color-primary-900: #d83b03;
+.theme-light {
+  --roundness: 0%;
 
+  --text-default: 0, 0, 0;
+  --background-default: 240, 240, 240;
+
+  --color-primary: 252, 77, 15;
+  --color-accent: 252, 77, 15;
+
+  --color-background: 198, 198, 198;
+  --color-surface: 215, 215, 215;
+
+  --color-headline: 0, 0, 0;
+  --color-text: 0, 0, 0;
+  --color-placeholder: 0, 0, 0;
+  --color-backdrop: 255, 255, 255;
+
+  --color-on-surface: 231, 231, 231;
+  --color-notification: 252, 77, 15;
+
+  --opacity-headline: 87%;
+  --opacity-text: 60%;
+  --opacity-placeholder: 38%;
+  --opacity-backdrop: 87%;
+
+  /** TODO: Remove */
   --color-content-38: #00000061;
   --color-content-60: #00000099;
   --color-content-87: #000000de;
   --color-content-100: #000000ff;
-
-  --color-background-600: #c6c6c6;
-  --color-background-700: #dfdfdf;
-  --color-background-800: #e7e7e7;
-  --color-background-900: #f0f0f0;
 }
 
-.dark {
+.theme-dark {
+  --roundness: 0%;
+
+  --text-default: 255, 255, 255;
+  --background-default: 28, 28, 28;
+
+  --color-primary: 252, 77, 15;
+  --color-accent: 252, 77, 15;
+
+  --color-background: 15, 15, 15;
+  --color-surface: 20, 20, 20;
+
+  --color-headline: 255, 255, 255;
+  --color-text: 255, 255, 255;
+  --color-placeholder: 255, 255, 255;
+  --color-backdrop: 0, 0, 0;
+
+  --color-on-surface: 32, 32, 32;
+  --color-notification: 252, 77, 15;
+
+  --opacity-headline: 87%;
+  --opacity-text: 60%;
+  --opacity-placeholder: 38%;
+  --opacity-backdrop: 87%;
+
+  /** TODO: Remove */
   --color-content-38: #ffffff61;
   --color-content-60: #ffffff99;
   --color-content-87: #ffffffde;
   --color-content-100: #ffffffff;
-
-  --color-background-38: #00000061;
-  --color-background-60: #00000099;
-  --color-background-87: #000000de;
-  --color-background-100: #000000ff;
-
-  --color-background-600: #393939;
-  --color-background-700: #202020;
-  --color-background-800: #181818;
-  --color-background-900: #0f0f0f;
 }

--- a/npm-pkgs/lgn-analytics-gui/src/components/CumulatedGraph/CallGraph.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/CumulatedGraph/CallGraph.svelte
@@ -17,7 +17,7 @@
   export let size: number;
 
   let store: CumulatedCallGraphStore;
-  let tickTimer: number;
+  let tickTimer: ReturnType<typeof setTimeout>;
 
   $: (begin || end) && tick();
 
@@ -54,9 +54,9 @@
       style:max-height={`${size}px`}
     >
       <table
-        class="w-full bg-skin-700 text-xs text-content-60 space-y-2 table-fixed "
+        class="w-full bg-background text-xs text-content-60 space-y-2 table-fixed "
       >
-        <tr class="bg-skin-800 w-100">
+        <tr class="bg-background w-100">
           <th style="width:66%" class="text-left">Function</th>
           <th class="table-header"><i class="bi bi-caret-right" />Count</th>
           <th class="table-header"

--- a/npm-pkgs/lgn-analytics-gui/src/components/CumulatedGraph/CallGraphLine.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/CumulatedGraph/CallGraphLine.svelte
@@ -54,6 +54,6 @@
   }
 
   tr:nth-child(even) {
-    @apply bg-skin-600;
+    @apply bg-surface;
   }
 </style>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Graph/GraphNode.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Graph/GraphNode.svelte
@@ -27,12 +27,12 @@
 
 <div class="text-sm py-1 rounded-lg overflow-x-hidden">
   <div
-    class="flex justify-between select-none cursor-pointer relative bg-skin-600 text-content-87"
+    class="flex justify-between select-none cursor-pointer relative bg-surface text-content-87"
     on:click={(_) => setCollapse(!collapsed)}
   >
     {#if desc}
       <div
-        class="text-left pl-2 py-1 whitespace-nowrap bg-skin-700"
+        class="text-left pl-2 py-1 whitespace-nowrap bg-background"
         style:width="{fill}%"
       >
         <i
@@ -54,7 +54,7 @@
     {/if}
   </div>
   {#if !collapsed && $node}
-    <div class="bg-skin-700 flex flex-col p-3">
+    <div class="bg-background flex flex-col p-3">
       <GraphNodeStat {node} />
       <div class="hidden md:block pb-4">
         <div class="w-full border-t border-charcoal-600" />

--- a/npm-pkgs/lgn-analytics-gui/src/components/List/ProcessList.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/List/ProcessList.svelte
@@ -58,13 +58,13 @@
       <input
         autofocus
         type="text"
-        class="search-input h-8 w-96 bg-skin-600 text-content-100 placeholder-content-100 rounded-sm pl-2"
+        class="search-input h-8 w-96 text-content-100 placeholder-content-100 rounded-sm pl-2 bg-surface"
         placeholder="Search process..."
         on:input={onSearchChange}
       />
     </div>
     <table class="w-full">
-      <thead class="select-none bg-skin-600">
+      <thead class="select-none">
         <th>User</th>
         <th>Executable</th>
         <th>Computer</th>
@@ -129,22 +129,33 @@
 </Loader>
 
 <style lang="postcss">
+  /** TODO: Use divs instead of a table */
+
+  table {
+    border-collapse: separate;
+    border-spacing: 0 0.2rem;
+  }
+
   table th {
-    @apply py-1 pl-1 border text-left;
+    @apply text-sm capitalize py-1 pl-1 border text-left;
+
     border-style: none;
   }
 
-  table tr:nth-child(even) {
-    @apply bg-skin-600;
+  table tr {
+    @apply bg-surface rounded-md;
+  }
+
+  table tr td:first-child {
+    @apply rounded-l-md;
+  }
+
+  table tr td:last-child {
+    @apply rounded-r-md;
   }
 
   table td {
-    @apply p-1;
-    @apply border-none;
-  }
-
-  table th {
-    @apply text-sm capitalize;
+    @apply px-2 py-1 border-none;
   }
 
   table td div {

--- a/npm-pkgs/lgn-analytics-gui/src/components/List/User.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/List/User.svelte
@@ -4,7 +4,7 @@
 
 <div class="flex gap-2 items-center select-none">
   <div
-    class="w-6 h-6 flex justify-center items-center rounded-full text-xs text-white-87 bg-orange-700"
+    class="w-5 h-5 flex justify-center items-center rounded-full text-xs text-white-87 bg-orange-700"
   >
     <span class="capitalize">{user.charAt(0)}</span>
   </div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Log/Log.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Log/Log.svelte
@@ -96,7 +96,7 @@
     </div>
   {/if}
   {#each logEntries as entry, index (index)}
-    <div class="text-left bg-skin-900 flex flex-row gap-x-4">
+    <div class="text-left bg-background flex flex-row gap-x-4">
       <div class="font-bold basis-28 shrink-0">
         {formatTime(entry.timeMs)}
       </div>
@@ -158,6 +158,6 @@
 
 <style lang="postcss">
   .nav-link {
-    @apply text-primary-900;
+    @apply text-primary;
   }
 </style>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Misc/Header.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Misc/Header.svelte
@@ -1,20 +1,34 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { getContext, onMount } from "svelte";
   import { link } from "svelte-navigator";
 
   import { authClient } from "@lgn/web-client/src/lib/auth";
+  import type { ThemeStore } from "@lgn/web-client/src/stores/theme";
+
+  import { themeContextKey } from "@/constants";
 
   import iconPath from "../../../icons/128x128.png";
   import User from "../List/User.svelte";
 
   let user: string | undefined;
-  let dark = true;
 
-  $: document.body.classList.toggle("dark", dark);
+  const theme = getContext<ThemeStore>(themeContextKey);
+
+  // TODO: Drop this whole logic when the dark theme is mature enough
+  // Feel free to set this const to "true" to enable fast theme switching
+  const themeIsTogglable = false;
 
   onMount(async () => {
     user = (await authClient.userInfo()).name;
   });
+
+  function toggleTheme(event: MouseEvent) {
+    if (event.ctrlKey && event.shiftKey) {
+      event.preventDefault();
+
+      $theme.name = $theme.name === "dark" ? "light" : "dark";
+    }
+  }
 </script>
 
 <div class="w-full flex justify-between pl-6 pt-4 pr-4">
@@ -25,12 +39,7 @@
         alt="logo"
         style="height:24px"
         class="inline"
-        on:click={(e) => {
-          if (e.shiftKey && e.ctrlKey) {
-            e.preventDefault();
-            dark = !dark;
-          }
-        }}
+        on:click={themeIsTogglable ? toggleTheme : undefined}
       />
       <span class="font-bold text-xl text-content-87">
         <a href="/" use:link>Legion Performance Analytics</a>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineProcess.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineProcess.svelte
@@ -46,7 +46,7 @@
 
 <div on:wheel|preventDefault={(e) => wheelDispatcher("zoom", e)} {style}>
   <div
-    class="bg-skin-700 text-content-87 px-1 text-sm text-left mb-1 flex flex-row place-content-between items-center"
+    class="bg-surface text-content-87 px-1 text-sm text-left mb-1 flex flex-row place-content-between items-center"
     on:click|preventDefault={() => (collapsed = !collapsed)}
   >
     <div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineRow.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineRow.svelte
@@ -20,7 +20,7 @@
 
 <div class="flex items-start overflow-hidden" {style}>
   <div
-    class="thread text-sm bg-skin-600 text-content-60 px-1 overflow-hidden cursor-pointer mr-1 self-stretch"
+    class="thread text-sm bg-background text-content-60 px-1 overflow-hidden cursor-pointer mr-1 self-stretch"
     on:click={() => setCollapse(!collapsed)}
     title={threadTitle}
   >

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineSearch.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineSearch.svelte
@@ -8,14 +8,14 @@
 <div>
   <input
     type="text"
-    class="metric-search border-0 text-sm text-content-60 bg-skin-600"
+    class="metric-search border-0 text-sm text-content-60 bg-background"
     placeholder="Search..."
     on:focus={() => (searching = true)}
     on:blur={() => (searching = false)}
     bind:value={$searchStore}
   />
   <button
-    class="text-sm bg-skin-600 text-content-60 w-5"
+    class="text-sm bg-background text-content-60 w-5"
     on:click={() => searchStore.set("")}><i class="bi bi-x-circle" /></button
   >
 </div>

--- a/npm-pkgs/lgn-analytics-gui/src/constants.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/constants.ts
@@ -1,0 +1,3 @@
+export const themeContextKey = Symbol.for("theme-context-key");
+
+export const themeStorageKey = "theme";

--- a/npm-pkgs/lgn-analytics-gui/src/index.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/index.ts
@@ -2,7 +2,6 @@ import { AppComponent, run } from "@lgn/web-client";
 
 import App from "./App.svelte";
 import "./assets/index.css";
-import "./assets/theme.css";
 
 const redirectUri = document.location.origin + "/";
 
@@ -23,7 +22,6 @@ run({
   },
   rootQuerySelector: "#root",
   logLevel: "debug",
-  onPreInit: undefined,
 })
   // eslint-disable-next-line no-console
   .catch((error) => console.error("Application couldn't start", error));

--- a/npm-pkgs/lgn-analytics-gui/tailwind.config.cjs
+++ b/npm-pkgs/lgn-analytics-gui/tailwind.config.cjs
@@ -1,5 +1,23 @@
 // @ts-check
 
+/**
+ * @param {string} varName
+ * @param {number} [defaultOpacity]
+ */
+function withOpacity(varName, defaultOpacity) {
+  return (/** @type {{opacityValue?: string }} */ { opacityValue }) => {
+    const opacity =
+      typeof opacityValue !== "undefined" ? opacityValue : defaultOpacity;
+
+    if (typeof opacity !== "undefined") {
+      return `rgba(var(${varName}), ${opacity})`;
+    }
+
+    return `rgb(var(${varName}))`;
+  };
+}
+
+// eslint-disable-next-line no-undef
 module.exports = {
   mode: "jit",
   content: ["index.html", "./src/**/*.{svelte,ts}"],
@@ -8,20 +26,25 @@ module.exports = {
       default: "Inter,Arial,sans-serif",
     },
     extend: {
-      backgroundColor: {
-        skin: {
-          600: "var(--color-background-600)",
-          700: "var(--color-background-700)",
-          800: "var(--color-background-800)",
-          900: "var(--color-background-900)",
-        },
+      borderRadius: {
+        DEFAULT: "var(--roundness)",
       },
       colors: {
-        primary: {
-          700: "var(--color-primary-700)",
-          800: "var(--color-primary-800)",
-          900: "var(--color-primary-900)",
+        primary: withOpacity("--color-primary"),
+        accent: withOpacity("--color-accent"),
+        headline: withOpacity("--color-headline", 87),
+        text: withOpacity("--color-text", 60),
+        placeholder: withOpacity("--color-placeholder", 38),
+        "on-surface": withOpacity("--color-on-surface"),
+        notification: withOpacity("--color-notification"),
+
+        // TODO: Revamp
+        graph: {
+          red: "#EE7B70FF",
+          orange: "#F5BB5CFF",
         },
+
+        // TODO: Remove all
         content: {
           38: "var(--color-content-38)",
           60: "var(--color-content-60)",
@@ -29,27 +52,20 @@ module.exports = {
           100: "var(--color-content-100)",
         },
         white: {
-          38: "#FFFFFF61",
-          60: "#FFFFFF99",
           87: "#FFFFFFDE",
           100: "#FFFFFFFF",
         },
         black: {
-          38: "#00000061",
-          60: "#00000099",
           87: "#000000DE",
-          100: "#000000FF",
         },
         charcoal: {
           600: "#393939",
-          700: "#202020",
-          800: "#181818",
-          900: "#0F0F0F",
         },
-        graph: {
-          red: "#EE7B70FF",
-          orange: "#F5BB5CFF",
-        },
+      },
+      backgroundColor: {
+        background: withOpacity("--color-background"),
+        surface: withOpacity("--color-surface"),
+        backdrop: withOpacity("--color-backdrop", 87),
       },
     },
   },

--- a/npm-pkgs/lgn-analytics-gui/tsconfig.json
+++ b/npm-pkgs/lgn-analytics-gui/tsconfig.json
@@ -29,10 +29,16 @@
     }
   },
   "include": [
+    // Source
     "src/**/*.ts",
     "src/**/*.d.ts",
     "src/**/*.svelte",
+    // Tests
     "tests/**/*.ts",
-    "proto/**/*.ts"
+    // Electron
+    "src/electron/**/*.cjs",
+    // Configuration files
+    "*.cjs",
+    "*.js"
   ]
 }

--- a/npm-pkgs/lgn-web-client/src/lib/html.ts
+++ b/npm-pkgs/lgn-web-client/src/lib/html.ts
@@ -63,3 +63,12 @@ export function remToPx(rem: number): number | null {
 
   return rem * fontSize;
 }
+
+/** Takes a `Element` and set its one and only class, removing all the others (if any) */
+export function replaceClassesWith(element: Element, newClass: string) {
+  if (element.classList.length > 0) {
+    element.classList.remove(...Array.from(element.classList));
+  }
+
+  element.classList.add(newClass);
+}

--- a/npm-pkgs/lgn-web-client/src/lib/storage.ts
+++ b/npm-pkgs/lgn-web-client/src/lib/storage.ts
@@ -7,6 +7,7 @@ export interface Storage<Key, Value extends JsonValue> {
   clear(): boolean;
   set(key: Key, value: Value): boolean;
   entries(): [Key, Value][];
+  canStore(value: Value): boolean;
 }
 
 export class DefaultLocalStorage<Key extends string, Value extends JsonValue>
@@ -68,6 +69,12 @@ export class DefaultLocalStorage<Key extends string, Value extends JsonValue>
     }
 
     return entries;
+  }
+
+  canStore(_value: Value): boolean {
+    // TODO: Check the size of the incoming value and return false if it's too large
+
+    return true;
   }
 }
 
@@ -131,6 +138,12 @@ export class DefaultSessionStorage<Key extends string, Value extends JsonValue>
 
     return entries;
   }
+
+  canStore(_value: Value): boolean {
+    // TODO: Check the size of the incoming value and return false if it's too large
+
+    return true;
+  }
 }
 
 export class InMemory<Key extends string, Value extends JsonValue>
@@ -180,5 +193,9 @@ export class InMemory<Key extends string, Value extends JsonValue>
 
   entries(): [Key, Value][] {
     return Object.entries(this.#record) as [Key, Value][];
+  }
+
+  canStore(_value: Value): boolean {
+    return true;
   }
 }

--- a/npm-pkgs/lgn-web-client/src/stores/theme.ts
+++ b/npm-pkgs/lgn-web-client/src/stores/theme.ts
@@ -1,0 +1,24 @@
+import type { Writable } from "svelte/store";
+
+import { DefaultLocalStorage } from "../lib/storage";
+import { connected } from "../lib/store";
+
+export type ThemeValue = {
+  name: string;
+};
+
+export type ThemeStore = Writable<ThemeValue>;
+
+export const themeName = window.matchMedia("(prefers-color-scheme: dark)")
+  .matches
+  ? "dark"
+  : "light";
+
+export function createThemeStore(
+  key: string,
+  defaultThemeName: string = themeName
+): ThemeStore {
+  return connected<string, ThemeValue>(new DefaultLocalStorage(), key, {
+    name: defaultThemeName,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,17 +58,6 @@ importers:
       ts-proto: 1.110.4
       typescript: 4.6.3
 
-  crates/lgn-electron/js:
-    specifiers:
-      electron: ^18.0.3
-      electron-serve: ^1.1.0
-      typescript: ^4.6.3
-    dependencies:
-      electron: 18.0.3
-      electron-serve: 1.1.0
-    devDependencies:
-      typescript: 4.6.3
-
   crates/lgn-log-stream-proto:
     specifiers:
       '@improbable-eng/grpc-web': ^0.15.0


### PR DESCRIPTION
Preparing the work related to theming a bit further.

This pr:
- [x] Introduces a new "smart" store that will automatically save the chosen theme in the local storage and use the [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) by default
- [x] Keep the theme switching logic as is for now before we drop it in future versions
- [x] Defaults to the light theme for now
- [x] Cleanup the current css variables and improve the tailwind config
- [x] Mutli small cleanups