### PR TITLE
Analytics: Translate the timeline page to French

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/src/App.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/App.svelte
@@ -57,6 +57,15 @@
     ],
     {
       local: {
+        functions: {
+          LOWERCASE([value]) {
+            if (!value || typeof value !== "string") {
+              return value;
+            }
+
+            return value.toLowerCase();
+          },
+        },
         connect: {
           key: localeStorageKey,
           storage: new DefaultLocalStorage(),

--- a/npm-pkgs/lgn-analytics-gui/src/assets/index.css
+++ b/npm-pkgs/lgn-analytics-gui/src/assets/index.css
@@ -14,25 +14,25 @@ body {
   --thread-item-length: 11rem;
 }
 
+/* TODO: Use theme for the scrollbar */
+
 /* Customize scrollbar on Chrome, Safari, Edge */
 *::-webkit-scrollbar {
   @apply w-3 h-3;
 }
 
 *::-webkit-scrollbar-track {
-  @apply on-surface;
+  @apply bg-default;
 }
 
 *::-webkit-scrollbar-thumb {
-  @apply hover:bg-gray-400 opacity-0 duration-150 transition-colors;
+  @apply hover:bg-gray-400 opacity-0 duration-150 transition-colors rounded-full;
 
-  background-color: rgba(var(--color-text), 0.5);
+  border: 0.15rem solid transparent;
+  background-color: #454545;
+  background-clip: content-box;
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(var(--color-text), 0.8);
-}
-
-.thin-scrollbar::-webkit-scrollbar {
-  @apply w-1 h-1;
+  background-color: #707070;
 }

--- a/npm-pkgs/lgn-analytics-gui/src/assets/locales/en-US/main.ftl
+++ b/npm-pkgs/lgn-analytics-gui/src/assets/locales/en-US/main.ftl
@@ -1,3 +1,21 @@
+# Global
+global-pagination-first = First
+global-pagination-previous = Previous
+global-pagination-last = Last
+global-pagination-next = Next
+global-platform =
+  {$platform ->
+    [linux] Linux
+    [windows] Windows
+    *[unknown] Unknown
+  }
+global-link-copy = Copy Link
+global-link-share = Share Link
+global-cumulative-call-graph = Cumulative Call Graph
+global-log = Log
+global-timeline = Timeline
+global-thread = thread
+
 # Process list
 process-list-user = User
 process-list-process = Process
@@ -12,27 +30,40 @@ log-process-id = Process Id:
 log-executable = Executable:
 log-parent-link = Parent Process Log
 
-# Global
-
-global-pagination-first = First
-global-pagination-previous = Previous
-global-pagination-last = Last
-global-pagination-next = Next
-
-# TODO: Remove these examples
-hello-user = Hello, {$userName}!
-
-shared-photos =
-    {$userName} {$photoCount ->
-        [one] added a new photo
-       *[other] added {$photoCount} new photos
-    } to {$userGender ->
-        [male] his stream
-        [female] her stream
-       *[other] their stream
-    }.
-
-login-input = Predefined value
-    .placeholder = email@example.com
-    .aria-label = Login input value
-    .title = Type your login email
+# Timeline
+timeline-open-cumulative-call-graph = Open { global-cumulative-call-graph }
+timeline-search = Search...
+timeline-table-function = Function
+timeline-table-count = Count
+timeline-table-average = Avg
+timeline-table-minimum = Min
+timeline-table-maximum = Max
+timeline-table-standard-deviation = Sd
+timeline-table-sum = Sum
+timeline-main-collapsed-extra =
+  {$validThreadCount ->
+    [0] (No thread data)
+    *[other] ({$validThreadCount} {$validThreadCount ->
+      [one] thread
+      *[other] threads
+    } with data)
+  }
+timeline-main-thread-description-title =
+  {$threadName}
+  {$threadLength}
+  {$threadBlocks} {$threadBlocks ->
+    [one] block
+    *[other] blocks
+  }
+timeline-main-thread-description =
+  {$threadLength} ({$threadBlocks} {$threadBlocks ->
+    [one] block
+    *[other] blocks
+  })
+timeline-main-collapse = Collapse
+timeline-main-expand = Expand
+timeline-debug-tooltip =
+  Pixel size: { $pixelSize }
+  Lod: { $lod }
+  Threshold: { $threshold }
+  Events: { $events }

--- a/npm-pkgs/lgn-analytics-gui/src/assets/locales/fr-CA/main.ftl
+++ b/npm-pkgs/lgn-analytics-gui/src/assets/locales/fr-CA/main.ftl
@@ -1,3 +1,21 @@
+# Global
+global-pagination-first = Première
+global-pagination-previous = Précédente
+global-pagination-last = Dernière
+global-pagination-next = Suivante
+global-platform =
+  {$platform ->
+    [linux] Linux
+    [windows] Windows
+    *[unknown] Inconnue
+  }
+global-link-copy = Copier le lien
+global-link-share = Partager le lien
+global-cumulative-call-graph = Graphique d'appel cumulatif
+global-log = Journal
+global-timeline = Ligne du temps
+global-thread = unité
+
 # Process list
 process-list-user = Utilisateur
 process-list-process = Processus
@@ -5,26 +23,47 @@ process-list-computer = Machine
 process-list-platform = Plateforme
 process-list-start-time = Débuté à
 process-list-statistics = Statistiques
-process-list-search = Recherche de processus...
+process-list-search = Rechercher des processus...
 
 # Log
 log-process-id = Identifiant du processus :
 log-executable = Nom de l'exécutable :
-log-parent-link = Journal du processus parent
+log-parent-link = { global-log } du processus parent
 
-# Global
-
-global-pagination-first = Première
-global-pagination-previous = Précédente
-global-pagination-last = Dernière
-global-pagination-next = Suivante
-
-# TODO: Remove these examples
-hello-user = Allô {$userName}!
-
-shared-photos =
-    {$userName} {$photoCount ->
-        [0] n'a ajouté aucune nouvelle photo
-        [one] a ajouté une nouvelle photo
-       *[other] a ajouté {$photoCount} nouvelles photos
-    } à son album.
+# Timeline
+timeline-open-cumulative-call-graph = Ouvrir le { LOWERCASE(global-cumulative-call-graph) }
+timeline-search = Rechercher...
+timeline-table-function = Fonction
+timeline-table-count = Total
+timeline-table-average = Moyenne
+timeline-table-minimum = Min
+timeline-table-maximum = Max
+timeline-table-standard-deviation = Écart type
+timeline-table-sum = Somme
+timeline-main-collapsed-extra =
+  {$validThreadCount ->
+    [0] (Aucune donnée disponible)
+    *[other] ({$validThreadCount} {$validThreadCount ->
+      [one] unité
+      *[other] unités
+    } contenant des données)
+  }
+timeline-main-thread-description-title =
+  {$threadName}
+  {$threadLength}
+  {$threadBlocks} {$threadBlocks ->
+    [one] bloc
+    *[other] blocs
+  }
+timeline-main-thread-description =
+  {$threadLength} ({$threadBlocks} {$threadBlocks ->
+    [one] bloc
+    *[other] blocs
+  })
+timeline-main-collapse = Fermer
+timeline-main-expand = Ouvrir
+timeline-debug-tooltip =
+  Un pixel représente : { $pixelSize }
+  Niveau de détail : { $lod }
+  Seuil : { $threshold }
+  Nombre d'événements : { $events }

--- a/npm-pkgs/lgn-analytics-gui/src/components/CallGraphFlat/CallGraphFlat.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/CallGraphFlat/CallGraphFlat.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import { getContext, onMount } from "svelte";
+  import { onMount } from "svelte";
   import { useLocation } from "svelte-navigator";
 
-  import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
-
-  import { httpClientContextKey } from "@/constants";
+  import { getHttpClientContext } from "@/contexts";
   import { CallGraphParameters } from "@/lib/CallGraph/CallGraphParameters";
   import { getProcessCumulatedCallGraphFlat } from "@/lib/CallGraph/CallGraphStore";
   import type { CumulatedCallGraphFlatStore } from "@/lib/CallGraph/CallGraphStore";
@@ -16,8 +14,7 @@
 
   const components: Record<number, GraphNode> = {};
   const locationStore = useLocation();
-  const client =
-    getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
+  const client = getHttpClientContext();
 
   let beginMsFilter = 0;
   let endMsFilter = 0;

--- a/npm-pkgs/lgn-analytics-gui/src/components/CallGraphHierachy/CallGraphHierachy.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/CallGraphHierachy/CallGraphHierachy.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
-  import { getContext, onMount } from "svelte";
+  import { onMount } from "svelte";
   import { BarLoader } from "svelte-loading-spinners";
   import { link } from "svelte-navigator";
 
-  import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
-
-  import { httpClientContextKey } from "@/constants";
+  import { getHttpClientContext } from "@/contexts";
   import type { CumulatedCallGraphHierarchyStore } from "@/lib/CallGraph/CallGraphStore";
   import { getProcessCumulatedCallGraphHierarchy } from "@/lib/CallGraph/CallGraphStore";
   import { endQueryParam, startQueryParam } from "@/lib/time";
 
+  import L10n from "../Misc/L10n.svelte";
   import CallTreeDebug from "./CallGraphHierachyDebug.svelte";
   import CallGraphLine from "./CallGraphHierachyLine.svelte";
 
-  const client =
-    getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
+  const client = getHttpClientContext();
 
   export let begin: number;
   export let end: number;
@@ -62,36 +60,55 @@
             use:link
           >
             <i class="bi bi-arrow-up-right-circle" />
-            Open Cumulative Call Graph
+            <L10n id="timeline-open-cumulative-call-graph" />
           </a>
         </div>
         <div class="overflow-auto" style:max-height={`${size}px`}>
-          <table class="w-full background text-xs text space-y-2 table-fixed">
-            <tr class="background w-100">
-              <th style="width:66%" class="text-left">Function</th>
-              <th class="table-header"><i class="bi bi-caret-right" />Count</th>
-              <th class="table-header"
-                ><i class="bi bi-chevron-bar-contract" />Avg</th
-              >
-              <th class="table-header"
-                ><i class="bi bi-chevron-bar-left" />Min</th
-              >
-              <th class="table-header"
-                ><i class="bi bi-chevron-bar-right" />Max</th
-              >
-              <th class="table-header"><i class="bi bi-lightbulb" />Sd</th>
-              <th class="table-header"
-                ><i class="bi bi bi-caret-right-fill" /> Sum</th
-              >
-            </tr>
-            {#each Array.from($store.threads) as [hash, thread] (hash)}
-              {#if thread.data}
-                {#each Array.from(thread.data).filter((obj) => obj[1].parents.size === 0) as [key, node] (key)}
-                  <CallGraphLine {node} {store} threadId={key} />
-                {/each}
-              {/if}
-            {/each}
-          </table>
+          <div role="table" class="w-full background text-xs text">
+            <div
+              role="rowgroup"
+              class="flex flex-row items-center h-6 w-full background sticky top-0"
+            >
+              <div role="row" class="flex flex-row background w-full px-1">
+                <div role="columnheader" class="text-left w-full">
+                  <div><L10n id="timeline-table-function" /></div>
+                </div>
+                <div role="columnheader" class="table-header">
+                  <div><i class="bi bi-caret-right" /></div>
+                  <div><L10n id="timeline-table-count" /></div>
+                </div>
+                <div role="columnheader" class="table-header">
+                  <div><i class="bi bi-chevron-bar-contract" /></div>
+                  <div><L10n id="timeline-table-average" /></div>
+                </div>
+                <div role="columnheader" class="table-header">
+                  <div><i class="bi bi-chevron-bar-left" /></div>
+                  <div><L10n id="timeline-table-minimum" /></div>
+                </div>
+                <div role="columnheader" class="table-header">
+                  <div><i class="bi bi-chevron-bar-right" /></div>
+                  <div><L10n id="timeline-table-maximum" /></div>
+                </div>
+                <div role="columnheader" class="table-header">
+                  <div><i class="bi bi-lightbulb" /></div>
+                  <div><L10n id="timeline-table-standard-deviation" /></div>
+                </div>
+                <div role="columnheader" class="table-header">
+                  <div><i class="bi bi bi-caret-right-fill" /></div>
+                  <div><L10n id="timeline-table-sum" /></div>
+                </div>
+              </div>
+            </div>
+            <div role="rowgroup">
+              {#each Array.from($store.threads) as [hash, thread] (hash)}
+                {#if thread.data}
+                  {#each Array.from(thread.data).filter((obj) => obj[1].parents.size === 0) as [key, node] (key)}
+                    <CallGraphLine {node} {store} threadId={key} />
+                  {/each}
+                {/if}
+              {/each}
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -99,34 +116,7 @@
 {/if}
 
 <style lang="postcss">
-  i {
-    @apply pr-1;
-  }
-
   .table-header {
-    @apply truncate;
-  }
-
-  ::-webkit-scrollbar {
-    width: 20px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background-color: transparent;
-  }
-
-  ::-webkit-scrollbar-corner {
-    background: rgba(0, 0, 0, 0);
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: #454545;
-    border-radius: 20px;
-    border: 6px solid transparent;
-    background-clip: content-box;
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    background-color: #707070;
+    @apply flex flex-shrink-0 w-28 truncate space-x-1 justify-center;
   }
 </style>

--- a/npm-pkgs/lgn-analytics-gui/src/components/CallGraphHierachy/CallGraphHierachyLine.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/CallGraphHierachy/CallGraphHierachyLine.svelte
@@ -23,36 +23,42 @@
       }
     }
   }
+
+  const children = Array.from(getChildren()).sort(
+    (r, l) => l.value.acc - r.value.acc
+  );
 </script>
 
 {#if node}
-  <tr class="cursor-pointer text-sm">
-    <td
-      style={`padding-left: ${depth * 20}px`}
-      class="truncate"
-      on:click={(_) => (collapsed = !collapsed)}
-      >{$store.scopes && $store.scopes[node.hash]?.name}
-    </td>
-    <td class="stat">{value.count.toLocaleString()}</td>
-    <td class="stat">{formatExecutionTime(value.avg)}</td>
-    <td class="stat">{formatExecutionTime(value.min)}</td>
-    <td class="stat">{formatExecutionTime(value.max)}</td>
-    <td class="stat">{formatExecutionTime(value.sd)}</td>
-    <td class="stat">{formatExecutionTime(value.acc)}</td>
-  </tr>
+  <div role="row" class="root flex flex-row cursor-pointer text-sm">
+    <div
+      role="cell"
+      style={`padding-left: ${depth + 0.25}rem`}
+      class="truncate w-1/2 flex-grow"
+      on:click={() => (collapsed = !collapsed)}
+    >
+      {$store.scopes && $store.scopes[node.hash]?.name}
+    </div>
+    <div role="cell" class="stat">{value.count.toLocaleString()}</div>
+    <div role="cell" class="stat">{formatExecutionTime(value.avg)}</div>
+    <div role="cell" class="stat">{formatExecutionTime(value.min)}</div>
+    <div role="cell" class="stat">{formatExecutionTime(value.max)}</div>
+    <div role="cell" class="stat">{formatExecutionTime(value.sd)}</div>
+    <div role="cell" class="stat">{formatExecutionTime(value.acc)}</div>
+  </div>
 {/if}
 {#if !collapsed}
-  {#each Array.from(getChildren()).sort((r, l) => l.value.acc - r.value.acc) as n (n.hash)}
+  {#each children as n (n.hash)}
     <svelte:self node={n} {store} {threadId} depth={depth + 1} />
   {/each}
 {/if}
 
 <style lang="postcss">
-  .stat {
-    @apply text-center text-xs w-48 truncate;
+  .root:nth-child(odd) {
+    @apply surface;
   }
 
-  tr:nth-child(even) {
-    @apply surface;
+  .stat {
+    @apply text-right text-xs w-28 truncate flex-shrink-0 pr-2;
   }
 </style>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Log/Log.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Log/Log.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
-  import { getContext, onMount } from "svelte";
+  import { onMount } from "svelte";
   import { link } from "svelte-navigator";
 
-  import type {
-    LogEntry,
-    PerformanceAnalyticsClientImpl,
-  } from "@lgn/proto-telemetry/dist/analytics";
+  import type { LogEntry } from "@lgn/proto-telemetry/dist/analytics";
   import type { Process } from "@lgn/proto-telemetry/dist/process";
 
   import L10n from "@/components/Misc/L10n.svelte";
-  import { httpClientContextKey } from "@/constants";
+  import { getHttpClientContext } from "@/contexts";
 
   const MAX_NB_ENTRIES_IN_PAGE = 1000;
 
-  const client =
-    getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
+  const client = getHttpClientContext();
 
   export let id: string;
 

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricCanvas.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricCanvas.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
   import * as d3 from "d3";
   import type { D3ZoomEvent } from "d3";
-  import { getContext, onDestroy, onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import type { Unsubscriber } from "svelte/store";
   import { get } from "svelte/store";
 
-  import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
-
-  import { httpClientContextKey } from "@/constants";
+  import { getHttpClientContext } from "@/contexts";
   import { formatExecutionTime } from "@/lib/format";
   import { getLodFromPixelSizeNs } from "@/lib/lod";
 
@@ -32,8 +30,7 @@
   const outerHeight = 600;
   const height = outerHeight - margin.top - margin.bottom;
 
-  const client =
-    getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
+  const client = getHttpClientContext();
 
   let mainWidth = 0;
   $: width = mainWidth - margin.left - margin.right;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Misc/Header.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Misc/Header.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
-  import { getContext } from "svelte";
   import { link } from "svelte-navigator";
 
-  import type { L10nOrchestrator } from "@lgn/web-client/src/orchestrators/l10n";
   import { userInfo } from "@lgn/web-client/src/orchestrators/userInfo";
 
-  import { l10nOrchestratorContextKey } from "@/constants";
+  import { getL10nOrchestratorContext } from "@/contexts";
 
   import iconPath from "../../../icons/128x128.png";
   import User from "../Process/User.svelte";
 
-  const { locale } = getContext<L10nOrchestrator<Fluent>>(
-    l10nOrchestratorContextKey
-  );
+  const { locale } = getL10nOrchestratorContext();
 
   function toggleLocale(event: MouseEvent) {
     if (event.ctrlKey && event.shiftKey) {

--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessItem.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessItem.svelte
@@ -1,30 +1,19 @@
 <script lang="ts">
   import { formatDistance } from "date-fns";
-  import { getContext } from "svelte";
   import { link } from "svelte-navigator";
 
-  import type {
-    PerformanceAnalyticsClientImpl,
-    ProcessInstance,
-  } from "@lgn/proto-telemetry/dist/analytics";
+  import type { ProcessInstance } from "@lgn/proto-telemetry/dist/analytics";
   import HighlightedText from "@lgn/web-client/src/components/HighlightedText.svelte";
-  import type { L10nOrchestrator } from "@lgn/web-client/src/orchestrators/l10n";
 
-  import {
-    httpClientContextKey,
-    l10nOrchestratorContextKey,
-  } from "@/constants";
+  import { getHttpClientContext, getL10nOrchestratorContext } from "@/contexts";
   import { formatProcessName } from "@/lib/format";
 
   import ProcessComputer from "./ProcessComputer.svelte";
   import ProcessPlatform from "./ProcessPlatform.svelte";
   import User from "./User.svelte";
 
-  const { locale } = getContext<L10nOrchestrator<Fluent>>(
-    l10nOrchestratorContextKey
-  );
-  const client =
-    getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
+  const { locale } = getL10nOrchestratorContext();
+  const client = getHttpClientContext();
 
   export let processInstance: ProcessInstance;
   export let depth: number;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPage.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPage.svelte
@@ -1,35 +1,24 @@
 <script lang="ts">
-  import { getContext } from "svelte";
   import { writable } from "svelte/store";
 
-  import type {
-    PerformanceAnalyticsClientImpl,
-    ProcessInstance,
-  } from "@lgn/proto-telemetry/dist/analytics";
+  import type { ProcessInstance } from "@lgn/proto-telemetry/dist/analytics";
   import { debounced } from "@lgn/web-client/src/lib/store";
-  import type { L10nOrchestrator } from "@lgn/web-client/src/orchestrators/l10n";
 
   import L10n from "@/components/Misc/L10n.svelte";
-  import {
-    httpClientContextKey,
-    l10nOrchestratorContextKey,
-  } from "@/constants";
+  import { getHttpClientContext, getL10nOrchestratorContext } from "@/contexts";
 
   import Loader from "../Misc/Loader.svelte";
   import ProcessItem from "./ProcessItem.svelte";
 
   type Mode = "default" | "search";
 
-  const { t } = getContext<L10nOrchestrator<Fluent>>(
-    l10nOrchestratorContextKey
-  );
+  const { t } = getL10nOrchestratorContext();
+
+  const client = getHttpClientContext();
 
   const searchValue = writable("");
 
   const debouncedSearchValue = debounced(searchValue, 300);
-
-  const client =
-    getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
 
   $: cleanSearchValue = $debouncedSearchValue.trim();
 

--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPlatform.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessPlatform.svelte
@@ -1,19 +1,24 @@
 <script lang="ts">
   import type { Process } from "@lgn/proto-telemetry/dist/process";
 
+  import L10n from "../Misc/L10n.svelte";
+
   export let process: Process | undefined;
 
   function getPlatform(distro: string | undefined) {
     if (!distro) {
-      return "Unknown";
+      return "unknown";
     }
+
     const lowerCaseDistro = distro.toLowerCase();
+
     if (lowerCaseDistro.startsWith("windows")) {
-      return "Windows";
+      return "windows";
     } else if (lowerCaseDistro.startsWith("ubuntu")) {
-      return "Linux";
+      return "linux";
     }
-    return "Unknown";
+
+    return "unknown";
   }
 
   $: platform = getPlatform(process?.distro);
@@ -21,5 +26,7 @@
 
 <div class="flex gap-2 items-center">
   <i class="bi bi-pc placeholder" />
-  <span class="capitalize">{platform}</span>
+  <span class="capitalize">
+    <L10n id="global-platform" variables={{ platform }} />
+  </span>
 </div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Timeline.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Timeline.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
-  import { afterUpdate, getContext, onMount, tick } from "svelte";
+  import { afterUpdate, onMount, tick } from "svelte";
   import { useLocation } from "svelte-navigator";
   import { get } from "svelte/store";
 
-  import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
-
-  import {
-    httpClientContextKey,
-    threadItemLengthContextKey,
-  } from "@/constants";
+  import { getHttpClientContext, getThreadItemLengthContext } from "@/contexts";
   import { loadingStore } from "@/lib/Misc/LoadingStore";
   import { endQueryParam, startQueryParam } from "@/lib/time";
 
@@ -27,9 +22,8 @@
   export let processId: string;
 
   const location = useLocation();
-  const client =
-    getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
-  const threadItemLength = getContext<number>(threadItemLengthContextKey);
+  const client = getHttpClientContext();
+  const threadItemLength = getThreadItemLengthContext();
 
   let stateManager: TimelineStateManager;
   let windowInnerWidth: number;
@@ -301,28 +295,5 @@
     display: flex;
     flex-direction: column;
     @apply gap-y-1;
-  }
-
-  ::-webkit-scrollbar {
-    width: 20px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background-color: transparent;
-  }
-
-  ::-webkit-scrollbar-corner {
-    background: rgba(0, 0, 0, 0);
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: #454545;
-    border-radius: 20px;
-    border: 6px solid transparent;
-    background-clip: content-box;
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    background-color: #707070;
   }
 </style>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineProcess.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineProcess.svelte
@@ -3,8 +3,10 @@
 
   import type { Process } from "@lgn/proto-telemetry/dist/process";
 
+  import { getL10nOrchestratorContext } from "@/contexts";
   import { formatExecutionTime, formatProcessName } from "@/lib/format";
 
+  import L10n from "../Misc/L10n.svelte";
   import { TimelineTrackCanvasAsyncDrawer } from "./Drawing/TimelineTrackCanvasAsyncDrawer";
   import { TimelineTrackCanvasSyncDrawer } from "./Drawing/TimelineTrackCanvasSyncDrawer";
   import type { TimelineStateStore } from "./Stores/TimelineStateStore";
@@ -23,6 +25,7 @@
 
   const wheelDispatcher = createEventDispatcher<{ zoom: WheelEvent }>();
   const processOffsetMs = Date.parse(process.startTime) - rootStartTime;
+  const { t } = getL10nOrchestratorContext();
 
   let collapsed = false;
   let components: TimelineRow[] = [];
@@ -55,25 +58,24 @@
         {formatProcessName(process)}
       </span>
       {#if collapsed}
-        <span class="text-xs placeholder"
-          >{!validThreadCount
-            ? "(No thread data)"
-            : `(${validThreadCount} thread${
-                validThreadCount > 1 ? "s" : ""
-              } with data)`}</span
-        >
+        <span class="text-xs placeholder">
+          <L10n
+            id="timeline-main-collapsed-extra"
+            variables={{ validThreadCount }}
+          />
+        </span>
       {/if}
     </div>
     {#if !collapsed}
       <div class="flex flex-row gap-1">
         <i
-          title="Collapse"
+          title={$t("timeline-main-collapse")}
           class="bi-arrows-angle-contract"
           on:click|stopPropagation={() =>
             components.forEach((c) => c.setCollapse(true))}
         />
         <i
-          title="Expand"
+          title={$t("timeline-main-expand")}
           class="bi-arrows-angle-expand"
           on:click|stopPropagation={() =>
             components.forEach((c) => c.setCollapse(false))}
@@ -111,15 +113,22 @@
         <TimelineRow
           bind:this={components[index + 1]}
           processCollapsed={collapsed}
-          threadTitle={`${threadName}\n${threadLength}\n${thread.block_ids.length} block(s)`}
+          threadTitle={$t("timeline-main-thread-description-title", {
+            threadName,
+            threadBlocks: thread.block_ids.length,
+            threadLength,
+          })}
           {threadName}
           maxDepth={thread.maxDepth}
         >
-          <span class="text text-xs placeholder" slot="details"
-            >{threadLength} ({thread.block_ids.length} block{thread.block_ids
-              .length
-              ? "s"
-              : ""})
+          <span class="text-xs placeholder" slot="details">
+            <L10n
+              id="timeline-main-thread-description"
+              variables={{
+                threadBlocks: thread.block_ids.length,
+                threadLength,
+              }}
+            />
           </span>
           <TimelineTrack
             slot="canvas"

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineAction.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineAction.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import { link } from "svelte-navigator";
-
   import type { Process } from "@lgn/proto-telemetry/dist/process";
+
+  import L10n from "@/components/Misc/L10n.svelte";
 
   export let timeRange: [number, number] | undefined;
   export let processId: string;
   export let process: Process;
 </script>
 
-<div class="flex flex-row justify-start text-xs gap-1">
+<div class="flex flex-row justify-start text-xs gap-1 w-full">
   {#if process.parentProcessId}
     <div class="action bg-orange-700 hover:bg-orange-800">
-      <a href={`/timeline/${process.parentProcessId}`} target="_blank" use:link>
+      <a href={`/timeline/${process.parentProcessId}`} target="_blank">
         <i class="bi bi-arrow-up-right-circle" />
-        Open Parent Timeline
+        <L10n id="timeline-open-cumulative-call-graph" />
       </a>
     </div>
   {/if}
@@ -22,23 +22,24 @@
       <a
         href={`/cumulative-call-graph?process=${processId}&begin=${timeRange[0]}&end=${timeRange[1]}`}
         target="_blank"
-        use:link
       >
-        <i class="bi bi-border-style pr-1" />Cumulative Call Graph
+        <i class="bi bi-border-style pr-1" />
+        <L10n id="global-cumulative-call-graph" />
       </a>
     </div>
     <div
       class="action bg-slate-400 cursor-pointer hover:bg-slate-500"
       on:click={() => navigator.clipboard.writeText(window.location.href)}
     >
-      <i class="bi bi bi-share-fill pr-1" />Copy Link
+      <i class="bi bi bi-share-fill pr-1" />
+      <L10n id="global-link-copy" />
     </div>
   {/if}
 </div>
 
 <style lang="postcss">
   .action {
-    @apply text-white p-1 min-w-thread-item;
+    @apply text-white py-1 px-2;
   }
 
   i {

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineAxis.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineAxis.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import * as d3 from "d3";
-  import { getContext, onMount } from "svelte";
+  import { onMount } from "svelte";
 
-  import { threadItemLengthContextKey } from "@/constants";
+  import { getThreadItemLengthContext } from "@/contexts";
   import { formatExecutionTime } from "@/lib/format";
 
   import type { TimelineStateStore } from "../Stores/TimelineStateStore";
 
   export let stateStore: TimelineStateStore;
 
-  const threadItemLength = getContext<number>(threadItemLengthContextKey);
+  const threadItemLength = getThreadItemLengthContext();
 
   const height = 20;
   const padding = 4;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineDebug.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineDebug.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getL10nOrchestratorContext } from "@/contexts";
   import { formatExecutionTime } from "@/lib/format";
   import { MergeThresholdForLOD, getLodFromPixelSizeMs } from "@/lib/lod";
 
@@ -6,24 +7,26 @@
 
   export let store: TimelineStateStore;
 
+  const { t } = getL10nOrchestratorContext();
+
   let pixelSize: number;
   let lod: number;
   let mergeThreshold: number;
   let title: string;
 
   $: {
-    const vr = $store.getViewRange();
-    pixelSize = (vr[1] - vr[0]) / $store.canvasWidth;
+    const [begin, end] = $store.getViewRange();
+
+    pixelSize = (end - begin) / $store.canvasWidth;
     lod = getLodFromPixelSizeMs(pixelSize);
     mergeThreshold = MergeThresholdForLOD(lod);
-    title = Array.from(getDebugEntries()).join("\n");
-  }
 
-  function* getDebugEntries() {
-    yield `Pixel size: ${formatExecutionTime(pixelSize)}`;
-    yield `Lod: ${lod}`;
-    yield `Threshold: ${formatExecutionTime(mergeThreshold)}`;
-    yield `Events: ${$store.eventCount.toLocaleString()}`;
+    title = $t("timeline-debug-tooltip", {
+      events: $store.eventCount.toLocaleString(),
+      lod,
+      pixelSize: formatExecutionTime(pixelSize),
+      threshold: formatExecutionTime(mergeThreshold),
+    });
   }
 </script>
 

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineMinimap.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineMinimap.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
 
-  import { threadItemLengthContextKey } from "@/constants";
+  import { getThreadItemLengthContext } from "@/contexts";
 
   import { TimelineMinimapViewport } from "../Lib/TimelineViewport";
   import type { TimelineStateStore } from "../Stores/TimelineStateStore";
@@ -11,8 +11,7 @@
   export let scrollHeight: number;
   export let scrollTop: number;
 
-  const threadItemLength = getContext<number>(threadItemLengthContextKey);
-
+  const threadItemLength = getThreadItemLengthContext();
   const canvasToMinimapRatio = 5;
   const minimapBreakpoint = 300;
   const bottomPadding = 20;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineSearch.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineSearch.svelte
@@ -1,22 +1,27 @@
 <script lang="ts">
+  import { getL10nOrchestratorContext } from "@/contexts";
+
   import { TimelineContext } from "../Stores/TimelineContext";
 
-  export let searching: boolean;
   const searchStore = TimelineContext.search;
+
+  const { t } = getL10nOrchestratorContext();
+
+  export let searching: boolean;
 </script>
 
 <div class="flex flex-row h-full w-full justify-end space-x-1">
   <input
     type="text"
     class="h-8 w-60 placeholder rounded-l-sm pl-2 surface"
-    placeholder="Search..."
+    placeholder={$t("timeline-search")}
     on:focus={() => (searching = true)}
     on:blur={() => (searching = false)}
     bind:value={$searchStore}
   />
   <button
     class="text-sm surface h-8 w-8 rounded-r-sm text-opacity-60"
-    on:click={() => searchStore.set("")}
+    on:click={() => ($searchStore = "")}
   >
     <i class="bi bi-x-circle" />
   </button>

--- a/npm-pkgs/lgn-analytics-gui/src/contexts.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/contexts.ts
@@ -1,0 +1,40 @@
+/** This module exposes short functions that retrieve a well typed version of the values in contexts */
+import { getContext } from "svelte";
+
+import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
+import type { L10nOrchestrator } from "@lgn/web-client/src/orchestrators/l10n";
+import type { NotificationsStore } from "@lgn/web-client/src/stores/notifications";
+import type { ThemeStore } from "@lgn/web-client/src/stores/theme";
+
+import {
+  httpClientContextKey,
+  l10nOrchestratorContextKey,
+  notificationsContextKey,
+  themeContextKey,
+  threadItemLengthContextKey,
+} from "./constants";
+
+/** Get the theme context */
+export function getThemeContext() {
+  return getContext<ThemeStore>(themeContextKey);
+}
+
+/** Get the thread item CSS with in pixel context */
+export function getThreadItemLengthContext() {
+  return getContext<number>(threadItemLengthContextKey);
+}
+
+/** Get the l10n store set context */
+export function getL10nOrchestratorContext() {
+  return getContext<L10nOrchestrator<Fluent>>(l10nOrchestratorContextKey);
+}
+
+/** Get the http client context */
+export function getHttpClientContext() {
+  return getContext<PerformanceAnalyticsClientImpl>(httpClientContextKey);
+}
+
+/** Get the notifications context */
+export function getNotificationsContext() {
+  return getContext<NotificationsStore>(notificationsContextKey);
+}

--- a/npm-pkgs/lgn-analytics-gui/src/types/fluent.d.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/types/fluent.d.ts
@@ -1,5 +1,60 @@
 /** A full dictionnary of all the found message ids, attributes, and variables */
 declare type Fluent = {
+  "global-pagination-first": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-pagination-previous": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-pagination-last": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-pagination-next": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-platform": {
+    attributes: null;
+    variables: "platform";
+  };
+
+  "global-link-copy": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-link-share": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-cumulative-call-graph": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-log": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-timeline": {
+    attributes: null;
+    variables: null;
+  };
+
+  "global-thread": {
+    attributes: null;
+    variables: null;
+  };
+
   "process-list-user": {
     attributes: null;
     variables: null;
@@ -50,38 +105,78 @@ declare type Fluent = {
     variables: null;
   };
 
-  "global-pagination-first": {
+  "timeline-open-cumulative-call-graph": {
     attributes: null;
     variables: null;
   };
 
-  "global-pagination-previous": {
+  "timeline-search": {
     attributes: null;
     variables: null;
   };
 
-  "global-pagination-last": {
+  "timeline-table-function": {
     attributes: null;
     variables: null;
   };
 
-  "global-pagination-next": {
+  "timeline-table-count": {
     attributes: null;
     variables: null;
   };
 
-  "hello-user": {
+  "timeline-table-average": {
     attributes: null;
-    variables: "userName";
-  };
-
-  "shared-photos": {
-    attributes: null;
-    variables: "userName" | "photoCount" | "userGender";
-  };
-
-  "login-input": {
-    attributes: "placeholder" | "aria-label" | "title";
     variables: null;
+  };
+
+  "timeline-table-minimum": {
+    attributes: null;
+    variables: null;
+  };
+
+  "timeline-table-maximum": {
+    attributes: null;
+    variables: null;
+  };
+
+  "timeline-table-standard-deviation": {
+    attributes: null;
+    variables: null;
+  };
+
+  "timeline-table-sum": {
+    attributes: null;
+    variables: null;
+  };
+
+  "timeline-main-collapsed-extra": {
+    attributes: null;
+    variables: "validThreadCount";
+  };
+
+  "timeline-main-thread-description-title": {
+    attributes: null;
+    variables: "threadName" | "threadLength" | "threadBlocks" | "threadBlocks";
+  };
+
+  "timeline-main-thread-description": {
+    attributes: null;
+    variables: "threadLength" | "threadBlocks" | "threadBlocks";
+  };
+
+  "timeline-main-collapse": {
+    attributes: null;
+    variables: null;
+  };
+
+  "timeline-main-expand": {
+    attributes: null;
+    variables: null;
+  };
+
+  "timeline-debug-tooltip": {
+    attributes: null;
+    variables: "pixelSize" | "lod" | "threshold" | "events";
   };
 };


### PR DESCRIPTION
While at it I also made the table's header fixed and right aligned the text (not sure if that helps):

(The scrollbar is also more consistent across the pages and reuses the style used in the timeline)

| Top | Scroll down |
| --- | --- |
| ![table-fr-fixed](https://user-images.githubusercontent.com/94377405/167506085-cb8680f4-823f-4b07-8fea-5e33d7828576.png) | ![table-fr-fixed-2](https://user-images.githubusercontent.com/94377405/167506086-783abf17-c380-498b-a836-2a00c319268a.png) |


