### PR TITLE
[auth] Implemented AWS DynamoDb API key validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,6 +3687,9 @@ name = "lgn-auth"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-sdk-dynamodb",
+ "aws-sdk-s3",
  "base64 0.13.0",
  "directories",
  "form_urlencoded",
@@ -3708,6 +3711,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower-http",
+ "ttl_cache",
  "webbrowser",
 ]
 
@@ -8808,6 +8812,15 @@ name = "ttf-parser"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c74c96594835e10fa545e2a51e8709f30b173a092bfd6036ef2cec53376244f3"
+
+[[package]]
+name = "ttl_cache"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "tungstenite"

--- a/crates/lgn-auth/Cargo.toml
+++ b/crates/lgn-auth/Cargo.toml
@@ -4,7 +4,15 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["aws", "ttl"]
+aws = ["aws-config", "aws-sdk-s3", "aws-sdk-dynamodb"]
+ttl = ["ttl_cache"]
+
 [dependencies]
+aws-config = { version = "0.9", optional = true }
+aws-sdk-s3 = { version = "0.9", optional = true }
+aws-sdk-dynamodb = { version = "0.9", optional = true }
 async-trait = "0.1.53"
 base64 = "0.13.0"
 form_urlencoded = "1.0.1"
@@ -14,6 +22,7 @@ http = "0.2.6"
 http-serde = "1.1.0"
 lgn-config = { path = "../lgn-config", version = "0.1.0" }
 lgn-tracing = { path = "../../crates/lgn-tracing", version = "0.1.0" }
+ttl_cache = { version = "0.5", optional = true }
 # napi = { version = "2.2.0", features = [
 #     "tokio_rt",
 #     "serde-json",

--- a/crates/lgn-auth/src/api_key/aws_dynamo_db_validation.rs
+++ b/crates/lgn-auth/src/api_key/aws_dynamo_db_validation.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+use aws_sdk_dynamodb::model::AttributeValue;
+use aws_sdk_dynamodb::Region;
+use lgn_tracing::span_fn;
+
+use super::{Error, Result};
+
+use super::{ApiKey, ApiKeyValidator};
+
+pub struct AwsDynamoDbValidation {
+    table_name: String,
+    client: aws_sdk_dynamodb::Client,
+}
+
+impl AwsDynamoDbValidation {
+    #[span_fn]
+    pub async fn new(region: Option<String>, table_name: impl Into<String>) -> Result<Self> {
+        let config = aws_config::from_env();
+
+        let config = if let Some(region) = region {
+            let region = Region::new(region);
+
+            config.region(region)
+        } else {
+            config
+        }
+        .load()
+        .await;
+
+        let client = aws_sdk_dynamodb::Client::new(&config);
+        let table_name = table_name.into();
+
+        Ok(Self { table_name, client })
+    }
+
+    fn get_api_key_attr(api_key: ApiKey) -> AttributeValue {
+        AttributeValue::S(api_key.0)
+    }
+}
+
+#[async_trait]
+impl ApiKeyValidator for AwsDynamoDbValidation {
+    async fn validate_api_key(&self, api_key: ApiKey) -> Result<()> {
+        let api_key_attr = Self::get_api_key_attr(api_key.clone());
+
+        match self
+            .client
+            .get_item()
+            .table_name(&self.table_name)
+            .key("api_key", api_key_attr)
+            .send()
+            .await
+        {
+            Ok(output) => output.item.ok_or(Error::InvalidApiKey(api_key)).map(|_| ()),
+            Err(err) => Err(Error::Unspecified(format!(
+                "unexpected error while reading API key from AWS DynamoDB: {}",
+                err
+            ))),
+        }
+    }
+}

--- a/crates/lgn-auth/src/api_key/errors.rs
+++ b/crates/lgn-auth/src/api_key/errors.rs
@@ -4,8 +4,12 @@ use super::ApiKey;
 
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error("invalid configuration: {0}")]
+    Configuration(String),
     #[error("The API key is invalid")]
     InvalidApiKey(ApiKey),
