### PR TITLE
[api-codegen] Add Rust modules override support

### DIFF
--- a/crates/lgn-api-codegen-node/src/lib.rs
+++ b/crates/lgn-api-codegen-node/src/lib.rs
@@ -25,6 +25,7 @@ pub struct GenerateOption {
 pub fn generate(options: GenerateOption) -> Result<()> {
     if let Err(error) = lgn_api_codegen::generate(
         Language::TypeScript,
+        lgn_api_codegen::GenerationOptions::default(),
         &options.path,
         &options.api_names,
         &options.out_dir,

--- a/crates/lgn-api-codegen/src/api_types.rs
+++ b/crates/lgn-api-codegen/src/api_types.rs
@@ -1,5 +1,10 @@
 use std::{
-    collections::BTreeMap, fmt::Display, iter::Chain, path::PathBuf, slice::Iter, str::FromStr,
+    collections::{BTreeMap, HashMap},
+    fmt::Display,
+    iter::Chain,
+    path::PathBuf,
+    slice::Iter,
+    str::FromStr,
 };
 
 use crate::{
@@ -12,36 +17,50 @@ use crate::{
 pub struct GenerationContext {
     pub root: PathBuf,
     pub location_contexts: BTreeMap<OpenApiRefLocation, LocationContext>,
+    pub options: GenerationOptions,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GenerationOptions {
+    /// A mapping of files to Rust modules.
+    pub rust_module_mappings: HashMap<PathBuf, ModulePath>,
 }
 
 impl GenerationContext {
-    pub fn new(root: PathBuf) -> Self {
+    pub fn new(root: PathBuf, options: GenerationOptions) -> Self {
         Self {
             root,
             location_contexts: BTreeMap::new(),
+            options,
         }
     }
 
-    pub fn ref_loc_to_module_path(&self, ref_loc: &OpenApiRefLocation) -> Result<ModulePath> {
+    pub fn ref_loc_to_rust_module_path(&self, ref_loc: &OpenApiRefLocation) -> Result<ModulePath> {
         let file_path = ref_loc.path();
 
-        let file_path =
-            file_path
-                .strip_prefix(&self.root)
-                .map_err(|_err| Error::DocumentOutOfRoot {
-                    document_path: file_path.clone(),
-                    root: self.root.clone(),
+        Ok(
+            if let Some(module_path) = self.options.rust_module_mappings.get(file_path) {
+                module_path.clone()
+            } else {
+                let file_path = file_path.strip_prefix(&self.root).map_err(|_err| {
+                    Error::DocumentOutOfRoot {
+                        document_path: file_path.clone(),
+                        root: self.root.clone(),
+                    }
                 })?;
 
-        Ok(ModulePath(
-            file_path
-                .with_extension("")
-                .display()
-                .to_string()
-                .split('/')
-                .map(ToString::to_string)
-                .collect::<Vec<_>>(),
-        ))
+                ModulePath {
+                    absolute: false,
+                    parts: file_path
+                        .with_extension("")
+                        .display()
+                        .to_string()
+                        .split('/')
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
+                }
+            },
+        )
     }
 
     /// Returns the location context as modules relative to the root.
@@ -49,7 +68,7 @@ impl GenerationContext {
         self.location_contexts
             .iter()
             .map(|(ref_loc, api_ctx)| {
-                let module_path = self.ref_loc_to_module_path(ref_loc)?;
+                let module_path = self.ref_loc_to_rust_module_path(ref_loc)?;
 
                 Ok((module_path, api_ctx))
             })
@@ -69,13 +88,20 @@ impl GenerationContext {
     }
 }
 
-/// Represents a module path.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ModulePath(pub Vec<String>);
+/// Represents a module path, agnostic of the language.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModulePath {
+    absolute: bool,
+    parts: Vec<String>,
+}
 
 impl Display for ModulePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0.join("/"))
+        if self.absolute {
+            write!(f, "/{}", self.parts.join("/"))
+        } else {
+            write!(f, "{}", self.parts.join("/"))
+        }
     }
 }
 
@@ -83,47 +109,156 @@ impl FromStr for ModulePath {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.split('/').map(ToString::to_string).collect()))
+        let absolute = s.starts_with('/');
+
+        let parts = if absolute { &s[1..] } else { s }
+            .split('/')
+            .filter_map(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.to_string())
+                }
+            })
+            .collect();
+
+        Ok(Self { absolute, parts })
+    }
+}
+
+#[allow(clippy::fallible_impl_from)]
+impl<'a> From<&'a str> for ModulePath {
+    fn from(s: &'a str) -> Self {
+        Self::from_str(s).unwrap()
+    }
+}
+
+#[allow(clippy::fallible_impl_from)]
+impl From<String> for ModulePath {
+    fn from(s: String) -> Self {
+        Self::from_str(&s).unwrap()
     }
 }
 
 impl ModulePath {
-    pub fn join(&self, module: impl Into<String>) -> ModulePath {
-        let mut parts = self.0.clone();
-        parts.push(module.into());
-
-        Self(parts)
+    pub fn from_absolute_rust_module_path(s: &str) -> Self {
+        Self {
+            absolute: true,
+            parts: s
+                .split("::")
+                .filter_map(|s| {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        Some(s.to_string())
+                    }
+                })
+                .collect(),
+        }
     }
 
-    pub fn parent(&self) -> ModulePath {
-        Self(self.0[..self.0.len() - 1].to_vec())
+    pub fn to_rust_module_path(&self) -> String {
+        self.parts()
+            .iter()
+            .map(|s| (if s == ".." { "super" } else { s }).to_string())
+            .collect::<Vec<String>>()
+            .join("::")
     }
 
-    pub fn relative_to(&self, other: &ModulePath) -> ModulePath {
-        for (i, part) in self.0.iter().enumerate() {
-            if i >= other.0.len() {
+    #[inline]
+    pub fn is_absolute(&self) -> bool {
+        self.absolute
+    }
+
+    #[inline]
+    pub fn is_relative(&self) -> bool {
+        !self.absolute
+    }
+
+    #[inline]
+    pub fn parts(&self) -> &[String] {
+        &self.parts
+    }
+
+    /// Join this module path with another.
+    ///
+    /// If the other module path is absolute, this path is ignored.
+    #[must_use]
+    pub fn join(&self, module_path: impl Into<ModulePath>) -> Self {
+        let module_path = module_path.into();
+
+        if module_path.is_absolute() {
+            return module_path;
+        }
+
+        let mut parts = self.parts.clone();
+        parts.extend(module_path.parts);
+
+        Self {
+            absolute: self.absolute,
+            parts,
+        }
+    }
+
+    /// Return the parent of this module path.
+    pub fn parent(&self) -> Option<ModulePath> {
+        if self.parts.is_empty() {
+            None
+        } else {
+            Some(Self {
+                absolute: self.absolute,
+                parts: self.parts[..self.parts.len() - 1].to_vec(),
+            })
+        }
+    }
+
+    /// Return a module path such `self.join(module_path) == other`.
+    ///
+    /// As a special case, if only one of the paths is absolute, it will be
+    /// returned as is.
+    #[must_use]
+    pub fn relative_to(&self, other: &ModulePath) -> Self {
+        // We can only ever compare absolute paths and non-absolute paths with
+        // one another.
+        if self.absolute != other.absolute {
+            return if self.absolute {
+                self.clone()
+            } else {
+                other.clone()
+            };
+        }
+
+        for (i, part) in self.parts.iter().enumerate() {
+            if i >= other.parts.len() {
                 // The other is a prefix of us: just strip the beginnning.
-                return Self(self.0[i..].to_vec());
+                return Self {
+                    absolute: false,
+                    parts: self.parts[i..].to_vec(),
+                };
             }
 
-            if part != &other.0[i] {
-                let mut parts = other.0[i..]
+            if part != &other.parts[i] {
+                let mut parts = other.parts[i..]
                     .iter()
                     .map(|_| "..".to_string())
                     .collect::<Vec<_>>();
 
-                parts.extend(self.0[i..].iter().cloned());
+                parts.extend(self.parts[i..].iter().cloned());
 
-                return Self(parts);
+                return Self {
+                    absolute: false,
+                    parts,
+                };
             }
         }
 
-        Self(
-            other.0[self.0.len()..]
+        Self {
+            absolute: false,
+            parts: other.parts[self.parts.len()..]
                 .iter()
                 .map(|_| "..".to_string())
                 .collect(),
-        )
+        }
     }
 }
 
@@ -411,8 +546,18 @@ mod tests {
     #[test]
     fn test_module_path() {
         assert_eq!(
-            ModulePath(vec!["foo".to_string(), "bar".to_string()]),
+            ModulePath {
+                absolute: false,
+                parts: vec!["foo".to_string(), "bar".to_string()]
+            },
             "foo/bar".parse().unwrap()
+        );
+        assert_eq!(
+            ModulePath {
+                absolute: true,
+                parts: vec!["foo".to_string(), "bar".to_string()]
+            },
+            "/foo/bar".parse().unwrap()
         );
     }
 
@@ -420,8 +565,13 @@ mod tests {
     fn test_module_path_relative_to() {
         let current: ModulePath = "foo/bar/baz".parse().unwrap();
         let other: ModulePath = "foo/bar".parse().unwrap();
+        let abs: ModulePath = "/i/am/absolute".parse().unwrap();
 
         assert_eq!(other.relative_to(&current), "..".parse().unwrap());
         assert_eq!(current.relative_to(&other), "baz".parse().unwrap());
+        assert_eq!(other.relative_to(&abs), "/i/am/absolute".parse().unwrap());
+        assert_eq!(abs.relative_to(&other), "/i/am/absolute".parse().unwrap());
+        assert_eq!(other.relative_to(&other), "".parse().unwrap());
+        assert_eq!(abs.relative_to(&abs), "".parse().unwrap());
     }
 }

--- a/crates/lgn-api-codegen/src/bin/cli.rs
+++ b/crates/lgn-api-codegen/src/bin/cli.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use lgn_api_codegen::{generate, Language};
+use lgn_api_codegen::{generate, GenerationOptions, Language};
 use lgn_telemetry_sink::TelemetryGuardBuilder;
 use lgn_tracing::LevelFilter;
 
@@ -51,7 +51,15 @@ fn main() -> anyhow::Result<()> {
         .with_local_sink_max_level(LevelFilter::Debug)
         .build();
 
-    generate(args.language, args.root, &args.openapis, &args.out_dir)?;
+    let options = GenerationOptions::default();
+
+    generate(
+        args.language,
+        options,
+        args.root,
+        &args.openapis,
+        &args.out_dir,
+    )?;
 
     Ok(())
 }

--- a/crates/lgn-api-codegen/src/rust/filters.rs
+++ b/crates/lgn-api-codegen/src/rust/filters.rs
@@ -64,7 +64,7 @@ pub fn fmt_type(
         Type::Named(ref_) => {
             // We need to compute the relative module path.
 
-            let ref_module_path = ctx.ref_loc_to_module_path(ref_.ref_location())?;
+            let ref_module_path = ctx.ref_loc_to_rust_module_path(ref_.ref_location())?;
 
             fmt_module_path(
                 &ref_module_path
@@ -82,12 +82,7 @@ pub fn fmt_type(
 
 #[allow(clippy::unnecessary_wraps)]
 pub fn fmt_module_path(module_path: &ModulePath) -> ::askama::Result<String> {
-    Ok(module_path
-        .0
-        .iter()
-        .map(|s| (if s == ".." { "super" } else { s }).to_string())
-        .collect::<Vec<String>>()
-        .join("::"))
+    Ok(module_path.to_rust_module_path())
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -166,6 +161,8 @@ fn is_keyword(name: &str) -> bool {
 mod tests {
     use std::path::PathBuf;
 
+    use crate::api_types::GenerationOptions;
+
     use super::*;
 
     #[test]
@@ -188,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_join_types() {
-        let ctx = GenerationContext::new(PathBuf::from("/"));
+        let ctx = GenerationContext::new(PathBuf::from("/"), GenerationOptions::default());
         let module_path = "foo/bar".parse().unwrap();
 
         let p1 = Parameter {

--- a/crates/lgn-api-codegen/src/rust/mod.rs
+++ b/crates/lgn-api-codegen/src/rust/mod.rs
@@ -41,7 +41,10 @@ fn generate_content(ctx: &GenerationContext) -> Result<String> {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{openapi_loader::OpenApiRefLocation, visitor::Visitor, OpenApiLoader};
+    use crate::{
+        api_types::GenerationOptions, openapi_loader::OpenApiRefLocation, visitor::Visitor,
+        OpenApiLoader,
+    };
 
     use super::*;
 
@@ -55,7 +58,8 @@ mod tests {
         let openapi = loader
             .load_openapi(OpenApiRefLocation::new(&root, "cars.yaml".into()))
             .unwrap();
-        let ctx = Visitor::new(root).visit(&[openapi.clone()]).unwrap();
+        let ctx = GenerationContext::new(root, GenerationOptions::default());
+        let ctx = Visitor::new(ctx).visit(&[openapi.clone()]).unwrap();
         let content = generate_content(&ctx).unwrap();
 
         insta::assert_snapshot!(content);

--- a/crates/lgn-api-codegen/src/rust/templates/api.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/api.rs.jinja
@@ -10,40 +10,40 @@
 pub mod errors {
     {% let module_path = module_path.join("errors") %}
     {% include "errors.rs.jinja" %}
-    {% let module_path = module_path.parent() %}
+    {% let module_path = module_path.parent().unwrap() %}
 }
 
 // ---------- Client ----------
 pub mod client {
     {% let module_path = module_path.join("client") %}
     {% include "client.rs.jinja" %}
-    {% let module_path = module_path.parent() %}
+    {% let module_path = module_path.parent().unwrap() %}
 }
 
 // ---------- Server ----------
 pub mod server {
     {% let module_path = module_path.join("server") %}
     {% include "server.rs.jinja" %}
-    {% let module_path = module_path.parent() %}
+    {% let module_path = module_path.parent().unwrap() %}
 }
 
 // ---------- Params ----------
 pub(crate) mod params {
     {% let module_path = module_path.join("params") %}
     {% include "parameters.rs.jinja" %}
-    {% let module_path = module_path.parent() %}
+    {% let module_path = module_path.parent().unwrap() %}
 }
 
 // ---------- Requests ----------
 pub mod requests {
     {% let module_path = module_path.join("requests") %}
     {% include "requests.rs.jinja" %}
-    {% let module_path = module_path.parent() %}
+    {% let module_path = module_path.parent().unwrap() %}
 }
 
 // ---------- Responses ----------
 pub mod responses {
     {% let module_path = module_path.join("responses") %}
     {% include "responses.rs.jinja" %}
-    {% let module_path = module_path.parent() %}
+    {% let module_path = module_path.parent().unwrap() %}
 }

--- a/crates/lgn-api-codegen/src/rust/templates/lib.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/lib.rs.jinja
@@ -1,5 +1,7 @@
 // Auto-generated file.
 
 {% for (module_path, location_ctx) in ctx.as_modules()? %}
+{% if module_path.is_relative() %}
 {% include "location_context.rs.jinja" %}
+{% endif %}
 {% endfor %}

--- a/crates/lgn-api-codegen/src/rust/templates/location_context.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/location_context.rs.jinja
@@ -1,6 +1,6 @@
 // Models and API from: {{ module_path }}
 
-{% for module in module_path.0.iter() %}
+{% for module in module_path.parts().iter() %}
 pub mod {{ module }} {
 {% endfor %}
 
@@ -10,6 +10,6 @@ pub mod {{ module }} {
 {% include "api.rs.jinja" %}
 {% endif %}
 
-{% for module in module_path.0.iter() %}
+{% for module in module_path.parts().iter() %}
 }
 {% endfor %}

--- a/crates/lgn-api-codegen/src/typescript/filters.rs
+++ b/crates/lgn-api-codegen/src/typescript/filters.rs
@@ -24,7 +24,7 @@ pub fn fmt_type(
         Type::Array(inner) => format!("{}[]", fmt_type(inner, ctx, module_path).unwrap()),
         Type::HashSet(inner) => format!("Set<{}>", fmt_type(inner, ctx, module_path).unwrap()),
         Type::Named(ref_) => {
-            let ref_module_path = ctx.ref_loc_to_module_path(ref_.ref_location())?;
+            let ref_module_path = ctx.ref_loc_to_rust_module_path(ref_.ref_location())?;
 
             fmt_module_path(
                 &ref_module_path
@@ -43,7 +43,7 @@ pub fn fmt_type(
 #[allow(clippy::unnecessary_wraps)]
 pub fn fmt_module_path(module_path: &ModulePath) -> ::askama::Result<String> {
     Ok(module_path
-        .0
+        .parts()
         .iter()
         .filter_map(|name| {
             if name == ".." {

--- a/crates/lgn-api-codegen/src/typescript/mod.rs
+++ b/crates/lgn-api-codegen/src/typescript/mod.rs
@@ -99,7 +99,10 @@ fn generate_content(ctx: &GenerationContext) -> Result<String> {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{openapi_loader::OpenApiRefLocation, visitor::Visitor, OpenApiLoader};
+    use crate::{
+        api_types::GenerationOptions, openapi_loader::OpenApiRefLocation, visitor::Visitor,
+        OpenApiLoader,
+    };
 
     use super::*;
 
@@ -113,7 +116,8 @@ mod tests {
         let openapi = loader
             .load_openapi(OpenApiRefLocation::new(&root, "cars.yaml".into()))
             .unwrap();
-        let ctx = Visitor::new(root).visit(&[openapi.clone()]).unwrap();
+        let ctx = GenerationContext::new(root, GenerationOptions::default());
+        let ctx = Visitor::new(ctx).visit(&[openapi.clone()]).unwrap();
         let content = generate_content(&ctx).unwrap();
 
         insta::assert_snapshot!(content);

--- a/crates/lgn-api-codegen/src/typescript/templates/location_context.ts.jinja
+++ b/crates/lgn-api-codegen/src/typescript/templates/location_context.ts.jinja
@@ -1,6 +1,6 @@
 // Models and API from: {{ module_path }}
 
-{% for module in module_path.0.iter() %}
+{% for module in module_path.parts().iter() %}
 export namespace {{ module|pascal_case }} {
 {% endfor %}
 
@@ -10,6 +10,6 @@ export namespace {{ module|pascal_case }} {
 {% include "api.ts.jinja" %}
 {% endif %}
 
-{% for module in module_path.0.iter() %}
+{% for module in module_path.parts().iter() %}
 }
 {% endfor %}

--- a/crates/lgn-api-codegen/src/visitor.rs
+++ b/crates/lgn-api-codegen/src/visitor.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::collections::BTreeMap;
 
 use indexmap::IndexMap;
 
@@ -18,10 +18,8 @@ pub struct Visitor {
 }
 
 impl Visitor {
-    pub fn new(root: PathBuf) -> Self {
-        Self {
-            ctx: GenerationContext::new(root),
-        }
+    pub fn new(ctx: GenerationContext) -> Self {
+        Self { ctx }
     }
 
     pub fn visit(mut self, openapis: &[OpenApi<'_>]) -> Result<GenerationContext> {
@@ -598,7 +596,7 @@ impl Visitor {
 #[cfg(test)]
 mod tests {
     use crate::{
-        api_types::{Content, LocationContext, MediaType, Path},
+        api_types::{Content, GenerationOptions, LocationContext, MediaType, Path},
         openapi_loader::{JsonPointer, OpenApiLoader},
     };
 
@@ -755,9 +753,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api.yaml", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -829,7 +830,10 @@ mod tests {
             )
             .unwrap();
 
-        let mut v = Visitor::new(std::env::current_dir().unwrap());
+        let mut v = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ));
 
         assert_eq!(
             v.resolve_array(&array).unwrap(),
@@ -852,7 +856,10 @@ mod tests {
             )
             .unwrap();
 
-        let mut v = Visitor::new(std::env::current_dir().unwrap());
+        let mut v = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ));
 
         assert_eq!(
             v.resolve_array(&array).unwrap(),
@@ -888,9 +895,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -971,9 +981,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -1045,9 +1058,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -1162,9 +1178,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let my_struct_ref = oas
             .ref_()
@@ -1274,9 +1293,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/requestBodies/Pet/content/application~1json/schema"
@@ -1421,9 +1443,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let my_struct_ref = oas
             .ref_()
@@ -1526,9 +1551,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas])
-            .unwrap_err();
+        Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas])
+        .unwrap_err();
     }
 
     #[test]
@@ -1575,9 +1603,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let response_ref = oas.ref_().join(
             "/paths/~1test-one-of/get/responses/200/content/application~1json/schema"
@@ -1645,9 +1676,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let expected_route = Route {
             name: "testHeaders".to_string(),
@@ -1737,9 +1771,12 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(std::env::current_dir().unwrap())
-            .visit(&[oas.clone()])
-            .unwrap();
+        let ctx = Visitor::new(GenerationContext::new(
+            std::env::current_dir().unwrap(),
+            GenerationOptions::default(),
+        ))
+        .visit(&[oas.clone()])
+        .unwrap();
 
         let expected_route = Route {
             name: "foo".to_string(),

--- a/crates/lgn-governance/build.rs
+++ b/crates/lgn-governance/build.rs
@@ -4,7 +4,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     lgn_api_codegen::generate!(
         Rust,
         "../../apis",
-        ["space", "session", "user", "permission"]
+        ["space", "session", "user", "permission"],
+        //rust_module_mappings => [("../../apis/common.yaml", "lgn_common::foo"),],
     )?;
 
     println!("cargo:rerun-if-changed=migrations");


### PR DESCRIPTION
This PR adds the ability to override the generate Rust module during generation, to favor code-reuse and segmentation.

Basically, one can now write:

```rust
lgn_api_codegen::generate!(
    Rust,
    "../../apis",
    ["space", "session", "user", "permission"],
    rust_module_mappings => [("../../apis/common.yaml", "lgn_common::api")],
)?;
```

To force any external references inside `../../apis/common.yaml` to use the `lgn_common::api` crate/module prefix instead of the automatically generated one.