### PR TITLE
Web client: Auth - Handle more advanced redirections

### DIFF
--- a/npm-pkgs/lgn-editor-gui/src/routes/__layout.svelte
+++ b/npm-pkgs/lgn-editor-gui/src/routes/__layout.svelte
@@ -74,7 +74,7 @@
           clientId,
           url,
           redirectFunction(url) {
-            return goto(url, { replaceState: true });
+            return goto(url.toString(), { replaceState: true });
           },
           login: {
             cookies: {


### PR DESCRIPTION
Addresses https://github.com/legion-labs/legion/issues/1394

So far it works well, we keep the same redirection logic and basically just save the url in the local storage before redirecting. Said local storage item is then deleted once the redirection is done.