### PR TITLE
Analytics: Add basic target/message search to the log page

### DIFF
--- a/crates/lgn-analytics-srv/src/log_entry.rs
+++ b/crates/lgn-analytics-srv/src/log_entry.rs
@@ -1,0 +1,22 @@
+use lgn_telemetry_proto::analytics::LogEntry;
+
+pub(crate) trait Searchable<Needle> {
+    fn matches(&self, needle: Needle) -> bool;
+}
+
+impl<'a, Needles> Searchable<Needles> for LogEntry
+where
+    Needles: 'a + AsRef<[String]>,
+{
+    fn matches(&self, needle: Needles) -> bool {
+        for needle in needle.as_ref() {
+            if self.target.to_lowercase().contains(needle)
+                || self.msg.to_lowercase().contains(needle)
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+}

--- a/crates/lgn-analytics-srv/src/main.rs
+++ b/crates/lgn-analytics-srv/src/main.rs
@@ -21,6 +21,7 @@ mod cumulative_call_graph;
 mod cumulative_call_graph_handler;
 mod cumulative_call_graph_node;
 mod health_check_service;
+mod log_entry;
 mod metrics;
 mod scope;
 mod thread_block_processor;

--- a/crates/lgn-telemetry-proto/protos/analytics.proto
+++ b/crates/lgn-telemetry-proto/protos/analytics.proto
@@ -113,6 +113,7 @@ message ProcessLogRequest {
   telemetry.Process process = 1;
   uint64 begin = 2;  // included
   uint64 end = 3;    // excluded
+  string search = 4;
 }
 
 message ProcessLogReply {

--- a/npm-pkgs/lgn-analytics-gui/src/assets/locales/en-US/main.ftl
+++ b/npm-pkgs/lgn-analytics-gui/src/assets/locales/en-US/main.ftl
@@ -47,6 +47,8 @@ log-parent-table-column =
     [msg] Message
     *[other] Unknown
   }
+log-search = Search Log Entries...
+
 
 # Timeline
 timeline-open-cumulative-call-graph = Open { global-cumulative-call-graph }

--- a/npm-pkgs/lgn-analytics-gui/src/assets/locales/fr-CA/main.ftl
+++ b/npm-pkgs/lgn-analytics-gui/src/assets/locales/fr-CA/main.ftl
@@ -47,6 +47,7 @@ global-severity-level =
     [4] Trace
     *[other] Unknown
   }
+log-search = Rechercher dans le journal...
 
 # Timeline
 timeline-open-cumulative-call-graph = Ouvrir le { LOWERCASE(global-cumulative-call-graph) }

--- a/npm-pkgs/lgn-analytics-gui/src/types/fluent.d.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/types/fluent.d.ts
@@ -32,6 +32,7 @@ declare type Fluent = {
   "log-parent-table-column": {
     variables: "columnName";
   };
+  "log-search": null;
   "timeline-open-cumulative-call-graph": null;
   "timeline-search": null;
   "timeline-table-function": null;

--- a/npm-pkgs/lgn-web-client/src/components/HighlightedText.svelte
+++ b/npm-pkgs/lgn-web-client/src/components/HighlightedText.svelte
@@ -1,26 +1,21 @@
 <script lang="ts">
   export let text: string;
 
-  export let pattern: RegExp | string;
+  export let pattern: RegExp | string | (RegExp | string)[];
 
-  $: patternRegExp =
-    pattern instanceof RegExp ? pattern : new RegExp(`(${pattern})`, "i");
+  function highlightText(text: string, pattern: RegExp | string) {
+    return text.replaceAll(
+      pattern,
+      (match) =>
+        `<mark class="bg-orange-700 text-black font-bold">${match}</mark>`
+    );
+  }
 
-  $: highlightedTextParts = text.split(patternRegExp);
+  $: highlightedText = Array.isArray(pattern)
+    ? pattern.reduce(highlightText, text)
+    : highlightText(text, pattern);
 </script>
 
 <div>
-  {#each highlightedTextParts as part, index}
-    {#if index % 2 === 0}
-      {part}
-    {:else}
-      <mark class="highlighted-text">{part}</mark>
-    {/if}
-  {/each}
+  {@html highlightedText}
 </div>
-
-<style lang="postcss">
-  .highlighted-text {
-    @apply bg-orange-700 text-black font-bold;
-  }
-</style>

--- a/npm-pkgs/lgn-web-client/src/lib/event.ts
+++ b/npm-pkgs/lgn-web-client/src/lib/event.ts
@@ -1,0 +1,31 @@
+/**
+ * Debounce an event.
+ */
+export function debounce(
+  cb: (event: Event) => void,
+  time: number
+): { (event: Event): void; clear(): void } {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  function clear() {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+
+      timeoutId = null;
+    }
+  }
+
+  function debounced(event: Event) {
+    clear();
+
+    timeoutId = setTimeout(() => {
+      timeoutId = null;
+
+      cb(event);
+    }, time);
+  }
+
+  debounced.clear = clear;
+
+  return debounced;
+}

--- a/npm-pkgs/lgn-web-client/src/lib/html.ts
+++ b/npm-pkgs/lgn-web-client/src/lib/html.ts
@@ -51,7 +51,7 @@ export function remToPx(rem: number): number | null {
 
   const parsedFontSize = fontSizeInPx.match(/(\d+)px/)?.[1];
 
-  if (!parsedFontSize) {
+  if (parsedFontSize === undefined || !parsedFontSize.length) {
     return null;
   }
 
@@ -71,4 +71,12 @@ export function replaceClassesWith(element: Element, newClass: string) {
   }
 
   element.classList.add(newClass);
+}
+
+/** Cleanup and convert a string into a `RegExp` */
+export function stringToSafeRegExp(s: string, flags?: string): RegExp {
+  return new RegExp(
+    s.replace(/([|&;$%@"<>()+,])/g, (char) => `\\${char}`),
+    flags
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
       '@napi-rs/cli': ^2.8.0
       rimraf: ^3.0.2
     devDependencies:
-      '@napi-rs/cli': 2.8.0
+      '@napi-rs/cli': 2.9.0
       rimraf: 3.0.2
 
   crates/lgn-config-node:
@@ -23,7 +23,7 @@ importers:
       '@napi-rs/cli': ^2.8.0
       rimraf: ^3.0.2
     devDependencies:
-      '@napi-rs/cli': 2.8.0
+      '@napi-rs/cli': 2.9.0
       rimraf: 3.0.2
 
   crates/lgn-content-store-proto:
@@ -423,7 +423,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.23.0_c63nfttrfhylg3zmgcxfslaw44
       '@typescript-eslint/parser': 5.23.0_hcfsmds2fshutdssjqluwm76uu
       autoprefixer: 10.4.7_postcss@8.4.13
-      c8: 7.11.2
+      c8: 7.11.3
       concurrently: 7.1.0
       cross-env: 7.0.3
       electron: 18.2.2
@@ -445,7 +445,7 @@ importers:
       typescript: 4.6.4
       vite: 2.9.9
       vite-tsconfig-paths: 3.4.1_vite@2.9.9
-      vitest: 0.12.4_c8@7.11.2+jsdom@19.0.0
+      vitest: 0.12.4_c8@7.11.3+jsdom@19.0.0
 
   npm-pkgs/lgn-runtime-gui:
     specifiers:
@@ -526,7 +526,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.23.0_c63nfttrfhylg3zmgcxfslaw44
       '@typescript-eslint/parser': 5.23.0_hcfsmds2fshutdssjqluwm76uu
       autoprefixer: 10.4.7_postcss@8.4.13
-      c8: 7.11.2
+      c8: 7.11.3
       concurrently: 7.1.0
       cross-env: 7.0.3
       eslint: 8.15.0
@@ -546,7 +546,7 @@ importers:
       typescript: 4.6.4
       vite: 2.9.9
       vite-tsconfig-paths: 3.4.1_vite@2.9.9
-      vitest: 0.12.4_c8@7.11.2+jsdom@19.0.0
+      vitest: 0.12.4_c8@7.11.3+jsdom@19.0.0
 
   npm-pkgs/lgn-web-client:
     specifiers:
@@ -634,7 +634,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.23.0_c63nfttrfhylg3zmgcxfslaw44
       '@typescript-eslint/parser': 5.23.0_hcfsmds2fshutdssjqluwm76uu
       autoprefixer: 10.4.7_postcss@8.4.13
-      c8: 7.11.2
+      c8: 7.11.3
       eslint: 8.15.0
       eslint-config-prettier: 8.5.0_eslint@8.15.0
       eslint-plugin-svelte3: 4.0.0_usjo443ynfgvutifl4ot2fkxzy
@@ -651,7 +651,7 @@ importers:
       type-fest: 2.12.2
       typescript: 4.6.4
       vite: 2.9.9
-      vitest: 0.12.4_c8@7.11.2+jsdom@19.0.0
+      vitest: 0.12.4_c8@7.11.3+jsdom@19.0.0
 
   npm-pkgs/vite-plugin-ts-proto:
     specifiers:
@@ -669,7 +669,7 @@ importers:
       '@types/mkdirp': 1.0.2
       '@types/node': 17.0.32
       '@types/which': 2.0.1
-      glob: 8.0.1
+      glob: 8.0.3
       mkdirp: 1.0.4
       rimraf: 3.0.2
       typescript: 4.6.4
@@ -1033,8 +1033,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.13
     dev: true
 
-  /@napi-rs/cli/2.8.0:
-    resolution: {integrity: sha512-yECNMAcIpdy58PcOgsIK6x6FzSButzpdR0QFjdv4d1d0OzeTSmcyt9tVqyc8ZPfEUXnQdNVBXY9wVQLVY1pi/A==}
+  /@napi-rs/cli/2.9.0:
+    resolution: {integrity: sha512-qZ49ORZJ8rsHlvnnLsJCg9Ik+KfhiIgSea1HDMf6A9KBVxwWCijNhSO8zFvvBr7m1m44cx9WWhnQDnwPqSDeLA==}
     engines: {node: '>= 10'}
     hasBin: true
     dev: true
@@ -1061,7 +1061,7 @@ packages:
     dev: true
 
   /@protobufjs/aspromise/1.1.2:
-    resolution: {integrity: sha1-m4sMxmPWaafY9vXQiToU00jzD78=}
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
   /@protobufjs/base64/1.1.2:
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
@@ -1070,28 +1070,28 @@ packages:
     resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
 
   /@protobufjs/eventemitter/1.1.0:
-    resolution: {integrity: sha1-NVy8mLr61ZePntCV85diHx0Ga3A=}
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
 
   /@protobufjs/fetch/1.1.0:
-    resolution: {integrity: sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=}
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
 
   /@protobufjs/float/1.0.2:
-    resolution: {integrity: sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=}
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
   /@protobufjs/inquire/1.1.0:
-    resolution: {integrity: sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=}
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
 
   /@protobufjs/path/1.1.2:
-    resolution: {integrity: sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=}
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
   /@protobufjs/pool/1.1.0:
-    resolution: {integrity: sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=}
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
   /@protobufjs/utf8/1.1.0:
-    resolution: {integrity: sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=}
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   /@rollup/pluginutils/4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -2066,8 +2066,8 @@ packages:
       ieee754: 1.2.1
     dev: true
 
-  /c8/7.11.2:
-    resolution: {integrity: sha512-6ahJSrhS6TqSghHm+HnWt/8Y2+z0hM/FQyB1ybKhAR30+NYL9CTQ1uwHxuWw6U7BHlHv6wvhgOrH81I+lfCkxg==}
+  /c8/7.11.3:
+    resolution: {integrity: sha512-6YBmsaNmqRm9OS3ZbIiL2EZgi1+Xc4O24jL3vMYGE6idixYuGdy76rIfIdltSKDj9DpLNrcXSonUTR1miBD0wA==}
     engines: {node: '>=10.12.0'}
     hasBin: true
     dependencies:
@@ -3414,16 +3414,15 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
-  /glob/8.0.1:
-    resolution: {integrity: sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==}
+  /glob/8.0.3:
+    resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
     engines: {node: '>=12'}
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.0.1
+      minimatch: 5.1.0
       once: 1.4.0
-      path-is-absolute: 1.0.1
     dev: true
 
   /global-agent/3.0.0:
@@ -3987,8 +3986,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimatch/5.0.1:
-    resolution: {integrity: sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==}
+  /minimatch/5.1.0:
+    resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
@@ -4603,7 +4602,7 @@ packages:
   /rxjs/7.5.5:
     resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: false
 
   /sade/1.8.1:
@@ -5121,8 +5120,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib/2.3.1:
-    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
     dev: false
 
   /tsutils/3.21.0_typescript@4.6.4:
@@ -5274,7 +5273,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.12.4_c8@7.11.2+jsdom@19.0.0:
+  /vitest/0.12.4_c8@7.11.3+jsdom@19.0.0:
     resolution: {integrity: sha512-EDxdhlAt6vcu6y4VouAI60z78iCAVFnfBL4VlSQVQnGmOk5altOtIKvp3xfZ+cfo4iVHgqq1QNyf5qOFiL4leg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -5295,7 +5294,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.1
       '@types/chai-subset': 1.3.3
-      c8: 7.11.2
+      c8: 7.11.3
       chai: 4.3.6
       jsdom: 19.0.0
       local-pkg: 0.4.1


### PR DESCRIPTION
- [x] Revamp the way we handle loading/data in the log page
- [x] Speedup the HighlightedText component (probably not by a lot, but it's still better than it used to be)
- [x] Add a search bar that searches for log entries' target or message
  - [x] Case insensitive
  - [x] Split on space to make the search more forgiving and inclusive
  - [x] Search in url that can be shared
  - [x] No pagination when in "search mode"
  - [x] Drop begin/end params from url when in "search mode"
  - [x] Debounced search (300ms)

![search-logs](https://user-images.githubusercontent.com/94377405/168908413-d3153e42-2135-4a6b-81ce-c664edc8b375.png)
