### PR TITLE
Analytics: Consistently generate colors from strings for metrics

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricColor.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricColor.ts
@@ -1,15 +1,5 @@
-import * as d3 from "d3";
+import { schemeCategory10 } from "d3";
 
-export function getMetricColor(name: string) {
-  const color = Math.abs(hashString(name)) % 10;
-  return d3.schemeCategory10[color];
-}
-
-function hashString(string: string): number {
-  let hash = 0;
-  for (let i = 0; i < string.length; i++) {
-    hash = string.charCodeAt(i) + ((hash << 5) - hash);
-    hash = hash & hash;
-  }
-  return hash;
+export function getMetricColor(index: number) {
+  return schemeCategory10[index % schemeCategory10.length];
 }

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricStore.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/Lib/MetricStore.ts
@@ -16,6 +16,8 @@ const lastUsedMetricStoreKey = "last-used-metric-store-key";
 
 export type MetricStore = ReturnType<typeof getMetricStore>;
 
+export type SelectedMetricStore = ReturnType<typeof getSelectedMetricStore>;
+
 export type RecentlyUsedMetricStore = ReturnType<
   typeof getRecentlyUsedMetricsStore
 >;
@@ -206,4 +208,10 @@ export function getMetricStore(
     switchHidden,
     clearSelection,
   };
+}
+
+export function getSelectedMetricStore(metricStore: MetricStore) {
+  return derived(metricStore, ($metricStore) =>
+    $metricStore.filter(({ selected }) => selected)
+  );
 }

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricLegend.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricLegend.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
+  import { getContext } from "svelte";
+
   import { getMetricColor } from "./Lib/MetricColor";
   import type { MetricState } from "./Lib/MetricState";
-  import type { MetricStore } from "./Lib/MetricStore";
 
-  export let metricStore: MetricStore;
   export let metric: MetricState;
+  export let index: number;
+
+  const metricStore = getContext("metrics-store");
 
   const iconMap = new Map<string, string>([
     ["us", "bi bi-hourglass-split"],
     ["frame_id", "bi bi-arrow-up-right"],
   ]);
 
-  $: color = metric.hidden ? "rgb(203 213 225)" : getMetricColor(metric.name);
+  $: color = getMetricColor(index);
 
   $: icon = iconMap.get(metric.unit);
 </script>
@@ -21,11 +24,11 @@
   on:click={() => metricStore.switchSelection(metric.name)}
 >
   <span class="h-4 w-4 block" style="background-color:{color}" />
-  <span class="text-sm flex space-x-1 {metric.hidden ? 'text' : 'black'}">
+  <span class="text-sm flex space-x-1 black">
     <span>{metric.name}</span>
     {#if metric.unit}<span style="color:{color}">({metric.unit})</span>{/if}
   </span>
   {#if icon}
-    <i class="{icon} {metric.hidden ? 'text' : 'headline'}" />
+    <i class="{icon} headline" />
   {/if}
 </div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricLegendGroup.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricLegendGroup.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-  import type { MetricStore } from "./Lib/MetricStore";
+  import { getContext } from "svelte";
+
   import MetricLegend from "./MetricLegend.svelte";
 
-  export let metricStore: MetricStore;
+  const selectedMetricStore = getContext("selected-metrics-store");
 </script>
 
 <div class="flex gap-3 flex-wrap">
-  {#each $metricStore as metric}
-    {#if metric.selected}
-      <MetricLegend {metricStore} {metric} />
-    {/if}
+  {#each $selectedMetricStore as metric, index}
+    <MetricLegend {metric} {index} />
   {/each}
 </div>

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricSelectionItem.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricSelectionItem.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
   import { getContext } from "svelte";
 
-  import { getMetricColor } from "./Lib/MetricColor";
   import type { MetricState } from "./Lib/MetricState";
 
   export let metric: MetricState;
 
   const metricStore = getContext("metrics-store");
-
-  $: color = getMetricColor(metric.name);
 </script>
 
 <div
@@ -17,16 +14,12 @@
 >
   <div class="metric-selection-item">
     <div>
-      <input
-        type="checkbox"
-        style="accent-color:{color}"
-        checked={metric.selected}
-      />
+      <input type="checkbox" checked={metric.selected} />
     </div>
     <div>
       {metric.name}
       {#if metric.unit}
-        <span style="color:{color}">
+        <span>
           ({metric.unit})
         </span>
       {/if}

--- a/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricTooltipItem.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Metric/MetricTooltipItem.svelte
@@ -1,23 +1,21 @@
 <script lang="ts">
-  import { getMetricColor } from "./Lib/MetricColor";
   import type { MetricPoint } from "./Lib/MetricPoint";
   import type { MetricState } from "./Lib/MetricState";
 
   export let metric: MetricState;
   export let value: MetricPoint | null;
-
-  $: color = getMetricColor(metric.name);
+  export let color: string;
 </script>
 
 <div class="flex align-middle justify-between gap-1 select-none">
   <div class="flex align-middle gap-1 ">
-    <span class="w-4 h-4 inline-block" style="background-color:{color}" />
+    <span class="w-4 h-4 inline-block" style={`background-color:${color}`} />
     <span class="overflow-hidden text-ellipsis">{metric.name}</span>
   </div>
   <div class="pl-2">
     <span class="font-semibold">{value?.value.toLocaleString()}</span>
     {#if metric.unit}
-      <span class="pl-1" style="color: {color}">({metric.unit})</span>
+      <span class="pl-1" style={`color:${color}`}>({metric.unit})</span>
     {/if}
   </div>
 </div>

--- a/npm-pkgs/lgn-analytics-gui/src/types/context.d.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/types/context.d.ts
@@ -10,6 +10,7 @@ import type {
   MetricConfigStore,
   MetricStore,
   RecentlyUsedMetricStore,
+  SelectedMetricStore,
 } from "@/components/Metric/Lib/MetricStore";
 
 declare module "svelte" {
@@ -35,6 +36,10 @@ declare module "svelte" {
 
   // Metrics
   function setContext(key: "metrics-store", context: MetricStore): MetricStore;
+  function setContext(
+    key: "selected-metrics-store",
+    context: SelectedMetricStore
+  ): SelectedMetricStore;
   function setContext(
     key: "metrics-config-store",
     context: MetricConfigStore
@@ -65,6 +70,7 @@ declare module "svelte" {
 
   // Metrics
   function getContext(key: "metrics-store"): MetricStore;
+  function getContext(key: "selected-metrics-store"): SelectedMetricStore;
   function getContext(key: "metrics-config-store"): MetricConfigStore;
   function getContext(
     key: "recently-used-metrics-store"


### PR DESCRIPTION
Addresses https://github.com/legion-labs/legion/issues/1921

We used to pick a pseudo-random (seed based, using the name of the metric) color among 10 colors (using [d3.schemeCategory10](https://github.com/d3/d3-scale-chromatic/blob/main/README.md#categorical)), this pr generates a color, any color, from a name. The result is predictable and consistent, but it doesn't look as good as it used to 😕 

Here is what it looks like after activating ~15 metrics:

![new-colors](https://user-images.githubusercontent.com/94377405/171502290-2cbac2d3-dd69-4f8f-ac4d-cc2f481f6626.png)


Any concerns @mad-legion @timnitsas-legion @juanlegion ?