### PR TITLE
[tracing] Added log interop

### DIFF
--- a/crates/lgn-tracing/Cargo.toml
+++ b/crates/lgn-tracing/Cargo.toml
@@ -21,13 +21,14 @@ memoffset = "0.6"
 thread-id = "4.0"
 lazy_static = "1.4"
 pin-project-lite = "0.2.9"
+log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-# to tests interop
-log = "0.4"
 
 [features]
+default = ["log_interop"]
+
 max_level_off = []
 max_level_error = []
 max_level_warn = []
@@ -51,6 +52,8 @@ release_max_lod_off = []
 release_max_lod_min = []
 release_max_lod_med = []
 release_max_lod_max = []
+
+log_interop = ["log"]
 
 [[bench]]
 name = "with_no_dispatch"

--- a/crates/lgn-tracing/src/interop.rs
+++ b/crates/lgn-tracing/src/interop.rs
@@ -1,0 +1,42 @@
+use std::sync::atomic::AtomicU32;
+
+use crate::{
+    dispatch::{flush_log_buffer, log_enabled, log_interop},
+    logs::{LogMetadata, FILTER_LEVEL_UNSET_VALUE},
+};
+
+pub struct LogDispatch;
+
+impl log::Log for LogDispatch {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        let log_metadata = LogMetadata {
+            level: metadata.level().into(),
+            level_filter: AtomicU32::new(0),
+            fmt_str: "",
+            target: "unknown",
+            module_path: "unknown",
+            file: "unknown",
+            line: 0,
+        };
+
+        log_enabled(&log_metadata)
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        let log_metadata = LogMetadata {
+            level: record.level().into(),
+            level_filter: AtomicU32::new(FILTER_LEVEL_UNSET_VALUE),
+            fmt_str: record.args().as_str().unwrap_or_default(),
+            target: record.module_path_static().unwrap_or("unknown"),
+            module_path: record.module_path_static().unwrap_or("unknown"),
+            file: record.file_static().unwrap_or("unknown"),
+            line: record.line().unwrap_or_default(),
+        };
+
+        log_interop(&log_metadata, *record.args());
+    }
+
+    fn flush(&self) {
+        flush_log_buffer();
+    }
+}

--- a/crates/lgn-tracing/src/levels.rs
+++ b/crates/lgn-tracing/src/levels.rs
@@ -44,6 +44,32 @@ impl Level {
     }
 }
 
+#[cfg(feature = "log_interop")]
+impl From<log::Level> for Level {
+    fn from(level: log::Level) -> Self {
+        match level {
+            log::Level::Error => Self::Error,
+            log::Level::Warn => Self::Warn,
+            log::Level::Info => Self::Info,
+            log::Level::Debug => Self::Debug,
+            log::Level::Trace => Self::Trace,
+        }
+    }
+}
+
+#[cfg(feature = "log_interop")]
+impl From<Level> for log::Level {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Error => Self::Error,
+            Level::Warn => Self::Warn,
+            Level::Info => Self::Info,
+            Level::Debug => Self::Debug,
+            Level::Trace => Self::Trace,
+        }
+    }
+}
+
 /// An enum representing the available verbosity level filters of the logger.
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
@@ -60,6 +86,34 @@ pub enum LevelFilter {
     Debug,
     /// Corresponds to the `Trace` log level.
     Trace,
+}
+
+#[cfg(feature = "log_interop")]
+impl From<log::LevelFilter> for LevelFilter {
+    fn from(level: log::LevelFilter) -> Self {
+        match level {
+            log::LevelFilter::Off => Self::Off,
+            log::LevelFilter::Error => Self::Error,
+            log::LevelFilter::Warn => Self::Warn,
+            log::LevelFilter::Info => Self::Info,
+            log::LevelFilter::Debug => Self::Debug,
+            log::LevelFilter::Trace => Self::Trace,
+        }
+    }
+}
+
+#[cfg(feature = "log_interop")]
+impl From<LevelFilter> for log::LevelFilter {
+    fn from(level: LevelFilter) -> Self {
+        match level {
+            LevelFilter::Off => Self::Off,
+            LevelFilter::Error => Self::Error,
+            LevelFilter::Warn => Self::Warn,
+            LevelFilter::Info => Self::Info,
+            LevelFilter::Debug => Self::Debug,
+            LevelFilter::Trace => Self::Trace,
+        }
+    }
 }
 
 impl PartialEq<LevelFilter> for Level {

--- a/crates/lgn-tracing/src/lib.rs
+++ b/crates/lgn-tracing/src/lib.rs
@@ -74,6 +74,9 @@ pub mod panic_hook;
 pub mod spans;
 pub mod string_id;
 
+#[cfg(feature = "log_interop")]
+pub mod interop;
+
 #[macro_use]
 mod macros;
 pub mod flush_monitor;

--- a/crates/lgn-tracing/tests/utils.rs
+++ b/crates/lgn-tracing/tests/utils.rs
@@ -1,10 +1,9 @@
 use std::{
     fmt,
-    sync::{atomic::AtomicU32, Arc, Mutex},
+    sync::{Arc, Mutex},
 };
 
 use lgn_tracing::{
-    dispatch::{flush_log_buffer, log_enabled, log_interop},
     event::EventSink,
     logs::{LogBlock, LogMetadata, LogMsgQueueAny, LogStream},
     metrics::{MetricsBlock, MetricsMsgQueueAny, MetricsStream},
@@ -108,53 +107,6 @@ impl EventSink for DebugEventSink {
 
     fn is_busy(&self) -> bool {
         false
-    }
-}
-
-pub struct LogDispatch;
-
-impl log::Log for LogDispatch {
-    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
-        let level = match metadata.level() {
-            log::Level::Error => Level::Error,
-            log::Level::Warn => Level::Warn,
-            log::Level::Info => Level::Info,
-            log::Level::Debug => Level::Debug,
-            log::Level::Trace => Level::Trace,
-        };
-        let log_metadata = LogMetadata {
-            level,
-            level_filter: AtomicU32::new(0),
-            fmt_str: "",
-            target: "unknown",
-            module_path: "unknown",
-            file: "unknown",
-            line: 0,
-        };
-        log_enabled(&log_metadata)
-    }
-
-    fn log(&self, record: &log::Record<'_>) {
-        let level = match record.level() {
-            log::Level::Error => Level::Error,
-            log::Level::Warn => Level::Warn,
-            log::Level::Info => Level::Info,
-            log::Level::Debug => Level::Debug,
-            log::Level::Trace => Level::Trace,
-        };
-        let log_metadata = LogMetadata {
-            level,
-            level_filter: AtomicU32::new(0),
-            fmt_str: record.args().as_str().unwrap_or(""),
-            target: record.module_path_static().unwrap_or("unknown"),
-            module_path: record.module_path_static().unwrap_or("unknown"),
-            file: record.file_static().unwrap_or("unknown"),
-            line: record.line().unwrap_or(0),
-        };
-        log_interop(&log_metadata, *record.args());
-    }
-    fn flush(&self) {
-        flush_log_buffer();
     }
 }
 


### PR DESCRIPTION
This PR adds some interop functions between `lgn-tracing` and `log` similar types (`Level`, `LevelFilter`).

It also removes some code duplication between `lgn-tracing` and `lgn-telemetry-sink`.