### PR TITLE
Web clients: Refresh token on request

### DIFF
--- a/npm-pkgs/lgn-analytics-gui/src/components/CallGraphHierachy/CallGraphHierachy.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/CallGraphHierachy/CallGraphHierachy.svelte
@@ -28,7 +28,7 @@
 
   onMount(async () => {
     store = await getProcessCumulatedCallGraphHierarchy(
-      $client,
+      client,
       processId,
       begin,
       end

--- a/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessItem.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/components/Process/ProcessItem.svelte
@@ -43,7 +43,7 @@
       return;
     }
 
-    ({ processes } = await $client.list_recent_processes({
+    ({ processes } = await client.list_recent_processes({
       parentProcessId: processInstance.processInfo?.processId,
     }));
   }

--- a/npm-pkgs/lgn-analytics-gui/src/constants.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/constants.ts
@@ -3,3 +3,6 @@ export const localeStorageKey = "locale";
 
 /** Abitrary thread item lenght used if the proper one cannot be computed, should never be used */
 export const threadItemLengthFallback = 170;
+
+export const accessTokenCookieName = "analytics_access_token_v2";
+export const refreshTokenCookieName = "analytics_refresh_token_v2";

--- a/npm-pkgs/lgn-analytics-gui/src/lib/client.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/lib/client.ts
@@ -1,11 +1,10 @@
-import { grpc } from "@improbable-eng/grpc-web";
-import { derived } from "svelte/store";
-import type { Readable } from "svelte/store";
-
 import {
   GrpcWebImpl,
   PerformanceAnalyticsClientImpl,
 } from "@lgn/proto-telemetry/dist/analytics";
+import { enhanceGrpcClient } from "@lgn/web-client/src/lib/grpcClient";
+
+import { accessTokenCookieName } from "@/constants";
 
 export function getRemoteHost(): string {
   return import.meta.env.VITE_LEGION_ANALYTICS_REMOTE_HOST as string;
@@ -15,22 +14,11 @@ export function getUrl(): string {
   return import.meta.env.VITE_LEGION_ANALYTICS_API_URL as string;
 }
 
-export function createGrpcClientStore(
-  accessTokenStore: Readable<string | null>
-) {
-  return derived(accessTokenStore, ($accessToken) => {
-    if ($accessToken === null) {
-      return new PerformanceAnalyticsClientImpl(new GrpcWebImpl(getUrl(), {}));
-    }
+export function createGrpcClient() {
+  const rpc = new GrpcWebImpl(getUrl(), {});
 
-    const metadata = new grpc.Metadata();
-
-    metadata.set("Authorization", `Bearer ${$accessToken}`);
-
-    const client = new PerformanceAnalyticsClientImpl(
-      new GrpcWebImpl(getUrl(), { metadata })
-    );
-
-    return client;
-  });
+  return enhanceGrpcClient(
+    new PerformanceAnalyticsClientImpl(rpc),
+    accessTokenCookieName
+  );
 }

--- a/npm-pkgs/lgn-analytics-gui/src/routes/__layout.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/__layout.svelte
@@ -34,8 +34,8 @@
           clientId,
           login: {
             cookies: {
-              accessToken: "analytics_access_token_v2",
-              refreshToken: "analytics_refresh_token_v2",
+              accessToken: accessTokenCookieName,
+              refreshToken: refreshTokenCookieName,
             },
             scopes: ["email", "openid", "profile"],
           },
@@ -82,7 +82,6 @@
   import log from "@lgn/web-client/src/lib/log";
   import { DefaultLocalStorage } from "@lgn/web-client/src/lib/storage";
   import { createL10nOrchestrator } from "@lgn/web-client/src/orchestrators/l10n";
-  import accessToken from "@lgn/web-client/src/stores/accessToken";
   import type { NotificationsStore } from "@lgn/web-client/src/stores/notifications";
   import { createThemeStore } from "@lgn/web-client/src/stores/theme";
 
@@ -91,11 +90,13 @@
   import LoadingBar from "@/components/Misc/LoadingBar.svelte";
   import { getThreadItemLength } from "@/components/Timeline/Values/TimelineValues";
   import {
+    accessTokenCookieName,
     localeStorageKey,
+    refreshTokenCookieName,
     themeStorageKey,
     threadItemLengthFallback,
   } from "@/constants";
-  import { createGrpcClientStore } from "@/lib/client";
+  import { createGrpcClient } from "@/lib/client";
 
   import "../assets/index.css";
 
@@ -141,7 +142,7 @@
 
   setContext(l10nOrchestratorContextKey, l10n);
 
-  setContext("http-client", createGrpcClientStore(accessToken));
+  setContext("http-client", createGrpcClient());
 
   setContext("notifications", notifications);
 

--- a/npm-pkgs/lgn-analytics-gui/src/routes/cumulative-call-graph/index.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/cumulative-call-graph/index.svelte
@@ -33,7 +33,7 @@
     loadingStore.reset(1);
 
     store = await getProcessCumulatedCallGraphFlat(
-      $client,
+      client,
       processId,
       beginMsFilter,
       endMsFilter,

--- a/npm-pkgs/lgn-analytics-gui/src/routes/index.svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/index.svelte
@@ -32,10 +32,10 @@
   function search(search: string) {
     return processesStore.run(async () => {
       const response = search.length
-        ? await $client.search_processes({
+        ? await client.search_processes({
             search,
           })
-        : await $client.list_recent_processes({ parentProcessId: undefined });
+        : await client.list_recent_processes({ parentProcessId: undefined });
 
       return response.processes;
     });

--- a/npm-pkgs/lgn-analytics-gui/src/routes/log/[processId].svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/log/[processId].svelte
@@ -57,11 +57,11 @@
 
   function fetchProcessInfo(processId: string) {
     return processStore.run(async () => {
-      const { count: nbEntries } = await $client.nb_process_log_entries({
+      const { count: nbEntries } = await client.nb_process_log_entries({
         processId,
       });
 
-      const { process } = await $client.find_process({
+      const { process } = await client.find_process({
         processId,
       });
 
@@ -84,7 +84,7 @@
     return logEntriesStore.run(async () => {
       const cleanSearch = search.trim();
 
-      const response = await $client.list_process_log_entries({
+      const response = await client.list_process_log_entries({
         process,
         begin: beginRange ?? 0,
         end: endRange ?? Math.min(nbEntries, MAX_NB_ENTRIES_IN_PAGE),

--- a/npm-pkgs/lgn-analytics-gui/src/routes/metrics/[processId].svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/metrics/[processId].svelte
@@ -162,7 +162,7 @@
 
   async function fetchMetrics() {
     metricStreamer = new MetricStreamer(
-      $client,
+      client,
       processId,
       metricStore,
       lastUsedMetricsStore,

--- a/npm-pkgs/lgn-analytics-gui/src/routes/timeline/[processId].svelte
+++ b/npm-pkgs/lgn-analytics-gui/src/routes/timeline/[processId].svelte
@@ -61,7 +61,7 @@
     const canvasWidth = windowInnerWidth - threadItemLength;
 
     stateManager = new TimelineStateManager(
-      $client,
+      client,
       processId,
       canvasWidth,
       start,
@@ -92,7 +92,7 @@
       import.meta.env.VITE_LEGION_ANALYTICS_ENABLE_TIMELINE_JIT_LAKEHOUSE ===
       "true"
     ) {
-      await $client.build_timeline_tables({
+      await client.build_timeline_tables({
         processId,
       });
     }

--- a/npm-pkgs/lgn-analytics-gui/src/types/context.d.ts
+++ b/npm-pkgs/lgn-analytics-gui/src/types/context.d.ts
@@ -1,4 +1,4 @@
-import type { Readable, Writable } from "svelte/store";
+import type { Writable } from "svelte/store";
 
 import type { PerformanceAnalyticsClientImpl } from "@lgn/proto-telemetry/dist/analytics";
 import { l10nOrchestratorContextKey } from "@lgn/web-client/src/constants";
@@ -23,7 +23,7 @@ declare module "svelte" {
   ): L10nOrchestrator<Fluent>;
   function setContext(
     key: "http-client",
-    context: Readable<PerformanceAnalyticsClientImpl>
+    context: PerformanceAnalyticsClientImpl
   ): PerformanceAnalyticsClientImpl;
   function setContext(
     key: "notifications",
@@ -62,9 +62,7 @@ declare module "svelte" {
   function getContext(
     key: typeof l10nOrchestratorContextKey
   ): L10nOrchestrator<Fluent>;
-  function getContext(
-    key: "http-client"
-  ): Readable<PerformanceAnalyticsClientImpl>;
+  function getContext(key: "http-client"): PerformanceAnalyticsClientImpl;
   function getContext(key: "notifications"): NotificationsStore<Fluent>;
   function getContext(key: "debug"): Writable<boolean>;
 

--- a/npm-pkgs/lgn-web-client/src/lib/grpcClient.ts
+++ b/npm-pkgs/lgn-web-client/src/lib/grpcClient.ts
@@ -1,0 +1,93 @@
+import { grpc } from "@improbable-eng/grpc-web";
+
+import { authClient } from "./auth";
+import { getCookie } from "./cookie";
+import log from "./log";
+
+/**
+ * Will create a Proxy around the provided GRPC client that will automatically refresh the token set
+ * if a request is performed when the user is not authenticated.
+ *
+ * _Warning: It's not possible to properly type the `client` argument,
+ * so pretty much anything will be accepted by this function, don't overuse it_
+ */
+export function enhanceGrpcClient(
+  client: object,
+  accessTokenCookieName: string,
+  { minLatency = 5 }: { minLatency?: number } = {}
+) {
+  const state = {
+    clientIsRefreshingToken: false,
+  };
+
+  return new Proxy(client, {
+    get(target, propertyKey) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const f: ((...args: unknown[]) => Promise<unknown>) | undefined =
+        Reflect.get(target, propertyKey);
+
+      if (!f) {
+        return;
+      }
+
+      return async function (
+        ...[params, metadataArg]: [unknown, grpc.Metadata | undefined]
+      ) {
+        if (state.clientIsRefreshingToken) {
+          await new Promise<void>((resolve) => {
+            const id = setInterval(() => {
+              if (!state.clientIsRefreshingToken) {
+                clearInterval(id);
+                resolve();
+              }
+            }, minLatency);
+          });
+        }
+
+        let accessToken = getCookie(accessTokenCookieName);
+
+        if (accessToken === null) {
+          state.clientIsRefreshingToken = true;
+
+          log.debug(
+            "http-client",
+            "Access token not found, trying to refresh the client token set"
+          );
+
+          try {
+            const clientTokenSet = await authClient.refreshClientTokenSet();
+
+            authClient.storeClientTokenSet(clientTokenSet);
+
+            accessToken = clientTokenSet.access_token;
+
+            state.clientIsRefreshingToken = false;
+          } catch {
+            log.debug(
+              "http-client",
+              "Couldn't refresh the client token set, redirecting to the idp"
+            );
+
+            state.clientIsRefreshingToken = false;
+
+            window.location.href = await authClient.getAuthorizationUrl();
+
+            return;
+          }
+        }
+
+        const metadata = new grpc.Metadata();
+
+        if (metadataArg) {
+          metadata.forEach((key, values) => {
+            metadata.set(key, values);
+          });
+        }
+
+        metadata.set("Authorization", `Bearer ${accessToken}`);
+
+        return f(params, metadata);
+      };
+    },
+  });
+}


### PR DESCRIPTION
Instead of checking for the access token each hour this pr will refresh it if a request is performed and the token is absent.

The logic is _slightly_ more complex and I had to use a Proxy for that.

@timnitsas-legion There's a new `enhanceGrpcClient` function exported by `@lgn/web-client`, it allows us to build a GRPC client that checks for authentication implicitly, if that's ok with you we can test this out on the editor side as well 🙂 