### PR TITLE
[api-codegen] Include status code in generated response types

### DIFF
--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -741,7 +741,7 @@ pub mod models {
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-    pub enum TestOneOfResponse {
+    pub enum TestOneOf200Response {
         #[serde(rename = "option1")]
         Option1(super::models::Pet),
         #[serde(rename = "option2")]
@@ -878,7 +878,7 @@ pub mod responses {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum TestOneOfResponse {
         /// Ok.
-        Status200(super::models::TestOneOfResponse),
+        Status200(super::models::TestOneOf200Response),
     }
 
     impl TestOneOfResponse {

--- a/crates/lgn-api-codegen/src/typescript/snapshots/lgn_api_codegen__typescript__tests__ts_generation.snap
+++ b/crates/lgn-api-codegen/src/typescript/snapshots/lgn_api_codegen__typescript__tests__ts_generation.snap
@@ -441,7 +441,7 @@ export class Client implements Api {
         
 
     
-            export type TestOneOfResponseModel = (| { type: "option1", value: PetModel }| { type: "option2", value: CarModel });
+            export type TestOneOf200ResponseModel = (| { type: "option1", value: PetModel }| { type: "option2", value: CarModel });
         
 
 
@@ -507,7 +507,7 @@ export class Client implements Api {
     
         
         
-        export type TestOneOfResponse = (| { /** Ok. */ type: "200", value: TestOneOfResponseModel });
+        export type TestOneOfResponse = (| { /** Ok. */ type: "200", value: TestOneOf200ResponseModel });
 
         export const TestOneOfResponse = {
             async fromResponse(response: Response): Promise<TestOneOfResponse> {

--- a/crates/lgn-api-codegen/src/visitor.rs
+++ b/crates/lgn-api-codegen/src/visitor.rs
@@ -191,8 +191,8 @@ impl Visitor {
 
                     let type_ = match &media_type_data.schema {
                         Some(schema_ref) => Some({
-                            let name = format!("{}_response", operation_name).to_case(Case::Pascal);
-
+                            let name = format!("{}_{}_response", operation_name, status_code)
+                                .to_case(Case::Pascal);
                             self.resolve_type_ref(
                                 &name.as_str().into(),
                                 &response.as_element_ref(schema_ref),
@@ -1376,7 +1376,7 @@ mod tests {
         let api: Api = oas.try_into().unwrap();
 
         let expected_one_of = Model {
-            name: "TestOneOfResponse".to_string(),
+            name: "TestOneOf200Response".to_string(),
             description: None,
             type_: Type::OneOf {
                 types: vec![
@@ -1387,7 +1387,10 @@ mod tests {
         };
 
         assert_eq!(api.models.len(), 3);
-        assert_eq!(api.models.get("TestOneOfResponse"), Some(&expected_one_of));
+        assert_eq!(
+            api.models.get("TestOneOf200Response"),
+            Some(&expected_one_of)
+        );
     }
 
     #[test]

--- a/tests/api-codegen/src/api_impl.rs
+++ b/tests/api-codegen/src/api_impl.rs
@@ -78,7 +78,7 @@ impl Api for ApiImpl {
 
     async fn test_one_of(&self, context: &mut Context) -> Result<TestOneOfResponse> {
         Ok(TestOneOfResponse::Status200(
-            models::TestOneOfResponse::Option1(models::Pet {
+            models::TestOneOf200Response::Option1(models::Pet {
                 name: Some("Cat".to_string()),
             }),
         ))

--- a/tests/api-codegen/tests/api.rs
+++ b/tests/api-codegen/tests/api.rs
@@ -98,7 +98,7 @@ async fn test_one_of() {
     let resp = client.test_one_of(&mut ctx).await.unwrap();
     assert_eq!(
         resp,
-        TestOneOfResponse::Status200(models::TestOneOfResponse::Option1(models::Pet {
+        TestOneOfResponse::Status200(models::TestOneOf200Response::Option1(models::Pet {
             name: Some("Cat".to_string()),
         }),)
     );


### PR DESCRIPTION
This PR adds the status code into the generated response type names.