### PR TITLE
Web clients: Strengthen conditions by enforcing boolean values

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/.eslintrc.cjs
+++ b/npm-pkgs/lgn-analytics-gui/.eslintrc.cjs
@@ -31,5 +31,6 @@ module.exports = {
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
     "@typescript-eslint/no-unused-vars": "off",
     eqeqeq: "error",
+    "@typescript-eslint/strict-boolean-expressions": "error",
   },
 };

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricBlockState.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricBlockState.ts
@@ -26,7 +26,7 @@ export class MetricBlockState {
     if (this.hasLod(lod)) {
       return false;
     }
-    if (this.inFlight.get(lod)) {
+    if (this.inFlight.get(lod) !== undefined) {
       return false;
     }
     this.inFlight.set(lod, true);
@@ -61,25 +61,31 @@ export class MetricBlockState {
     if (withBoundaries) {
       if (points.length > 0) {
         const boundaryInPoint = data[data.indexOf(points[0]) - 1];
-        if (boundaryInPoint && !points.includes(boundaryInPoint)) {
+        if (
+          boundaryInPoint !== undefined &&
+          !points.includes(boundaryInPoint)
+        ) {
           points.unshift(boundaryInPoint);
         }
         const boundaryOutPoint =
           data[data.indexOf(points[points.length - 1]) + 1];
-        if (boundaryOutPoint && !points.includes(boundaryOutPoint)) {
+        if (
+          boundaryOutPoint !== undefined &&
+          !points.includes(boundaryOutPoint)
+        ) {
           points.push(boundaryOutPoint);
         }
       } else {
         const nextMinPoint = data
           .filter((p) => p.time <= min)
           .sort((a, b) => (a > b ? -1 : 1))[0];
-        if (nextMinPoint && !points.includes(nextMinPoint)) {
+        if (nextMinPoint !== undefined && !points.includes(nextMinPoint)) {
           points.push(nextMinPoint);
         }
         const nextMaxPoint = data
           .filter((p) => p.time >= max)
           .sort((a, b) => (a > b ? 1 : -1))[0];
-        if (nextMaxPoint && !points.includes(nextMaxPoint)) {
+        if (nextMaxPoint !== undefined && !points.includes(nextMaxPoint)) {
           points.push(nextMaxPoint);
         }
       }

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricStore.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricStore.ts
@@ -12,7 +12,7 @@ export type MetricStore = ReturnType<typeof getMetricStore>;
 function getMetricConfig(): MetricConfig[] {
   const jsonData = localStorage.getItem(localStorageKey);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const data: MetricConfig[] = jsonData ? JSON.parse(jsonData) : [];
+  const data: MetricConfig[] = jsonData !== null ? JSON.parse(jsonData) : [];
   return data.sort((a, b) => a.lastUse - b.lastUse);
 }
 
@@ -43,7 +43,7 @@ export function getMetricStore() {
       const data = s.filter((s) => s.selected);
       const config: MetricConfig[] = [];
       data.forEach((m) => {
-        if (m.lastUse) {
+        if (m.lastUse !== null) {
           config.push({
             name: m.name,
             lastUse: m.lastUse,

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricStreamer.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricStreamer.ts
@@ -46,14 +46,12 @@ export class MetricStreamer {
     const metricStates = new Map<string, MetricState>();
 
     for (const blockManifest of blockManifests) {
-      if (blockManifest) {
-        for (const metricDesc of blockManifest.metrics) {
-          if (!metricStates.get(metricDesc.name)) {
-            metricStates.set(metricDesc.name, new MetricState(metricDesc));
-          }
-          const metricState = metricStates.get(metricDesc.name);
-          metricState?.registerBlock(blockManifest);
+      for (const metricDesc of blockManifest.metrics) {
+        if (!metricStates.get(metricDesc.name)) {
+          metricStates.set(metricDesc.name, new MetricState(metricDesc));
         }
+        const metricState = metricStates.get(metricDesc.name);
+        metricState?.registerBlock(blockManifest);
       }
     }
 
@@ -89,14 +87,15 @@ export class MetricStreamer {
       metric.blocks.forEach(async (block) => {
         await this.#semaphore.acquire();
         try {
-          const blockData = await this.#client?.fetch_block_metric({
+          const blockData = await this.#client.fetch_block_metric({
             processId: this.#processId,
             streamId: block.streamId,
             metricName: metric.name,
             blockId: block.blockId,
             lod: lod,
           });
-          if (blockData) {
+          // TODO: Is this really correct? It seems the value is guaranteed not to be undefined
+          if (blockData !== undefined) {
             this.metricStore.registerBlock(
               blockData,
               block.blockId,

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Drawing/TimelineTrackCanvasBaseDrawer.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Drawing/TimelineTrackCanvasBaseDrawer.ts
@@ -50,7 +50,7 @@ export abstract class TimelineTrackCanvasBaseDrawer {
       return;
     }
 
-    const [begin, end] = state.getViewRange();
+    const [begin, end] = state.viewRange;
     const invTimeSpan = 1.0 / (end - begin);
     const msToPixelsFactor = invTimeSpan * canvasWidth;
     const context = { begin, end, msToPixelsFactor, search };
@@ -144,7 +144,7 @@ export abstract class TimelineTrackCanvasBaseDrawer {
       if (span.scopeHash !== 0) {
         let name = "<unknown_scope>";
         const scope = state.scopes[span.scopeHash];
-        if (scope) {
+        if (scope !== undefined) {
           name = scope.name;
         }
         ctx.fillStyle =

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Stores/TimelineState.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Stores/TimelineState.ts
@@ -27,41 +27,32 @@ export class TimelineState {
     this.canvasWidth = canvasWidth;
     this.timelineStart = start;
     this.timelineEnd = end;
-    this.viewRange = this.getViewRange();
+
+    const viewRangeStart =
+      this.timelineStart !== null ? this.timelineStart : this.minMs;
+
+    const viewRangeEnd =
+      this.timelineEnd !== null ? this.timelineEnd : this.maxMs;
+
+    this.viewRange = [viewRangeStart, viewRangeEnd];
   }
 
   getPixelWidthMs(): number {
-    const range = this.getViewRange();
-    const timeSpan = range[1] - range[0];
+    const timeSpan = this.viewRange[1] - this.viewRange[0];
     return this.canvasWidth / timeSpan;
   }
 
   isFullyVisible() {
-    if (!this.viewRange) {
-      return false;
-    }
     return !(
       this.viewRange[0] <= this.minMs && this.viewRange[1] >= this.maxMs
     );
   }
 
   createdWithParameters() {
-    return this.timelineStart && this.timelineEnd;
-  }
-
-  getViewRange(): [number, number] {
-    if (this.viewRange) {
-      return this.viewRange;
-    }
-    let start = this.minMs;
-    if (this.timelineStart) {
-      start = this.timelineStart;
-    }
-    let end = this.maxMs;
-    if (this.timelineEnd) {
-      end = this.timelineEnd;
-    }
-    return [start, end];
+    return (
+      typeof this.timelineStart === "number" &&
+      typeof this.timelineEnd === "number"
+    );
   }
 
   getMaxRange() {

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Stores/TimelineStateManager.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Stores/TimelineStateManager.ts
@@ -183,7 +183,7 @@ export class TimelineStateManager {
     }
 
     const state = get(this.state);
-    const viewRange = state.getViewRange();
+    const viewRange = state.viewRange;
     const processAsyncData = state.processAsyncData[process.processId];
 
     const sectionWidthMs = 1000.0;
@@ -217,7 +217,7 @@ export class TimelineStateManager {
     const asyncData = state.processAsyncData[process.processId];
     const promises: Promise<void>[] = [];
     let sentRequest = false;
-    const viewRange = state.getViewRange();
+    const viewRange = state.viewRange;
 
     for (const block of Object.values(state.blocks)) {
       const streamId = block.blockDefinition.streamId;
@@ -287,13 +287,13 @@ export class TimelineStateManager {
 
   async fetchThreadData(): Promise<boolean> {
     const state = get(this.state);
-    const range = state.getViewRange();
+    const range = state.viewRange;
     const promises: Promise<void>[] = [];
     let sentRequest = false;
     for (const block of Object.values(state.blocks)) {
       const lod = computePreferredBlockLod(state.canvasWidth, range, block);
 
-      if (typeof lod === "number" && !block.lods[lod]) {
+      if (typeof lod === "number" && !(lod in block.lods)) {
         block.lods[lod] = {
           state: LODState.Missing,
           tracks: [],

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Stores/TimelineStateStore.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Stores/TimelineStateStore.ts
@@ -20,7 +20,7 @@ export function createTimelineStateStore(state: TimelineState) {
 
   const keyboardZoom = (positive: boolean) => {
     update((s) => {
-      const range = s.getViewRange();
+      const range = s.viewRange;
       const length = range[1] - range[0];
       const change = ((positive ? 1 : -1) * length) / 10;
       s.viewRange = [range[0] + change, range[1] - change];
@@ -30,7 +30,7 @@ export function createTimelineStateStore(state: TimelineState) {
 
   const keyboardTranslate = (positive: boolean) => {
     update((s) => {
-      const range = s.getViewRange();
+      const range = s.viewRange;
       const length = range[1] - range[0];
       const delta = ((positive ? 1 : -1) * length) / 10;
       s.viewRange = [range[0] + delta, range[1] + delta];
@@ -42,7 +42,7 @@ export function createTimelineStateStore(state: TimelineState) {
     const speed = 0.75;
     const factor = event.deltaY > 0 ? 1.0 / speed : speed;
     update((s) => {
-      const range = s.getViewRange();
+      const range = s.viewRange;
       const length = range[1] - range[0];
       const newLength = length * factor;
       const pctCursor = event.offsetX / s.canvasWidth;
@@ -212,7 +212,7 @@ export function createTimelineStateStore(state: TimelineState) {
 
   const updateSelection = (x: number) => {
     updateState((s) => {
-      if (s.beginRange) {
+      if (s.beginRange !== null) {
         const viewRange = s.viewRange;
         const factor = (viewRange[1] - viewRange[0]) / s.canvasWidth;
         const first = viewRange[0] + factor * s.beginRange;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineTrack.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineTrack.svelte
@@ -28,7 +28,7 @@
 
   $: if (
     $stateStore?.scopes ||
-    $stateStore?.getViewRange() ||
+    $stateStore?.viewRange ||
     $stateStore?.canvasWidth ||
     $stateStore?.currentSelection
   ) {
@@ -86,7 +86,7 @@
     }
 
     const selectionState = $stateStore.currentSelection;
-    const viewRange = $stateStore.getViewRange();
+    const viewRange = $stateStore.viewRange;
     const [begin, end] = viewRange;
     const invTimeSpan = 1.0 / (end - begin);
     const canvasWidth = canvas.clientWidth;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineAxis.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineAxis.svelte
@@ -23,7 +23,7 @@
   $: if ($stateStore && svg) {
     const tickCount = Math.ceil($stateStore.canvasWidth / tickSize);
     svg = svg.attr("width", Math.max(0, $stateStore.canvasWidth));
-    x.range([0, $stateStore.canvasWidth]).domain($stateStore.getViewRange());
+    x.range([0, $stateStore.canvasWidth]).domain($stateStore.viewRange);
     ticks.length = 0;
     svg.call(
       d3

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineDebug.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineDebug.svelte
@@ -15,7 +15,7 @@
   let title: string;
 
   $: {
-    const [begin, end] = $store.getViewRange();
+    const [begin, end] = $store.viewRange;
 
     pixelSize = (end - begin) / $store.canvasWidth;
     lod = getLodFromPixelSizeMs(pixelSize);

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineMinimap.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineMinimap.svelte
@@ -99,7 +99,7 @@
   }
 
   function updateViewport() {
-    const viewRange = $stateStore.getViewRange();
+    const viewRange = $stateStore.viewRange;
     const maxViewRange = viewRange[1] - viewRange[0];
     const maxRange = $stateStore.getMaxRange();
     let x = viewRange[0] / maxRange;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineRange.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Tools/TimelineRange.svelte
@@ -9,7 +9,7 @@
 
   $: if ($stateStore?.currentSelection) {
     const width = $stateStore?.canvasWidth;
-    const [begin, end] = $stateStore.getViewRange();
+    const [begin, end] = $stateStore.viewRange;
     const invTimeSpan = 1.0 / (end - begin);
     const msToPixelsFactor = invTimeSpan * width;
     const [beginSelection, endSelection] = $stateStore.currentSelection;

--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Values/TimelineValues.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/Values/TimelineValues.ts
@@ -13,7 +13,7 @@ export function getThreadItemLength(): number {
 
   const rem = value.match(/^(\d+)rem$/)?.[1];
 
-  if (!rem) {
+  if (rem === undefined || !rem.length) {
     throw new Error(
       `The --thread-item-length CSS variable is not set or not set properly, it should be provided using the rem unit, was "${value}"`
     );

--- a/npm-pkgs/lgn-analytics-gui/src/lib/CallGraph/CallGraphParameters.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/lib/CallGraph/CallGraphParameters.ts
@@ -4,6 +4,7 @@ export class CallGraphParameters {
   processId: string;
   beginMs: number;
   endMs: number;
+
   constructor(processId: string, beginMs: number, endMs: number) {
     this.processId = processId;
     this.beginMs = beginMs;
@@ -12,22 +13,32 @@ export class CallGraphParameters {
 
   static getGraphParameter(value: string) {
     const params = new URLSearchParams(value);
+
     const processId = params.get("process");
-    if (!processId) {
+    if (processId === null || !processId.length) {
       throw new Error("missing param process");
     }
+
     const beginStr = params.get(startQueryParam);
-    if (!beginStr) {
+    if (beginStr === null || !beginStr.length) {
       throw new Error("missing param begin");
     }
+
+    const beginMs = parseFloat(beginStr);
+    if (isNaN(beginMs)) {
+      throw new Error(`param begin is not a valid float: ${beginStr}`);
+    }
+
     const endStr = params.get(endQueryParam);
-    if (!endStr) {
+    if (endStr === null || !endStr.length) {
       throw new Error("missing param end");
     }
-    return new CallGraphParameters(
-      processId,
-      parseFloat(beginStr),
-      parseFloat(endStr)
-    );
+
+    const endMs = parseFloat(endStr);
+    if (isNaN(endMs)) {
+      throw new Error(`param end is not a valid float: ${endStr}`);
+    }
+
+    return new CallGraphParameters(processId, beginMs, endMs);
   }
 }

--- a/npm-pkgs/lgn-analytics-gui/src/lib/client.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/lib/client.ts
@@ -18,7 +18,7 @@ export function makeGrpcClient() {
   const metadata = new grpc.Metadata();
   const token = authClient.accessToken;
 
-  if (!token) {
+  if (token === null) {
     return new PerformanceAnalyticsClientImpl(new GrpcWebImpl(getUrl(), {}));
   }
 

--- a/npm-pkgs/lgn-analytics-gui/src/lib/time.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/lib/time.ts
@@ -19,7 +19,7 @@ export function processMsOffsetToRoot(
   currentProcess: Process | undefined,
   process: Process
 ): number {
-  if (!currentProcess?.startTime) {
+  if (currentProcess?.startTime === undefined) {
     throw new Error("Parent process start time undefined");
   }
   const parentStartTime = Date.parse(currentProcess?.startTime);

--- a/npm-pkgs/lgn-editor-gui/.eslintrc.cjs
+++ b/npm-pkgs/lgn-editor-gui/.eslintrc.cjs
@@ -62,5 +62,7 @@ module.exports = {
         ignoreReadBeforeAssign: false,
       },
     ],
+    // Switch to error as soon as all the warninngs are gone
+    "@typescript-eslint/strict-boolean-expressions": "warn",
   },
 };

--- a/npm-pkgs/lgn-runtime-gui/.eslintrc.cjs
+++ b/npm-pkgs/lgn-runtime-gui/.eslintrc.cjs
@@ -62,5 +62,6 @@ module.exports = {
       },
     ],
     eqeqeq: "error",
+    "@typescript-eslint/strict-boolean-expressions": "error",
   },
 };

--- a/npm-pkgs/lgn-web-client/.eslintrc.cjs
+++ b/npm-pkgs/lgn-web-client/.eslintrc.cjs
@@ -62,5 +62,7 @@ module.exports = {
         ignoreReadBeforeAssign: false,
       },
     ],
+    // Switch to error as soon as all the warninngs are gone
+    "@typescript-eslint/strict-boolean-expressions": "warn",
   },
 };


### PR DESCRIPTION
First pass on Analytics, but still many things to cleanup on web-client and editor :/

I only set the new [https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md](rule) to warning in these projects and to error in analytics.

I also slightly changed some conditions (mostly transforming `if (xxx)` statements to `if (xxx !== null)` instead of `if (xxx !== null && xxx > 0)` when `xxx` is a number, as it seemed we actually cared about the 0 value).