+    #[error("Unspecified error: {0}")]
+    Unspecified(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -19,6 +23,10 @@ where
         match err {
             Error::InvalidApiKey(_) => http::Response::builder()
                 .status(http::StatusCode::UNAUTHORIZED)
+                .body(Default::default())
+                .unwrap(),
+            Error::Configuration(_) | Error::Unspecified(_) => http::Response::builder()
+                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
                 .body(Default::default())
                 .unwrap(),
         }

--- a/crates/lgn-auth/src/api_key/mod.rs
+++ b/crates/lgn-auth/src/api_key/mod.rs
@@ -1,13 +1,21 @@
+#[cfg(feature = "aws")]
+mod aws_dynamo_db_validation;
 mod errors;
 mod memory_validation;
 mod request_authorizer;
+#[cfg(feature = "ttl")]
+mod ttl_cache_validation;
 
 use std::{fmt::Formatter, sync::Arc};
 
 use async_trait::async_trait;
+#[cfg(feature = "aws")]
+pub use aws_dynamo_db_validation::AwsDynamoDbValidation;
 pub use errors::{Error, Result};
 pub use memory_validation::MemoryValidation;
 pub use request_authorizer::RequestAuthorizer;
+#[cfg(feature = "ttl")]
+pub use ttl_cache_validation::TtlCacheValidation;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct ApiKey(String);

--- a/crates/lgn-auth/src/api_key/ttl_cache_validation.rs
+++ b/crates/lgn-auth/src/api_key/ttl_cache_validation.rs
@@ -1,0 +1,47 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use super::{Error, Result};
+
+use super::{ApiKey, ApiKeyValidator};
+
+pub struct TtlCacheValidation<T> {
+    inner: T,
+    ttl: Duration,
+    cache: RwLock<ttl_cache::TtlCache<ApiKey, bool>>,
+}
+
+impl<T> TtlCacheValidation<T> {
+    pub fn new(inner: T, capacity: usize, ttl: Duration) -> Self {
+        Self {
+            inner,
+            ttl,
+            cache: RwLock::new(ttl_cache::TtlCache::new(capacity)),
+        }
+    }
+}
+
+#[async_trait]
+impl<T: ApiKeyValidator + Send + Sync> ApiKeyValidator for TtlCacheValidation<T> {
+    async fn validate_api_key(&self, api_key: ApiKey) -> Result<()> {
+        let exists = self.cache.read().await.get(&api_key).copied();
+
+        match exists {
+            Some(true) => Ok(()),
+            Some(false) => Err(Error::InvalidApiKey(api_key)),
+            None => match self.inner.validate_api_key(api_key.clone()).await {
+                Ok(()) => {
+                    self.cache.write().await.insert(api_key, true, self.ttl);
+                    Ok(())
+                }
+                Err(Error::InvalidApiKey(err_api_key)) => {
+                    self.cache.write().await.insert(api_key, false, self.ttl);
+                    Err(Error::InvalidApiKey(err_api_key))
+                }
+                Err(err) => Err(err),
+            },
+        }
+    }
+}

--- a/crates/lgn-telemetry-ingestion-srv/src/main.rs
+++ b/crates/lgn-telemetry-ingestion-srv/src/main.rs
@@ -60,10 +60,21 @@ async fn serve_grpc(
     args: &Cli,
     lake: DataLakeConnection,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // For now we still load the API key from the environment. Next step:
-    // validating it against a database.
-    let api_key = std::env::var("LGN_TELEMETRY_GRPC_API_KEY")?.into();
+    // To enable AWS DynamoDb API key validation, uncomment the following (and possibly adapt the name of the DynamoDb table):
+    //let validation = Arc::new(lgn_auth::api_key::TtlCacheValidation::new(
+    //    lgn_auth::api_key::AwsDynamoDbValidation::new(None, "legionlabs-telemetry-api-keys")
+    //        .await?,
+    //    10,                                  // Hold up to 10 API keys in memory.
+    //    std::time::Duration::from_secs(600), // Hold them for 10 minutes.
+    //));
+
+    // This validates against an in-memory API key.
+    // In a real world scenario, you would want to read the API key from the
+    // environment at runtime, but for now we'll hardcode it during compilation.
+    //let api_key = std::env::var("LGN_TELEMETRY_GRPC_API_KEY")?.into();
+    let api_key = env!("LGN_TELEMETRY_GRPC_API_KEY").to_string().into();
     let validation = Arc::new(lgn_auth::api_key::MemoryValidation::new(vec![api_key]));
+
     let auth_layer =
         AsyncRequireAuthorizationLayer::new(lgn_auth::api_key::RequestAuthorizer::new(validation));
 


### PR DESCRIPTION
This PR implements AWS DynamoDb API key validation and integrates it (commented-out for now) in the telemetry ingestion service.

It also reverts back for now to using the hardcoded (at compilation time) API key to make sure the demos keep working.

Fixes #1827.