### PR TITLE
Analytics: Use @lgn/config

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/package.json
+++ b/npm-pkgs/lgn-analytics-gui/package.json
@@ -24,6 +24,7 @@
     "fluent:generate": "cargo run --bin lgn-fluent-generator -- -i ./src/assets/locales/en-US/**/*.ftl -o ./src/types"
   },
   "devDependencies": {
+    "@lgn/config": "workspace:^0.1.0",
     "@lgn/vite-plugin-ts-proto": "workspace:^0.1.0",
     "@sveltejs/adapter-static": "^1.0.0-next.28",
     "@sveltejs/kit": "^1.0.0-next.327",

--- a/npm-pkgs/lgn-analytics-gui/src/routes/__layout.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/__layout.svelte
@@ -14,6 +14,12 @@
 
   const notifications = createNotificationsStore<Fluent>();
 
+  const issuerUrl = import.meta.env
+    .VITE_LEGION_ANALYTICS_ONLINE_AUTHENTICATION_OAUTH_ISSUER_URL as string;
+
+  const clientId = import.meta.env
+    .VITE_LEGION_ANALYTICS_ONLINE_AUTHENTICATION_OAUTH_CLIENT_ID as string;
+
   let loaded = false;
 
   export const load: Load = async ({ fetch, url }) => {
@@ -25,10 +31,9 @@
       const { dispose, initAuthStatus } = await headlessRun({
         auth: {
           fetch,
-          issuerUrl:
-            "https://cognito-idp.ca-central-1.amazonaws.com/ca-central-1_SkZKDimWz",
+          issuerUrl,
           redirectUri,
-          clientId: "2kp01gr54dfc7qp1325hibcro3",
+          clientId,
           login: {
             cookies: {
               accessToken: "analytics_access_token_v2",

--- a/npm-pkgs/lgn-analytics-gui/vite.config.js
+++ b/npm-pkgs/lgn-analytics-gui/vite.config.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+import { loadAll } from "@lgn/config";
 import viteTsProto from "@lgn/vite-plugin-ts-proto";
 
 /** @type {"jsdom"} */
@@ -28,19 +29,28 @@ if ("VITEST" in process.env) {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(() => ({
-  // TODO: Drop this option when vite-tsconfig-paths
-  // will work properly with SvelteKit
-  resolve: {
-    alias: {
-      "@/resources": path.resolve("./tests/resources"),
-      "@": path.resolve("./src"),
+export default defineConfig(() => {
+  loadAll({
+    VITE_LEGION_ANALYTICS_ONLINE_AUTHENTICATION_OAUTH_ISSUER_URL:
+      "online.authentication.issuer_url",
+    VITE_LEGION_ANALYTICS_ONLINE_AUTHENTICATION_OAUTH_CLIENT_ID:
+      "online.authentication.client_id",
+  });
+
+  return {
+    // TODO: Drop this option when vite-tsconfig-paths
+    // will work properly with SvelteKit
+    resolve: {
+      alias: {
+        "@/resources": path.resolve("./tests/resources"),
+        "@": path.resolve("./src"),
+      },
     },
-  },
-  plugins,
-  test: {
-    environment: testEnvironment,
-    globals: true,
-    setupFiles: "tests/setup.ts",
-  },
-}));
+    plugins,
+    test: {
+      environment: testEnvironment,
+      globals: true,
+      setupFiles: "tests/setup.ts",
+    },
+  };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,7 @@ importers:
     specifiers:
       '@fluent/bundle': ^0.17.1
       '@improbable-eng/grpc-web': ^0.15.0
+      '@lgn/config': workspace:^0.1.0
       '@lgn/proto-telemetry': ^0.1.0
       '@lgn/vite-plugin-ts-proto': workspace:^0.1.0
       '@lgn/web-client': ^0.1.0
@@ -272,6 +273,7 @@ importers:
       svelte-loading-spinners: 0.1.7
       uuid-random: 1.3.2
     devDependencies:
+      '@lgn/config': link:../../crates/lgn-config-node
       '@lgn/vite-plugin-ts-proto': link:../vite-plugin-ts-proto
       '@sveltejs/adapter-static': 1.0.0-next.29
       '@sveltejs/kit': 1.0.0-next.327_svelte@3.48.0


### PR DESCRIPTION
@ereOn We might switch from .env to legion.toml in the near future but it's still unclear to me whether or not we can override the legion.toml with using a suffix like "legion.local.toml" or "legion.dev.toml", etc... If not we might have to keep .env.

(The relevant commit is here: https://github.com/legion-labs/legion/pull/1830/commits/442b64491df7eeb859e319be47b214a0ad41f94f)