### PR TITLE
Analytics: Debounce and highlight process search

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessComputer.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessComputer.svelte
@@ -3,15 +3,7 @@
 
   export let process: Process | undefined;
 
-  function getComputer() {
-    if (!process) {
-      return "Unknown";
-    }
-    if (!process.computer) {
-      return "Unknown";
-    }
-    return process.computer;
-  }
+  $: computer = process?.computer || "Unknown";
 </script>
 
 <div
@@ -19,5 +11,9 @@
   class="flex gap-2 items-center"
 >
   <i class="bi bi-pc placeholder" />
-  <span>{getComputer()}</span>
+  <span>
+    <slot {computer}>
+      {computer}
+    </slot>
+  </span>
 </div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPage.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPage.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { getContext, onMount } from "svelte";
+  import { writable } from "svelte/store";
 
   import type {
     PerformanceAnalyticsClientImpl,
     ProcessInstance,
   } from "@lgn/proto-telemetry/dist/analytics";
+  import { debounced } from "@lgn/web-client/src/lib/store";
   import type { L10nOrchestrator } from "@lgn/web-client/src/orchestrators/l10n";
 
   import L10n from "@/components/Misc/L10n.svelte";
@@ -14,32 +16,49 @@
   import Loader from "../Misc/Loader.svelte";
   import ProcessItem from "./ProcessItem.svelte";
 
+  type Mode = "default" | "search";
+
   const { t } = getContext<L10nOrchestrator<Fluent>>(
     l10nOrchestratorContextKey
   );
 
+  const searchValue = writable("");
+
+  const debouncedSearchValue = debounced(searchValue, 300);
+
   let processes: ProcessInstance[] = [];
   let client: PerformanceAnalyticsClientImpl | null = null;
   let loading = true;
+  let mode: Mode = "default";
 
   onMount(async () => {
     client = makeGrpcClient();
-    const result = await client
+
+    const response = await client
       .list_recent_processes({ parentProcessId: undefined })
       .finally(() => (loading = false));
-    processes = result.processes;
+
+    processes = response.processes;
   });
 
-  async function onSearchChange(
-    evt: Event & { currentTarget: EventTarget & HTMLInputElement }
-  ) {
+  async function search(mode: Mode) {
     if (!client) {
       return;
     }
-    const searchString = evt.currentTarget.value;
-    const response = await client.search_processes({ search: searchString });
+
+    const response =
+      mode === "search"
+        ? await client.search_processes({
+            search: $debouncedSearchValue,
+          })
+        : await client.list_recent_processes({ parentProcessId: undefined });
+
     processes = response.processes;
   }
+
+  $: mode = $debouncedSearchValue.trim() ? "search" : "default";
+
+  $: search(mode);
 </script>
 
 <Loader {loading}>
@@ -51,7 +70,7 @@
         type="text"
         class="h-8 w-96 placeholder rounded-sm pl-2 surface"
         placeholder={$t("process-list-search")}
-        on:input={onSearchChange}
+        bind:value={$searchValue}
       />
     </div>
     <div class="flex flex-col gap-y-2 text-sm">
@@ -78,7 +97,13 @@
         </div>
       </div>
       {#each processes as processInstance, index (processInstance.processInfo?.processId)}
-        <ProcessItem {processInstance} depth={0} {index} />
+        <ProcessItem
+          highlightedPattern={$debouncedSearchValue}
+          {processInstance}
+          depth={0}
+          {index}
+          noFold={mode === "search"}
+        />
       {/each}
     </div>
   </div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPlatform.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPlatform.svelte
@@ -15,9 +15,11 @@
     }
     return "Unknown";
   }
+
+  $: platform = getPlatform(process?.distro);
 </script>
 
 <div class="flex gap-2 items-center">
   <i class="bi bi-pc placeholder" />
-  <span class="capitalize">{getPlatform(process?.distro)}</span>
+  <span class="capitalize">{platform}</span>
 </div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/User.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/User.svelte
@@ -8,5 +8,9 @@
   >
     <span class="capitalize">{user.charAt(0)}</span>
   </div>
-  <span class="capitalize">{user}</span>
+  <div class="capitalize">
+    <slot {user}>
+      {user}
+    </slot>
+  </div>
 </div>


### PR DESCRIPTION
closes: https://github.com/legion-labs/legion/issues/1671

It seems to work ok, but we also get some results that don't match the search pattern (needle). I'm investigating why. If that's intended, it means there are some cases where we can't display the highlighted value because it's just not displayed in the table. If so, we should whether not filter the processes using a column that's not displayed or display said column. What do you think @alexandra-nemery  @mad-legion ?

I'm also trying to see how the search engine works regarding the sub processes. For me, it's pretty clear we can simply open all the processes that have at least one matching sub process, the question is, what should happen if the search field is cleared @alexandra-nemery ? (If that's not clear, I'll make a video to show you what I mean 👍 )