### PR TITLE
[content-store] Implemented unwrite_content method

### DIFF
--- a/crates/lgn-content-store/src/bin/cli.rs
+++ b/crates/lgn-content-store/src/bin/cli.rs
@@ -541,7 +541,7 @@ async fn main() -> anyhow::Result<()> {
 
                     let index: Pin<Box<dyn Future<Output = anyhow::Result<_>>>> =
                         Box::pin(async move {
-                            let mut provider = provider.begin_transaction_in_memory();
+                            let provider = provider.begin_transaction_in_memory();
                             let mut tree_id = provider.write_tree(&Tree::default()).await?;
 
                             let seq_len = sequence_length.try_into().unwrap();
@@ -559,13 +559,6 @@ async fn main() -> anyhow::Result<()> {
                                         .get(&bar_id)
                                         .unwrap()
                                         .set_position(indexed_count.try_into().unwrap());
-
-                                    provider = match provider.commit_transaction().await {
-                                        Ok(provider) => provider.begin_transaction_in_memory(),
-                                        Err((_, err)) => {
-                                            return Err(err.into());
-                                        }
-                                    };
                                 }
 
                                 if word.len() < seq_len {

--- a/crates/lgn-content-store/src/config.rs
+++ b/crates/lgn-content-store/src/config.rs
@@ -233,9 +233,7 @@ impl Config {
             ));
         }
 
-        let provider = Provider::new(content_provider, alias_provider);
-
-        Ok(provider)
+        Ok(Provider::new(content_provider, alias_provider))
     }
 
     /// Load the configuration from the specified section and immediately instantiate the provider.

--- a/crates/lgn-content-store/src/content_providers/errors.rs
+++ b/crates/lgn-content-store/src/content_providers/errors.rs
@@ -5,6 +5,8 @@ use super::{HashRef, InvalidHashRef};
 /// An error type for the content-store crate.
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error("the provider does not support unwritting")]
+    UnwriteNotSupported,
     #[error("the hash reference `{0}` was not found")]
     HashRefNotFound(HashRef),
     #[error("the hash reference `{0}` already exists")]

--- a/crates/lgn-content-store/src/content_providers/lru.rs
+++ b/crates/lgn-content-store/src/content_providers/lru.rs
@@ -92,6 +92,20 @@ impl ContentWriter for LruContentProvider {
             })))
         }
     }
+
+    fn supports_unwrite(&self) -> bool {
+        true
+    }
+
+    async fn unwrite_content(&self, id: &HashRef) -> Result<()> {
+        async_span_scope!("LruContentProvider::unwrite");
+
+        if self.content_map.lock().await.pop(id).is_some() {
+            Ok(())
+        } else {
+            Err(Error::HashRefNotFound(id.clone()))
+        }
+    }
 }
 
 type MemoryUploader = Uploader<LruUploaderImpl>;

--- a/crates/lgn-content-store/src/content_providers/monitor.rs
+++ b/crates/lgn-content-store/src/content_providers/monitor.rs
@@ -179,6 +179,14 @@ impl<Inner: ContentWriter + Send + Sync> ContentWriter for ContentProviderMonito
             writer
         })
     }
+
+    fn supports_unwrite(&self) -> bool {
+        self.inner.supports_unwrite()
+    }
+
+    async fn unwrite_content(&self, id: &HashRef) -> Result<()> {
+        self.inner.unwrite_content(id).await
+    }
 }
 
 #[pin_project]

--- a/crates/lgn-content-store/src/indexing/static_indexer.rs
+++ b/crates/lgn-content-store/src/indexing/static_indexer.rs
@@ -346,7 +346,7 @@ impl StaticIndexer {
                         }
 
                         // The branch is actually removed from the tree as this point.
-                        provider.unwrite(tree_id.as_identifier()).await;
+                        provider.unwrite(tree_id.as_identifier()).await?;
                     }
                 }
             }
