### PR TITLE
Analytics: Fix translation in timeline when thread name is undefined

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineProcess.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Timeline/TimelineProcess.svelte
@@ -117,7 +117,7 @@
           bind:this={components[index + 1]}
           processCollapsed={collapsed}
           threadTitle={$t("timeline-main-thread-description-title", {
-            threadName,
+            threadName: threadName || "Undefined",
             threadBlocks: thread.block_ids.length,
             threadLength,
           })}


### PR DESCRIPTION
Fixes the notification spam when a thread name is unknown in the timeline (e.g.: https://analytics.legionengine.com/timeline/e6a91a17-8596-4a84-a591-996be6df3c15)