### PR TITLE
[codegen] Add support for oneof openapi schemas

### DIFF
--- a/crates/lgn-api-codegen/src/api.rs
+++ b/crates/lgn-api-codegen/src/api.rs
@@ -40,6 +40,7 @@ pub enum Type {
 pub enum Model {
     Enum(Enum),
     Struct(Struct),
+    OneOf(OneOf),
 }
 
 impl Model {
@@ -47,6 +48,7 @@ impl Model {
         match self {
             Model::Enum(enum_) => &enum_.name,
             Model::Struct(struct_) => &struct_.name,
+            Model::OneOf(oneof) => &oneof.name,
         }
     }
 }
@@ -56,6 +58,13 @@ pub struct Enum {
     pub name: String,
     pub description: Option<String>,
     pub variants: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Default)]
+pub struct OneOf {
+    pub name: String,
+    pub description: Option<String>,
+    pub types: Vec<Type>,
 }
 
 #[derive(Debug, PartialEq, Default)]

--- a/crates/lgn-api-codegen/src/rust/fixtures/openapi.yaml
+++ b/crates/lgn-api-codegen/src/rust/fixtures/openapi.yaml
@@ -52,14 +52,12 @@ paths:
       operationId: testBinary
       responses:
         "200":
-          description: Successful operation
+          description: Ok.
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-        default:
-          description: successful operation
       requestBody:
         required: true
         content:
@@ -67,6 +65,18 @@ paths:
             schema:
               type: string
               format: binary
+  /test-one-of:
+    get:
+      operationId: testOneOf
+      responses:
+        "200":
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Pet"
+                  - $ref: "#/components/schemas/Car"
 components:
   parameters:
     SpaceId:
@@ -101,6 +111,11 @@ components:
         extra:
           type: string
           format: byte
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
   requestBodies:
     Car:
       description: The content of the car.

--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -34,6 +34,8 @@ pub mod api {
             body: ByteArray,
             extra: Extra,
         ) -> Result<responses::TestBinaryResponse>;
+
+        async fn test_one_of(&self, extra: Extra) -> Result<responses::TestOneOfResponse>;
     }
 }
 
@@ -178,6 +180,16 @@ pub mod client {
 
             responses::TestBinaryResponse::from_reqwest(resp).await
         }
+
+        async fn test_one_of(&self, extra: Extra) -> Result<responses::TestOneOfResponse> {
+            let uri = format!("{}/test-one-of", self.base_uri);
+
+            let mut headers = extra.headers;
+
+            let resp = self.inner.get(&uri).headers(headers).send().await?;
+
+            responses::TestOneOfResponse::from_reqwest(resp).await
+        }
     }
 }
 
@@ -214,6 +226,7 @@ pub mod server {
                 "/spaces/:space-id/car-service/test-binary",
                 routing::post(test_binary::<T>),
             )
+            .route("/test-one-of", routing::get(test_one_of::<T>))
             .layer(Extension(api))
     }
 
@@ -263,6 +276,17 @@ pub mod server {
             Err(err) => err.into_response(),
         }
     }
+
+    async fn test_one_of<T>(Extension(api): Extension<T>, headers: HeaderMap) -> Response
+    where
+        T: api::Api + Send + Sync + 'static,
+    {
+        let resp = api.test_one_of(Extra { headers }).await;
+        match resp {
+            Ok(resp) => resp.into_response(),
+            Err(err) => err.into_response(),
+        }
+    }
 }
 
 // ---------- Models ----------
@@ -301,6 +325,21 @@ pub mod models {
         #[serde(rename = "extra")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub extra: Option<ByteArray>,
+    }
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    pub struct Pet {
+        #[serde(rename = "name")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    pub enum TestOneOfResponse {
+        #[serde(rename = "option1")]
+        Option1(crate::models::Pet),
+        #[serde(rename = "option2")]
+        Option2(crate::models::Car),
     }
 }
 
@@ -380,7 +419,7 @@ pub mod responses {
 
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     pub enum TestBinaryResponse {
-        /// Successful operation
+        /// Ok.
         Ok(ByteArray),
     }
 
@@ -397,6 +436,33 @@ pub mod responses {
         pub(crate) async fn from_reqwest(response: reqwest::Response) -> Result<Self> {
             match response.status().as_u16() {
                 200 => Ok(Self::Ok(response.bytes().await?.into())),
+                status => Err(Error::Internal(format!(
+                    "unexpected status code: {}",
+                    status
+                ))),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub enum TestOneOfResponse {
+        /// Ok.
+        Ok(crate::models::TestOneOfResponse),
+    }
+
+    impl TestOneOfResponse {
+        pub(crate) fn into_response(self) -> Response {
+            match self {
+                TestOneOfResponse::Ok(inner) => {
+                    let inner = Json(inner);
+                    (StatusCode::from_u16(200).unwrap(), inner).into_response()
+                }
+            }
+        }
+
+        pub(crate) async fn from_reqwest(response: reqwest::Response) -> Result<Self> {
+            match response.status().as_u16() {
+                200 => Ok(Self::Ok(response.json().await?)),
                 status => Err(Error::Internal(format!(
                     "unexpected status code: {}",
                     status

--- a/crates/lgn-api-codegen/src/rust/templates/models.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/models.rs.jinja
@@ -12,6 +12,16 @@ use lgn_online::codegen::ByteArray;
                     {{ variant|pascal_case }},
                 {%- endfor -%}
             }
+        {% when Model::OneOf with (one_of) %}
+            {% if let Some(description) = one_of.description %}/// {{ description }}{% endif %}
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+            pub enum {{ one_of.name }}
+            {
+                {%- for type_ in one_of.types -%}
+                    #[serde(rename = "option{{loop.index}}")]
+                    Option{{loop.index}}({{ type_|fmt_type }}),
+                {%- endfor -%}
+            }
         {% when Model::Struct with (struct_) %}
             {% if let Some(description) = struct_.description %}/// {{ description }}{% endif %}
             #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
This PR adds support for `oneOf` OpenApi schemas in the code generation.