### PR TITLE
[api-codegen] Add percent encoding to header values

### DIFF
--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -158,11 +158,33 @@ pub mod client {
                 req.headers_mut().extend(headers);
             }
 
-            if let Some(x_static_header) = request.x_static_header {
+            if let Some(x_string_header) = request.x_string_header {
+                let x_string_header =
+                    lgn_online::codegen::encoding::to_percent_encoded_string(&x_string_header)?;
                 req.headers_mut().insert(
-                    "x-static-header",
-                    HeaderValue::from_str(&x_static_header)
-                        .map_err(|err| Error::InvalidHeader(format!("x-static-header: {}", err)))?,
+                    "x-string-header",
+                    HeaderValue::from_str(&x_string_header)
+                        .map_err(|err| Error::InvalidHeader(format!("x-string-header: {}", err)))?,
+                );
+            }
+
+            if let Some(x_bytes_header) = request.x_bytes_header {
+                let x_bytes_header =
+                    lgn_online::codegen::encoding::to_percent_encoded_string(&x_bytes_header)?;
+                req.headers_mut().insert(
+                    "x-bytes-header",
+                    HeaderValue::from_str(&x_bytes_header)
+                        .map_err(|err| Error::InvalidHeader(format!("x-bytes-header: {}", err)))?,
+                );
+            }
+
+            if let Some(x_int_header) = request.x_int_header {
+                let x_int_header =
+                    lgn_online::codegen::encoding::to_percent_encoded_string(&x_int_header)?;
+                req.headers_mut().insert(
+                    "x-int-header",
+                    HeaderValue::from_str(&x_int_header)
+                        .map_err(|err| Error::InvalidHeader(format!("x-int-header: {}", err)))?,
                 );
             }
             let resp = self.inner.request(req).await?;
@@ -266,6 +288,7 @@ pub mod client {
                 .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
             if let Some(span_id) = request.span_id {
+                let span_id = lgn_online::codegen::encoding::to_percent_encoded_string(&span_id)?;
                 req.headers_mut().insert(
                     "span-id",
                     HeaderValue::from_str(&span_id)
@@ -437,25 +460,65 @@ pub mod server {
     where
         T: super::Api + Send + Sync + 'static,
     {
-        let x_static_header = parts
+        let x_string_header = parts
             .headers
-            .get(HeaderName::from_static("x-static-header"));
-        let x_static_header = x_static_header.map(|x_static_header| {
-            x_static_header
-                .to_str()
-                .map_err(|err| {
-                    error!("Failed to read `x-static-header` header: {}", err);
-                    Error::InvalidHeader("x-static-header".to_owned()).into_response()
-                })
-                .unwrap()
-                .to_owned()
-        });
+            .get(HeaderName::from_static("x-string-header"))
+            .map(|h| {
+                let s = h
+                    .to_str()
+                    .map_err(|err| {
+                        Error::InvalidHeader("x-string-header".to_owned()).into_response()
+                    })
+                    .unwrap();
+
+                lgn_online::codegen::encoding::from_percent_encoded_string(s)
+                    .map_err(|err| {
+                        Error::InvalidHeader("x-string-header".to_owned()).into_response()
+                    })
+                    .unwrap()
+            });
+
+        let x_bytes_header = parts
+            .headers
+            .get(HeaderName::from_static("x-bytes-header"))
+            .map(|h| {
+                let s = h
+                    .to_str()
+                    .map_err(|err| {
+                        Error::InvalidHeader("x-bytes-header".to_owned()).into_response()
+                    })
+                    .unwrap();
+
+                lgn_online::codegen::encoding::from_percent_encoded_string(s)
+                    .map_err(|err| {
+                        Error::InvalidHeader("x-bytes-header".to_owned()).into_response()
+                    })
+                    .unwrap()
+            });
+
+        let x_int_header = parts
+            .headers
+            .get(HeaderName::from_static("x-int-header"))
+            .map(|h| {
+                let s = h
+                    .to_str()
+                    .map_err(|err| Error::InvalidHeader("x-int-header".to_owned()).into_response())
+                    .unwrap();
+
+                lgn_online::codegen::encoding::from_percent_encoded_string(s)
+                    .map_err(|err| Error::InvalidHeader("x-int-header".to_owned()).into_response())
+                    .unwrap()
+            });
 
         let mut context = Context::default();
         context.set_request_addr(addr);
         context.set_request(parts);
 
-        let request = requests::TestHeadersRequest { x_static_header };
+        let request = requests::TestHeadersRequest {
+            x_string_header,
+            x_bytes_header,
+            x_int_header,
+        };
 
         let resp = api.test_headers(&mut context, request).await;
         let mut resp = match resp {
@@ -550,17 +613,19 @@ pub mod server {
     where
         T: super::Api + Send + Sync + 'static,
     {
-        let span_id = parts.headers.get(HeaderName::from_static("span-id"));
-        let span_id = span_id.map(|span_id| {
-            span_id
-                .to_str()
-                .map_err(|err| {
-                    error!("Failed to read `span-id` header: {}", err);
-                    Error::InvalidHeader("span-id".to_owned()).into_response()
-                })
-                .unwrap()
-                .to_owned()
-        });
+        let span_id = parts
+            .headers
+            .get(HeaderName::from_static("span-id"))
+            .map(|h| {
+                let s = h
+                    .to_str()
+                    .map_err(|err| Error::InvalidHeader("span-id".to_owned()).into_response())
+                    .unwrap();
+
+                lgn_online::codegen::encoding::from_percent_encoded_string(s)
+                    .map_err(|err| Error::InvalidHeader("span-id".to_owned()).into_response())
+                    .unwrap()
+            });
 
         let mut context = Context::default();
         context.set_request_addr(addr);
@@ -770,7 +835,9 @@ pub mod requests {
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct TestHeadersRequest {
-        pub x_static_header: Option<String>,
+        pub x_string_header: Option<String>,
+        pub x_bytes_header: Option<Bytes>,
+        pub x_int_header: Option<i32>,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -822,7 +889,9 @@ pub mod responses {
     pub enum TestHeadersResponse {
         /// Ok.
         Status200 {
-            x_static_header: String,
+            x_bytes_header: Bytes,
+            x_int_header: i32,
+            x_string_header: String,
             body: super::models::Pet,
         },
     }
@@ -831,15 +900,61 @@ pub mod responses {
         pub(crate) fn into_response(self) -> Response {
             match self {
                 TestHeadersResponse::Status200 {
-                    x_static_header,
+                    x_bytes_header,
+                    x_int_header,
+                    x_string_header,
                     body,
                 } => {
                     let body = Json(body);
                     let mut resp = (StatusCode::from_u16(200).unwrap(), body).into_response();
-                    match HeaderValue::from_str(&x_static_header) {
-                        Ok(value) => resp.headers_mut().insert("x-static-header", value),
+                    let x_bytes_header_value =
+                        match lgn_online::codegen::encoding::to_percent_encoded_string(
+                            &x_bytes_header,
+                        ) {
+                            Ok(value) => value,
+                            Err(err) => {
+                                return Error::InvalidHeader(format!("x-bytes-header: {}", err))
+                                    .into_response();
+                            }
+                        };
+                    match HeaderValue::from_str(&x_bytes_header_value) {
+                        Ok(value) => resp.headers_mut().insert("x-bytes-header", value),
                         Err(err) => {
-                            return Error::InvalidHeader(format!("x-static-header: {}", err))
+                            return Error::InvalidHeader(format!("x-bytes-header: {}", err))
+                                .into_response();
+                        }
+                    };
+                    let x_int_header_value =
+                        match lgn_online::codegen::encoding::to_percent_encoded_string(
+                            &x_int_header,
+                        ) {
+                            Ok(value) => value,
+                            Err(err) => {
+                                return Error::InvalidHeader(format!("x-int-header: {}", err))
+                                    .into_response();
+                            }
+                        };
+                    match HeaderValue::from_str(&x_int_header_value) {
+                        Ok(value) => resp.headers_mut().insert("x-int-header", value),
+                        Err(err) => {
+                            return Error::InvalidHeader(format!("x-int-header: {}", err))
+                                .into_response();
+                        }
+                    };
+                    let x_string_header_value =
+                        match lgn_online::codegen::encoding::to_percent_encoded_string(
+                            &x_string_header,
+                        ) {
+                            Ok(value) => value,
+                            Err(err) => {
+                                return Error::InvalidHeader(format!("x-string-header: {}", err))
+                                    .into_response();
+                            }
+                        };
+                    match HeaderValue::from_str(&x_string_header_value) {
+                        Ok(value) => resp.headers_mut().insert("x-string-header", value),
+                        Err(err) => {
+                            return Error::InvalidHeader(format!("x-string-header: {}", err))
                                 .into_response();
                         }
                     };
@@ -854,16 +969,37 @@ pub mod responses {
         ) -> Result<Self> {
             match parts.status.as_u16() {
                 200 => {
-                    let x_static_header = parts
+                    let x_bytes_header = parts
                         .headers
-                        .get("x-static-header")
-                        .ok_or_else(|| Error::MissingHeader("x-static-header".to_owned()))?
+                        .get("x-bytes-header")
+                        .ok_or_else(|| Error::MissingHeader("x-bytes-header".to_owned()))?
                         .to_str()
-                        .map_err(|e| Error::InvalidHeader(format!("x-static-header: {}", e)))?;
+                        .map_err(|e| Error::InvalidHeader(format!("x-bytes-header: {}", e)))?;
+                    let x_int_header = parts
+                        .headers
+                        .get("x-int-header")
+                        .ok_or_else(|| Error::MissingHeader("x-int-header".to_owned()))?
+                        .to_str()
+                        .map_err(|e| Error::InvalidHeader(format!("x-int-header: {}", e)))?;
+                    let x_string_header = parts
+                        .headers
+                        .get("x-string-header")
+                        .ok_or_else(|| Error::MissingHeader("x-string-header".to_owned()))?
+                        .to_str()
+                        .map_err(|e| Error::InvalidHeader(format!("x-string-header: {}", e)))?;
                     let bytes = hyper::body::to_bytes(body).await?;
                     let body = serde_json::from_slice(&bytes)?;
                     Ok(Self::Status200 {
-                        x_static_header: x_static_header.to_string(),
+                        x_bytes_header: lgn_online::codegen::encoding::from_percent_encoded_string(
+                            x_bytes_header,
+                        )?,
+                        x_int_header: lgn_online::codegen::encoding::from_percent_encoded_string(
+                            x_int_header,
+                        )?,
+                        x_string_header:
+                            lgn_online::codegen::encoding::from_percent_encoded_string(
+                                x_string_header,
+                            )?,
                         body,
                     })
                 }

--- a/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
@@ -82,14 +82,16 @@ where
                 {%- for parameter in route.parameters.header -%}
                     {% let param_name = "{}"|format(parameter.name|snake_case) %}
                     {% if parameter.required -%}
+                        let {{ param_name }} = lgn_online::codegen::encoding::to_percent_encoded_string(&request.{{ param_name }})?;
                         req.headers_mut().insert(
                             "{{ parameter.name }}",
-                            HeaderValue::from_str(&request.{{ param_name }}).map_err(|err| {
+                            HeaderValue::from_str(&{{ param_name }}).map_err(|err| {
                                 Error::InvalidHeader(format!("{{ parameter.name }}: {}", err))
                             })?,
                         );
                     {% else -%}
                         if let Some({{ param_name }}) = request.{{ param_name }} {
+                            let {{ param_name }} = lgn_online::codegen::encoding::to_percent_encoded_string(&{{ param_name }})?;
                             req.headers_mut().insert(
                                 "{{ parameter.name }}",
                                 HeaderValue::from_str(&{{ param_name }}).map_err(|err| {

--- a/crates/lgn-api-codegen/src/rust/templates/responses.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/responses.rs.jinja
@@ -58,7 +58,13 @@ use http::HeaderValue;
                                     {% endif -%}
                                     let mut resp = (StatusCode::from_u16({{ status_code.as_u16() }}).unwrap(), body).into_response();
                                     {% for (header_name, header) in response.headers -%}
-                                        match HeaderValue::from_str(&{{ header_name|snake_case }}){
+                                        let {{ header_name|snake_case }}_value = match lgn_online::codegen::encoding::to_percent_encoded_string(&{{ header_name|snake_case }}){
+                                            Ok(value) => value,
+                                            Err(err) => {
+                                                return Error::InvalidHeader(format!("{{ header_name }}: {}", err)).into_response();
+                                            },
+                                        };
+                                        match HeaderValue::from_str(&{{ header_name|snake_case }}_value){
                                             Ok(value) => resp.headers_mut().insert("{{ header_name }}", value),
                                             Err(err) => {
                                                 return Error::InvalidHeader(format!("{{ header_name }}: {}", err)).into_response();
@@ -119,7 +125,7 @@ use http::HeaderValue;
 
                                         Ok(Self::Status{{ status_code }}{
                                             {% for (header_name, header) in response.headers -%}
-                                                {{ header_name|snake_case }}: {{ header_name|snake_case }}.to_string(),
+                                                {{ header_name|snake_case }}: lgn_online::codegen::encoding::from_percent_encoded_string({{ header_name|snake_case }})?,
                                             {% endfor -%}
                                             {% if let Some(content) = response.content -%}
                                                 body,

--- a/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
@@ -66,16 +66,20 @@ where
         {
             {%- for parameter in route.parameters.header -%}
             {% let param_name = "{}"|format(parameter.name|snake_case) %}
-                let {{ param_name }} = parts.headers.get(HeaderName::from_static("{{ parameter.name }}"));
-                let {{ param_name }} = {{ param_name }}.map(|{{ param_name }}| {
-                    {{ param_name }}
-                        .to_str()
+                let {{ param_name }} = parts.headers
+                    .get(HeaderName::from_static("{{ parameter.name }}"))
+                    .map(|h| {
+                        let s = h.to_str()
                         .map_err(|err| {
-                            error!("Failed to read `{{ parameter.name }}` header: {}", err);
+                            Error::InvalidHeader("{{ parameter.name }}".to_owned()).into_response()
+                        })
+                        .unwrap();
+
+                        lgn_online::codegen::encoding::from_percent_encoded_string(s)
+                        .map_err(|err| {
                             Error::InvalidHeader("{{ parameter.name }}".to_owned()).into_response()
                         })
                         .unwrap()
-                        .to_owned()
                 });
 
                 {% if parameter.required %}

--- a/crates/lgn-api-codegen/src/typescript/snapshots/lgn_api_codegen__typescript__tests__ts_generation.snap
+++ b/crates/lgn-api-codegen/src/typescript/snapshots/lgn_api_codegen__typescript__tests__ts_generation.snap
@@ -21,7 +21,9 @@ export interface Api {
     
     
     headers: {
-        "x-static-header"?: string;
+        "x-string-header"?: string;
+        "x-bytes-header"?: Blob;
+        "x-int-header"?: number;
         },
     
     
@@ -153,7 +155,9 @@ export class Client implements Api {
     
     
     headers: {
-        "x-static-header"?: string;
+        "x-string-header"?: string;
+        "x-bytes-header"?: Blob;
+        "x-int-header"?: number;
         },
     
     

--- a/crates/lgn-api-codegen/src/visitor.rs
+++ b/crates/lgn-api-codegen/src/visitor.rs
@@ -115,10 +115,15 @@ impl Visitor {
                     )?);
                 }
                 openapiv3::Parameter::Header { parameter_data, .. } => {
-                    // Only string header parameters are supported for now.
-                    // There is no standard on how to parse them so we just
-                    // forward the raw string value to the implementor.
-                    let allowed_types = Some(vec![Type::String]);
+                    let allowed_types = Some(vec![
+                        Type::String,
+                        Type::Int32,
+                        Type::Int64,
+                        Type::Boolean,
+                        Type::Float32,
+                        Type::Float64,
+                        Type::Bytes,
+                    ]);
                     parameters.header.push(self.visit_parameter(
                         path,
                         &parameter.as_element_ref(parameter_data),

--- a/crates/lgn-online/src/codegen/encoding/de.rs
+++ b/crates/lgn-online/src/codegen/encoding/de.rs
@@ -1,0 +1,168 @@
+use super::{Error, Result};
+use serde::{de::Visitor, Deserializer};
+use std::any::type_name;
+
+macro_rules! unsupported_type {
+    ($trait_fn:ident) => {
+        fn $trait_fn<V>(self, _: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            Err(Error::Unsupported(type_name::<V::Value>().to_string()))
+        }
+    };
+}
+
+macro_rules! deserialize_type {
+    ($trait_fn:ident, $visit_fn:ident, $ty:literal) => {
+        fn $trait_fn<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            let value = self.input.parse().map_err(|err| {
+                Error::Parsing(format!(
+                    "cannot parse {} to {}: {}",
+                    self.input.clone(),
+                    $ty,
+                    err
+                ))
+            })?;
+            visitor.$visit_fn(value)
+        }
+    };
+}
+
+#[derive(Default)]
+pub(crate) struct PercentEncodingDeserializer {
+    input: String,
+}
+
+impl<'de> PercentEncodingDeserializer {
+    pub(crate) fn new(input: &'de str) -> Result<Self> {
+        Ok(Self {
+            input: percent_encoding::percent_decode_str(input)
+                .decode_utf8()?
+                .to_string(),
+        })
+    }
+}
+
+impl<'de> Deserializer<'de> for &PercentEncodingDeserializer {
+    type Error = Error;
+
+    unsupported_type!(deserialize_any);
+    unsupported_type!(deserialize_bytes);
+    unsupported_type!(deserialize_option);
+    unsupported_type!(deserialize_identifier);
+    unsupported_type!(deserialize_ignored_any);
+
+    deserialize_type!(deserialize_bool, visit_bool, "bool");
+    deserialize_type!(deserialize_i8, visit_i8, "i8");
+    deserialize_type!(deserialize_i16, visit_i16, "i16");
+    deserialize_type!(deserialize_i32, visit_i32, "i32");
+    deserialize_type!(deserialize_i64, visit_i64, "i64");
+    deserialize_type!(deserialize_i128, visit_i128, "i128");
+    deserialize_type!(deserialize_u8, visit_u8, "u8");
+    deserialize_type!(deserialize_u16, visit_u16, "u16");
+    deserialize_type!(deserialize_u32, visit_u32, "u32");
+    deserialize_type!(deserialize_u64, visit_u64, "u64");
+    deserialize_type!(deserialize_u128, visit_u128, "u128");
+    deserialize_type!(deserialize_f32, visit_f32, "f32");
+    deserialize_type!(deserialize_f64, visit_f64, "f64");
+    deserialize_type!(deserialize_string, visit_string, "String");
+    deserialize_type!(deserialize_byte_buf, visit_string, "String");
+    deserialize_type!(deserialize_char, visit_char, "char");
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_str(self.input.as_str())
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Unsupported(format!("<newtype struct {}>", name)))
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Unsupported("<seq>".to_string()))
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Unsupported("<tuple>".to_string()))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Unsupported(format!("<tuple struct {}>", name)))
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Unsupported("<map>".to_string()))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Unsupported(format!("<struct {}>", name)))
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::Unsupported(format!("<enum {}>", name)))
+    }
+}

--- a/crates/lgn-online/src/codegen/encoding/errors.rs
+++ b/crates/lgn-online/src/codegen/encoding/errors.rs
@@ -4,6 +4,10 @@ use thiserror::Error;
 pub enum Error {
     #[error("complex type `{0}` cannot be percent encoded")]
     Unsupported(String),
+    #[error("parsing error: {0}")]
+    Parsing(String),
+    #[error("utf8 error: {0}")]
+    Utf8(#[from] std::str::Utf8Error),
     #[error(transparent)]
     Unknown(#[from] anyhow::Error),
 }
@@ -15,6 +19,12 @@ impl Error {
 }
 
 impl serde::ser::Error for Error {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        Self::Unknown(anyhow::anyhow!("{}", msg))
+    }
+}
+
+impl serde::de::Error for Error {
     fn custom<T: std::fmt::Display>(msg: T) -> Self {
         Self::Unknown(anyhow::anyhow!("{}", msg))
     }

--- a/crates/lgn-online/src/codegen/encoding/mod.rs
+++ b/crates/lgn-online/src/codegen/encoding/mod.rs
@@ -1,18 +1,11 @@
-use percent_encoding::{utf8_percent_encode, AsciiSet};
-
+mod de;
 mod errors;
+mod ser;
 
 pub use errors::{Error, Result};
-use serde::Serialize;
 
-pub fn to_percent_encoded_string<T>(value: &T) -> Result<String>
-where
-    T: Serialize,
-{
-    let mut serializer = PercentEncodingSerializer::default();
-
-    value.serialize(&mut serializer)
-}
+use percent_encoding::AsciiSet;
+use serde::{Deserialize, Serialize};
 
 const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
     .add(b' ')
@@ -21,321 +14,31 @@ const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
     .add(b'>')
     .add(b'`');
 
-#[derive(Default)]
-struct PercentEncodingSerializer {}
-
-impl PercentEncodingSerializer {
-    #[allow(clippy::unnecessary_wraps)]
-    fn serialize_as_string<T: std::fmt::Display>(v: T) -> Result<String> {
-        Ok(utf8_percent_encode(&v.to_string(), FRAGMENT_ENCODE_SET).to_string())
-    }
+pub fn to_percent_encoded_string<T>(value: &T) -> Result<String>
+where
+    T: Serialize,
+{
+    let mut serializer = ser::PercentEncodingSerializer::default();
+    value.serialize(&mut serializer)
 }
 
-impl<'a> serde::ser::Serializer for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-    type SerializeSeq = Self;
-    type SerializeTuple = Self;
-    type SerializeTupleStruct = Self;
-    type SerializeTupleVariant = Self;
-    type SerializeMap = Self;
-    type SerializeStruct = Self;
-    type SerializeStructVariant = Self;
-
-    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        PercentEncodingSerializer::serialize_as_string(v)
-    }
-
-    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Err(Error::unsupported(v))
-    }
-
-    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<none>".to_string()))
-    }
-
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        value.serialize(self)
-    }
-
-    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<unit>".to_string()))
-    }
-
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.serialize_unit()
-    }
-
-    fn serialize_unit_variant(
-        self,
-        name: &'static str,
-        _variant_index: u32,
-        variant: &'static str,
-    ) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported(format!(
-            "<unit variant {} {}>",
-            name, variant
-        )))
-    }
-
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        name: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported(format!("<newtype struct {}>", name)))
-    }
-
-    fn serialize_newtype_variant<T: ?Sized>(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<newtype variant>".to_string()))
-    }
-
-    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(Error::Unsupported("<seq>".to_string()))
-    }
-
-    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(Error::Unsupported("<tuple>".to_string()))
-    }
-
-    fn serialize_tuple_struct(
-        self,
-        name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(Error::Unsupported(format!("<tuple struct {}>", name)))
-    }
-
-    fn serialize_tuple_variant(
-        self,
-        name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(Error::Unsupported(format!("<tuple variant {}>", name)))
-    }
-
-    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(Error::Unsupported("<map>".to_string()))
-    }
-
-    fn serialize_struct(
-        self,
-        name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(Error::Unsupported(format!("<struct {}>", name)))
-    }
-
-    fn serialize_struct_variant(
-        self,
-        name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(Error::Unsupported(format!("<struct variant {}>", name)))
-    }
-}
-
-impl<'a> serde::ser::SerializeSeq for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-
-    fn serialize_element<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<seq element>".to_string()))
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<seq end>".to_string()))
-    }
-}
-
-impl<'a> serde::ser::SerializeTuple for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-
-    fn serialize_element<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<tuple element>".to_string()))
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<tuple end>".to_string()))
-    }
-}
-
-impl<'a> serde::ser::SerializeTupleStruct for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<tuple struct field>".to_string()))
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<tuple struct end>".to_string()))
-    }
-}
-
-impl<'a> serde::ser::SerializeTupleVariant for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<tuple variant field>".to_string()))
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<tuple variant end>".to_string()))
-    }
-}
-
-impl<'a> serde::ser::SerializeMap for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-
-    fn serialize_key<T: ?Sized>(&mut self, _key: &T) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<map key>".to_string()))
-    }
-
-    fn serialize_value<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<map value>".to_string()))
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<map end>".to_string()))
-    }
-}
-
-impl<'a> serde::ser::SerializeStruct for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        _key: &'static str,
-        _value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<struct field>".to_string()))
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<struct end>".to_string()))
-    }
-}
-
-impl<'a> serde::ser::SerializeStructVariant for &'a mut PercentEncodingSerializer {
-    type Ok = String;
-    type Error = Error;
-
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        _key: &'static str,
-        _value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        Err(Error::Unsupported("<struct variant field>".to_string()))
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("<struct variant end>".to_string()))
-    }
+pub fn from_percent_encoded_string<'de, T>(value: &str) -> Result<T>
+where
+    T: Deserialize<'de>,
+{
+    let deserializer = de::PercentEncodingDeserializer::new(value)?;
+    T::deserialize(&deserializer)
 }
 
 #[cfg(test)]
 mod tests {
     use serde::Serialize;
 
+    use crate::codegen::Bytes;
+
     pub use super::*;
 
-    #[derive(Serialize)]
+    #[derive(Debug, Serialize, Deserialize)]
     struct ComplexType {
         a: String,
         b: u32,
@@ -344,6 +47,10 @@ mod tests {
 
     #[test]
     fn test_to_percent_encoded_string() {
+        assert_eq!(
+            to_percent_encoded_string::<i32>(&2).unwrap(),
+            "2".to_string()
+        );
         assert_eq!(
             to_percent_encoded_string(&"foo").unwrap(),
             "foo".to_string()
@@ -356,6 +63,10 @@ mod tests {
             to_percent_encoded_string(&"this is a \"very\" <complex> val`ue").unwrap(),
             "this%20is%20a%20%22very%22%20%3Ccomplex%3E%20val%60ue".to_string()
         );
+        assert_eq!(
+            to_percent_encoded_string(&Bytes(b"1234".to_vec())).unwrap(),
+            "MTIzNA".to_string()
+        );
 
         // Some complex types are not supported.
         to_percent_encoded_string(&ComplexType {
@@ -364,5 +75,30 @@ mod tests {
             c: vec![1, 2, 3],
         })
         .unwrap_err();
+    }
+
+    #[test]
+    fn test_from_percent_encoded_string() {
+        assert_eq!(from_percent_encoded_string::<i32>("2").unwrap(), 2);
+        assert_eq!(
+            from_percent_encoded_string::<String>("foo").unwrap(),
+            "foo".to_string()
+        );
+        assert_eq!(
+            from_percent_encoded_string::<String>("hello%20world").unwrap(),
+            "hello world".to_string()
+        );
+        assert_eq!(
+            from_percent_encoded_string::<String>(
+                "this%20is%20a%20%22very%22%20%3Ccomplex%3E%20val%60ue"
+            )
+            .unwrap(),
+            "this is a \"very\" <complex> val`ue".to_string()
+        );
+        assert_eq!(
+            from_percent_encoded_string::<Bytes>("MTIzNA").unwrap(),
+            Bytes(b"1234".to_vec())
+        );
+        from_percent_encoded_string::<ComplexType>("{ a: \"foo\" }").unwrap_err();
     }
 }

--- a/crates/lgn-online/src/codegen/encoding/ser.rs
+++ b/crates/lgn-online/src/codegen/encoding/ser.rs
@@ -1,0 +1,310 @@
+use super::{Error, Result};
+use percent_encoding::utf8_percent_encode;
+
+#[derive(Default)]
+pub(crate) struct PercentEncodingSerializer {}
+
+impl PercentEncodingSerializer {
+    #[allow(clippy::unnecessary_wraps)]
+    fn serialize_as_string<T: std::fmt::Display>(v: T) -> Result<String> {
+        Ok(utf8_percent_encode(&v.to_string(), super::FRAGMENT_ENCODE_SET).to_string())
+    }
+}
+
+impl<'a> serde::ser::Serializer for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        PercentEncodingSerializer::serialize_as_string(v)
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Error::unsupported(v))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<none>".to_string()))
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<unit>".to_string()))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported(format!(
+            "<unit variant {} {}>",
+            name, variant
+        )))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported(format!("<newtype struct {}>", name)))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<newtype variant>".to_string()))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Error::Unsupported("<seq>".to_string()))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(Error::Unsupported("<tuple>".to_string()))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Error::Unsupported(format!("<tuple struct {}>", name)))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Error::Unsupported(format!("<tuple variant {}>", name)))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Error::Unsupported("<map>".to_string()))
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Error::Unsupported(format!("<struct {}>", name)))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Error::Unsupported(format!("<struct variant {}>", name)))
+    }
+}
+
+impl<'a> serde::ser::SerializeSeq for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<seq element>".to_string()))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<seq end>".to_string()))
+    }
+}
+
+impl<'a> serde::ser::SerializeTuple for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<tuple element>".to_string()))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<tuple end>".to_string()))
+    }
+}
+
+impl<'a> serde::ser::SerializeTupleStruct for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<tuple struct field>".to_string()))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<tuple struct end>".to_string()))
+    }
+}
+
+impl<'a> serde::ser::SerializeTupleVariant for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<tuple variant field>".to_string()))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<tuple variant end>".to_string()))
+    }
+}
+
+impl<'a> serde::ser::SerializeMap for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+
+    fn serialize_key<T: ?Sized>(&mut self, _key: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<map key>".to_string()))
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<map value>".to_string()))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<map end>".to_string()))
+    }
+}
+
+impl<'a> serde::ser::SerializeStruct for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        _key: &'static str,
+        _value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<struct field>".to_string()))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<struct end>".to_string()))
+    }
+}
+
+impl<'a> serde::ser::SerializeStructVariant for &'a mut PercentEncodingSerializer {
+    type Ok = String;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        _key: &'static str,
+        _value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        Err(Error::Unsupported("<struct variant field>".to_string()))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::Unsupported("<struct variant end>".to_string()))
+    }
+}

