### PR TITLE
Analytics smarter history search

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/src/routes/index.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/index.svelte
@@ -25,6 +25,7 @@
   }: CustomEvent<{ encodedValue: string }>) {
     goto(`/${encodedValue.length ? `?search=${encodedValue}` : ""}`, {
       keepfocus: true,
+      replaceState: $page.url.searchParams.has("search"),
     });
   }
 

--- a/npm-pkgs/lgn-analytics-gui/src/routes/log/[processId].svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/log/[processId].svelte
@@ -50,6 +50,7 @@
       }`,
       {
         keepfocus: true,
+        replaceState: $page.url.searchParams.has("search"),
       }
     );
   }


### PR DESCRIPTION
Instead of pushing a new entry in the browser history on each search, we replace the last search.

For instance, let's take these steps:
- User goes to logs/xxx
- Goes to page 2
- Searches for "foo"
- Searches for "bar"
- Clears the search bar

Here is the resulting history:

_Before_

```
/logs/xxx
/logs/xxx?begin=1000&end=2000
/logs/xxx?search=foo
/logs/xxx?search=bar
/logs/xxx
```

_After_

```
/logs/xxx
/logs/xxx?begin=1000&end=2000
/logs/xxx?search=bar
/logs/xxx
```