@@ -449,7 +449,7 @@ impl BasicIndexer for StaticIndexer {
                     item.tree.count += 1;
 
                     if let Some(old_node) = item.tree.insert_children(item.key, node) {
-                        provider.unwrite(old_node.as_identifier()).await;
+                        provider.unwrite(old_node.as_identifier()).await?;
                     }
 
                     item.tree.total_size += size_delta;
@@ -460,7 +460,7 @@ impl BasicIndexer for StaticIndexer {
                     if let Some(next) = stack.pop() {
                         item = next;
                     } else {
-                        provider.unwrite(root_id.as_identifier()).await;
+                        provider.unwrite(root_id.as_identifier()).await?;
 
                         break Ok(node.into_branch().unwrap());
                     }
@@ -491,7 +491,7 @@ impl BasicIndexer for StaticIndexer {
 
                     loop {
                         if let Some(old_node) = item.tree.insert_children(item.key, node) {
-                            provider.unwrite(old_node.as_identifier()).await;
+                            provider.unwrite(old_node.as_identifier()).await?;
                         }
 
                         item.tree.total_size += data_size;
@@ -504,7 +504,7 @@ impl BasicIndexer for StaticIndexer {
                         if let Some(next) = stack.pop() {
                             item = next;
                         } else {
-                            provider.unwrite(root_id.as_identifier()).await;
+                            provider.unwrite(root_id.as_identifier()).await?;
 
                             break Ok((node.into_branch().unwrap(), existing_leaf_node));
                         }
@@ -535,7 +535,7 @@ impl BasicIndexer for StaticIndexer {
 
                 loop {
                     if let Some(old_node) = item.tree.remove_children(item.key) {
-                        provider.unwrite(old_node.as_identifier()).await;
+                        provider.unwrite(old_node.as_identifier()).await?;
                     }
 
                     if !item.tree.is_empty() {
@@ -550,7 +550,7 @@ impl BasicIndexer for StaticIndexer {
                         // to return.
                         //
                         // This should always return an empty tree.
-                        provider.unwrite(root_id.as_identifier()).await;
+                        provider.unwrite(root_id.as_identifier()).await?;
 
                         return Ok((
                             provider.write_tree(&Tree::default()).await?,
@@ -572,13 +572,13 @@ impl BasicIndexer for StaticIndexer {
                     if let Some(next) = stack.pop() {
                         item = next;
                     } else {
-                        provider.unwrite(root_id.as_identifier()).await;
+                        provider.unwrite(root_id.as_identifier()).await?;
 
                         break Ok((node.into_branch().unwrap(), existing_leaf_node));
                     }
 
                     if let Some(old_node) = item.tree.insert_children(item.key, node) {
-                        provider.unwrite(old_node.as_identifier()).await;
+                        provider.unwrite(old_node.as_identifier()).await?;
                     }
                 }
             }

--- a/crates/lgn-content-store/src/indexing/string_path_indexer.rs
+++ b/crates/lgn-content-store/src/indexing/string_path_indexer.rs
@@ -232,7 +232,7 @@ impl BasicIndexer for StringPathIndexer {
                     item.tree.count += 1;
 
                     if let Some(old_node) = item.tree.insert_children(item.key, node) {
-                        provider.unwrite(old_node.as_identifier()).await;
+                        provider.unwrite(old_node.as_identifier()).await?;
                     }
 
                     item.tree.total_size += size_delta;
@@ -242,7 +242,7 @@ impl BasicIndexer for StringPathIndexer {
                     if let Some(next) = stack.pop() {
                         item = next;
                     } else {
-                        provider.unwrite(root_id.as_identifier()).await;
+                        provider.unwrite(root_id.as_identifier()).await?;
 
                         break Ok(node.into_branch().unwrap());
                     }
@@ -271,7 +271,7 @@ impl BasicIndexer for StringPathIndexer {
 
                     loop {
                         if let Some(old_node) = item.tree.insert_children(item.key, node) {
-                            provider.unwrite(old_node.as_identifier()).await;
+                            provider.unwrite(old_node.as_identifier()).await?;
                         }
 
                         item.tree.total_size += data_size;
@@ -284,7 +284,7 @@ impl BasicIndexer for StringPathIndexer {
                         if let Some(next) = stack.pop() {
                             item = next;
                         } else {
-                            provider.unwrite(root_id.as_identifier()).await;
+                            provider.unwrite(root_id.as_identifier()).await?;
 
                             break Ok((node.into_branch().unwrap(), existing_leaf_node));
                         }
@@ -313,7 +313,7 @@ impl BasicIndexer for StringPathIndexer {
 
                 loop {
                     if let Some(old_node) = item.tree.remove_children(item.key) {
-                        provider.unwrite(old_node.as_identifier()).await;
+                        provider.unwrite(old_node.as_identifier()).await?;
                     }
 
                     if !item.tree.is_empty() || self.keep_empty_branches {
@@ -328,7 +328,7 @@ impl BasicIndexer for StringPathIndexer {
                         // to return.
                         //
                         // This should always return an empty tree.
-                        provider.unwrite(root_id.as_identifier()).await;
+                        provider.unwrite(root_id.as_identifier()).await?;
 
                         return Ok((
                             provider.write_tree(&Tree::default()).await?,
@@ -348,13 +348,13 @@ impl BasicIndexer for StringPathIndexer {
                     if let Some(next) = stack.pop() {
                         item = next;
                     } else {
-                        provider.unwrite(root_id.as_identifier()).await;
+                        provider.unwrite(root_id.as_identifier()).await?;
 
                         break Ok((node.into_branch().unwrap(), existing_leaf_node));
                     }
 
                     if let Some(old_node) = item.tree.insert_children(item.key, node) {
-                        provider.unwrite(old_node.as_identifier()).await;
+                        provider.unwrite(old_node.as_identifier()).await?;
                     }
                 }
             }


### PR DESCRIPTION
This PR adds an optional `unwrite_content` method on `ContentProvider` that allows some content providers to make efficient usage of their memory by deleting unreferenced content when it is known that said content is non-persistent anyway.