--- a/tests/api-codegen/cars.yaml
+++ b/tests/api-codegen/cars.yaml
@@ -116,10 +116,19 @@ paths:
     get:
       operationId: testHeaders
       parameters:
-        - name: x-static-header
+        - name: x-string-header
           in: header
           schema:
             type: string
+        - name: x-bytes-header
+          in: header
+          schema:
+            type: string
+            format: byte
+        - name: x-int-header
+          in: header
+          schema:
+            type: integer
       responses:
         "200":
           description: Ok.
@@ -128,9 +137,16 @@ paths:
               schema:
                 $ref: "#/components/schemas/Pet"
           headers:
-            x-static-header:
+            x-string-header:
               schema:
                 type: string
+            x-bytes-header:
+              schema:
+                type: string
+                format: byte
+            x-int-header:
+              schema:
+                type: integer
 components:
   parameters:
     SpaceId:

--- a/tests/api-codegen/src/api_impl.rs
+++ b/tests/api-codegen/src/api_impl.rs
@@ -96,7 +96,9 @@ impl Api for ApiImpl {
         }
 
         Ok(TestHeadersResponse::Status200 {
-            x_static_header: request.x_static_header.unwrap(),
+            x_string_header: request.x_string_header.unwrap(),
+            x_bytes_header: request.x_bytes_header.unwrap(),
+            x_int_header: request.x_int_header.unwrap(),
             body: models::Pet {
                 name: Some("Cat".to_string()),
             },

--- a/tests/api-codegen/tests/api.rs
+++ b/tests/api-codegen/tests/api.rs
@@ -122,7 +122,9 @@ async fn test_headers() {
     ctx.set_request_extensions(extensions);
     ctx.set_request_headers(headers);
     let req = TestHeadersRequest {
-        x_static_header: Some("static".to_string()),
+        x_string_header: Some("string".to_string()),
+        x_int_header: Some(5),
+        x_bytes_header: Some(b"bytes".to_vec().into()),
     };
     let resp = client.test_headers(&mut ctx, req).await.unwrap();
 
@@ -130,7 +132,9 @@ async fn test_headers() {
     assert_eq!(
         resp,
         TestHeadersResponse::Status200 {
-            x_static_header: "static".to_string(),
+            x_string_header: "string".to_string(),
+            x_int_header: 5,
+            x_bytes_header: b"bytes".to_vec().into(),
             body: models::Pet {
                 name: Some("Cat".to_string()),
             }


### PR DESCRIPTION
This PR adds a percent encoding deserializer to support the encoding and decoding of header values.