### PR TITLE
[codegen] Use same output file name as input openapi file

### DIFF
--- a/crates/lgn-api-codegen/src/lib.rs
+++ b/crates/lgn-api-codegen/src/lib.rs
@@ -37,16 +37,17 @@ pub fn generate(
     openapi_file: impl AsRef<Path>,
     output_dir: impl AsRef<Path>,
 ) -> Result<()> {
-    let openapi_file = std::fs::File::open(openapi_file)?;
-    let openapi: openapiv3::OpenAPI = serde_yaml::from_reader(&openapi_file)?;
+    let openapi_file = openapi_file.as_ref();
+    let openapi_reader = std::fs::File::open(openapi_file)?;
+    let openapi: openapiv3::OpenAPI = serde_yaml::from_reader(&openapi_reader)?;
     let api = Api::try_from(&openapi)?;
 
     let generator = load_generator_for_language(language);
-    generator.generate(&api, output_dir.as_ref())
+    generator.generate(&api, openapi_file, output_dir.as_ref())
 }
 
 pub(crate) trait Generator {
-    fn generate(&self, api: &Api, output_dir: &Path) -> Result<()>;
+    fn generate(&self, api: &Api, openapi_file: &Path, output_dir: &Path) -> Result<()>;
 }
 
 fn load_generator_for_language(language: &Language) -> Box<dyn Generator> {

--- a/crates/lgn-api-codegen/src/rust/mod.rs
+++ b/crates/lgn-api-codegen/src/rust/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use askama::Template;
 use rust_format::{Formatter, RustFmt};
-use std::path::Path;
+use std::{ffi::OsStr, path::Path};
 
 #[derive(askama::Template)]
 #[template(path = "lib.rs.jinja", escape = "none")]
@@ -18,11 +18,19 @@ struct RustTemplate<'a> {
 pub(crate) struct RustGenerator {}
 
 impl Generator for RustGenerator {
-    fn generate(&self, api: &Api, output_dir: &Path) -> Result<()> {
+    fn generate(&self, api: &Api, openapi_file: &Path, output_dir: &Path) -> Result<()> {
         let content = generate(api)?;
 
+        let output_file = output_dir.join(
+            openapi_file
+                .to_path_buf()
+                .with_extension("rs")
+                .file_name()
+                .unwrap_or_else(|| OsStr::new("openapi.rs")),
+        );
+
         std::fs::create_dir_all(output_dir)?;
-        std::fs::write(output_dir.join("lib.rs"), content)?;
+        std::fs::write(output_file, content)?;
 
         Ok(())
     }

--- a/crates/lgn-api-codegen/src/typescript/mod.rs
+++ b/crates/lgn-api-codegen/src/typescript/mod.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
 #[cfg(feature = "typescript-format")]
 use std::sync::Arc;
+use std::{ffi::OsStr, path::Path};
 
 #[cfg(feature = "typescript-format")]
 use anyhow::anyhow;
@@ -29,14 +29,22 @@ struct TypeScriptTemplate<'a> {
 pub(crate) struct TypeScriptGenerator {}
 
 impl Generator for TypeScriptGenerator {
-    fn generate(&self, api: &Api, output_dir: &Path) -> Result<()> {
+    fn generate(&self, api: &Api, openapi_file: &Path, output_dir: &Path) -> Result<()> {
         let content = generate(api)?;
 
         #[cfg(feature = "typescript-format")]
         let content = format(content)?;
 
+        let output_file = output_dir.join(
+            openapi_file
+                .to_path_buf()
+                .with_extension("ts")
+                .file_name()
+                .unwrap_or_else(|| OsStr::new("index.ts")),
+        );
+
         std::fs::create_dir_all(output_dir)?;
-        std::fs::write(output_dir.join("index.ts"), content)?;
+        std::fs::write(output_file, content)?;
 
         Ok(())
     }


### PR DESCRIPTION
The PR changes the output file name of the code generation. We now use the same output file name as input openapi file one.