### PR TITLE
[content-store] Fixed streams not being marked as Send

### DIFF
--- a/crates/lgn-content-store/src/indexing/composite_indexer.rs
+++ b/crates/lgn-content-store/src/indexing/composite_indexer.rs
@@ -193,7 +193,7 @@ where
         &'s self,
         provider: &'s Provider,
         root_id: &'s TreeIdentifier,
-    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + 's>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + Send + 's>>> {
         let leaves = self.first.enumerate_leaves(provider, root_id).await?;
 
         Ok(Box::pin(stream! {

--- a/crates/lgn-content-store/src/indexing/mod.rs
+++ b/crates/lgn-content-store/src/indexing/mod.rs
@@ -144,7 +144,7 @@ pub trait BasicIndexer {
         &'s self,
         provider: &'s Provider,
         root_id: &'s TreeIdentifier,
-    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + 's>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + Send + 's>>> {
         Ok(Box::pin(tree_leaves(
             provider,
             root_id,
@@ -172,7 +172,7 @@ pub trait OrderedIndexer {
         provider: &'s Provider,
         root_id: &'s TreeIdentifier,
         range: R,
-    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + 's>>>
+    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + Send + 's>>>
     where
         T: Into<IndexKey> + Clone,
         R: RangeBounds<T> + Send + 's;
@@ -221,7 +221,7 @@ pub trait RecursiveIndexer {
         provider: &'s Provider,
         root_id: &'s TreeIdentifier,
         index_key: &'s IndexKey,
-    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + 's>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + Send + 's>>> {
         match self.get(provider, root_id, index_key).await? {
             Some(node) => Ok(match node {
                 TreeNode::Leaf(leaf_node) => Box::pin(futures::stream::once(async {

--- a/crates/lgn-content-store/src/indexing/static_indexer.rs
+++ b/crates/lgn-content-store/src/indexing/static_indexer.rs
@@ -598,7 +598,7 @@ impl OrderedIndexer for StaticIndexer {
         provider: &'s Provider,
         root_id: &'s TreeIdentifier,
         range: R,
-    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + 's>>>
+    ) -> Result<Pin<Box<dyn Stream<Item = (IndexKey, Result<TreeLeafNode>)> + Send + 's>>>
     where
         T: Into<IndexKey> + Clone,
         R: RangeBounds<T> + Send + 's,


### PR DESCRIPTION
This fixes weird issues where calling the stream methods in another async call that requires `Send` was causing a compilation error.