### PR TITLE
[api-codegen] Add blanket trait impl for Api trait

### DIFF
--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -77,41 +77,228 @@ pub mod cars {
     pub trait Api {
         async fn test_headers(
             &self,
-            context: &mut Context,
+            api_codegen_context: &mut Context,
             request: requests::TestHeadersRequest,
         ) -> Result<responses::TestHeadersResponse>;
 
-        async fn test_one_of(&self, context: &mut Context) -> Result<responses::TestOneOfResponse>;
+        async fn test_one_of(
+            &self,
+            api_codegen_context: &mut Context,
+        ) -> Result<responses::TestOneOfResponse>;
 
         async fn get_cars(
             &self,
-            context: &mut Context,
+            api_codegen_context: &mut Context,
             request: requests::GetCarsRequest,
         ) -> Result<responses::GetCarsResponse>;
 
         async fn create_car(
             &self,
-            context: &mut Context,
+            api_codegen_context: &mut Context,
             request: requests::CreateCarRequest,
         ) -> Result<responses::CreateCarResponse>;
 
         async fn get_car(
             &self,
-            context: &mut Context,
+            api_codegen_context: &mut Context,
             request: requests::GetCarRequest,
         ) -> Result<responses::GetCarResponse>;
 
         async fn delete_car(
             &self,
-            context: &mut Context,
+            api_codegen_context: &mut Context,
             request: requests::DeleteCarRequest,
         ) -> Result<responses::DeleteCarResponse>;
 
         async fn test_binary(
             &self,
-            context: &mut Context,
+            api_codegen_context: &mut Context,
             request: requests::TestBinaryRequest,
         ) -> Result<responses::TestBinaryResponse>;
+    }
+
+    // Blanket implementation of the Api trait for common wrapper types.
+
+    #[async_trait::async_trait]
+    impl<T: Api + Send + Sync> Api for std::sync::Arc<T> {
+        async fn test_headers(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::TestHeadersRequest,
+        ) -> Result<responses::TestHeadersResponse> {
+            self.as_ref()
+                .test_headers(api_codegen_context, request)
+                .await
+        }
+
+        async fn test_one_of(
+            &self,
+            api_codegen_context: &mut Context,
+        ) -> Result<responses::TestOneOfResponse> {
+            self.as_ref().test_one_of(api_codegen_context).await
+        }
+
+        async fn get_cars(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::GetCarsRequest,
+        ) -> Result<responses::GetCarsResponse> {
+            self.as_ref().get_cars(api_codegen_context, request).await
+        }
+
+        async fn create_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::CreateCarRequest,
+        ) -> Result<responses::CreateCarResponse> {
+            self.as_ref().create_car(api_codegen_context, request).await
+        }
+
+        async fn get_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::GetCarRequest,
+        ) -> Result<responses::GetCarResponse> {
+            self.as_ref().get_car(api_codegen_context, request).await
+        }
+
+        async fn delete_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::DeleteCarRequest,
+        ) -> Result<responses::DeleteCarResponse> {
+            self.as_ref().delete_car(api_codegen_context, request).await
+        }
+
+        async fn test_binary(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::TestBinaryRequest,
+        ) -> Result<responses::TestBinaryResponse> {
+            self.as_ref()
+                .test_binary(api_codegen_context, request)
+                .await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<T: Api + Send + Sync + ?Sized> Api for Box<T> {
+        async fn test_headers(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::TestHeadersRequest,
+        ) -> Result<responses::TestHeadersResponse> {
+            self.as_ref()
+                .test_headers(api_codegen_context, request)
+                .await
+        }
+
+        async fn test_one_of(
+            &self,
+            api_codegen_context: &mut Context,
+        ) -> Result<responses::TestOneOfResponse> {
+            self.as_ref().test_one_of(api_codegen_context).await
+        }
+
+        async fn get_cars(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::GetCarsRequest,
+        ) -> Result<responses::GetCarsResponse> {
+            self.as_ref().get_cars(api_codegen_context, request).await
+        }
+
+        async fn create_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::CreateCarRequest,
+        ) -> Result<responses::CreateCarResponse> {
+            self.as_ref().create_car(api_codegen_context, request).await
+        }
+
+        async fn get_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::GetCarRequest,
+        ) -> Result<responses::GetCarResponse> {
+            self.as_ref().get_car(api_codegen_context, request).await
+        }
+
+        async fn delete_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::DeleteCarRequest,
+        ) -> Result<responses::DeleteCarResponse> {
+            self.as_ref().delete_car(api_codegen_context, request).await
+        }
+
+        async fn test_binary(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::TestBinaryRequest,
+        ) -> Result<responses::TestBinaryResponse> {
+            self.as_ref()
+                .test_binary(api_codegen_context, request)
+                .await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<T: Api + Send + Sync + ?Sized> Api for &T {
+        async fn test_headers(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::TestHeadersRequest,
+        ) -> Result<responses::TestHeadersResponse> {
+            (**self).test_headers(api_codegen_context, request).await
+        }
+
+        async fn test_one_of(
+            &self,
+            api_codegen_context: &mut Context,
+        ) -> Result<responses::TestOneOfResponse> {
+            (**self).test_one_of(api_codegen_context).await
+        }
+
+        async fn get_cars(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::GetCarsRequest,
+        ) -> Result<responses::GetCarsResponse> {
+            (**self).get_cars(api_codegen_context, request).await
+        }
+
+        async fn create_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::CreateCarRequest,
+        ) -> Result<responses::CreateCarResponse> {
+            (**self).create_car(api_codegen_context, request).await
+        }
+
+        async fn get_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::GetCarRequest,
+        ) -> Result<responses::GetCarResponse> {
+            (**self).get_car(api_codegen_context, request).await
+        }
+
+        async fn delete_car(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::DeleteCarRequest,
+        ) -> Result<responses::DeleteCarResponse> {
+            (**self).delete_car(api_codegen_context, request).await
+        }
+
+        async fn test_binary(
+            &self,
+            api_codegen_context: &mut Context,
+            request: requests::TestBinaryRequest,
+        ) -> Result<responses::TestBinaryResponse> {
+            (**self).test_binary(api_codegen_context, request).await
+        }
     }
 
     // ---------- Errors ----------
@@ -204,7 +391,7 @@ pub mod cars {
         {
             async fn test_headers(
                 &self,
-                context: &mut Context,
+                api_codegen_context: &mut Context,
                 request: requests::TestHeadersRequest,
             ) -> Result<responses::TestHeadersResponse> {
                 let mut uri = format!("{}/test-headers", self.base_uri);
@@ -214,11 +401,11 @@ pub mod cars {
                     .uri(uri)
                     .body(Body::empty())
                     .unwrap();
-                if let Some(extensions) = context.request_extensions() {
+                if let Some(extensions) = api_codegen_context.request_extensions() {
                     req.extensions_mut().extend(extensions);
                 }
 
-                if let Some(headers) = context.request_headers() {
+                if let Some(headers) = api_codegen_context.request_headers() {
                     req.headers_mut().extend(headers);
                 }
 
@@ -258,13 +445,13 @@ pub mod cars {
 
                 let (parts, body) = resp.into_parts();
                 let resp = responses::TestHeadersResponse::from_response(&parts, body).await;
-                context.set_response(parts);
+                api_codegen_context.set_response(parts);
                 resp
             }
 
             async fn test_one_of(
                 &self,
-                context: &mut Context,
+                api_codegen_context: &mut Context,
             ) -> Result<responses::TestOneOfResponse> {
                 let mut uri = format!("{}/test-one-of", self.base_uri);
 
@@ -273,11 +460,11 @@ pub mod cars {
                     .uri(uri)
                     .body(Body::empty())
                     .unwrap();
-                if let Some(extensions) = context.request_extensions() {
+                if let Some(extensions) = api_codegen_context.request_extensions() {
                     req.extensions_mut().extend(extensions);
                 }
 
-                if let Some(headers) = context.request_headers() {
+                if let Some(headers) = api_codegen_context.request_headers() {
                     req.headers_mut().extend(headers);
                 }
 
@@ -285,13 +472,13 @@ pub mod cars {
 
                 let (parts, body) = resp.into_parts();
                 let resp = responses::TestOneOfResponse::from_response(&parts, body).await;
-                context.set_response(parts);
+                api_codegen_context.set_response(parts);
                 resp
             }
 
             async fn get_cars(
                 &self,
-                context: &mut Context,
+                api_codegen_context: &mut Context,
                 request: requests::GetCarsRequest,
             ) -> Result<responses::GetCarsResponse> {
                 let mut uri = format!(
@@ -313,11 +500,11 @@ pub mod cars {
                     .uri(uri)
                     .body(Body::empty())
                     .unwrap();
-                if let Some(extensions) = context.request_extensions() {
+                if let Some(extensions) = api_codegen_context.request_extensions() {
                     req.extensions_mut().extend(extensions);
                 }
 
-                if let Some(headers) = context.request_headers() {
+                if let Some(headers) = api_codegen_context.request_headers() {
                     req.headers_mut().extend(headers);
                 }
 
@@ -325,13 +512,13 @@ pub mod cars {
 
                 let (parts, body) = resp.into_parts();
                 let resp = responses::GetCarsResponse::from_response(&parts, body).await;
-                context.set_response(parts);
+                api_codegen_context.set_response(parts);
                 resp
             }
 
             async fn create_car(
                 &self,
-                context: &mut Context,
+                api_codegen_context: &mut Context,
                 request: requests::CreateCarRequest,
             ) -> Result<responses::CreateCarResponse> {
                 let mut uri = format!(
@@ -346,11 +533,11 @@ pub mod cars {
                     .body(Body::from(serde_json::to_string(&request.body)?))
                     .map_err(|err| Error::InvalidBody(err.to_string()))?;
 
-                if let Some(extensions) = context.request_extensions() {
+                if let Some(extensions) = api_codegen_context.request_extensions() {
                     req.extensions_mut().extend(extensions);
                 }
 
-                if let Some(headers) = context.request_headers() {
+                if let Some(headers) = api_codegen_context.request_headers() {
                     req.headers_mut().extend(headers);
                 }
 
@@ -370,13 +557,13 @@ pub mod cars {
 
                 let (parts, body) = resp.into_parts();
                 let resp = responses::CreateCarResponse::from_response(&parts, body).await;
-                context.set_response(parts);
+                api_codegen_context.set_response(parts);
                 resp
             }
 
             async fn get_car(
                 &self,
-                context: &mut Context,
+                api_codegen_context: &mut Context,
                 request: requests::GetCarRequest,
             ) -> Result<responses::GetCarResponse> {
                 let mut uri = format!(
@@ -391,11 +578,11 @@ pub mod cars {
                     .uri(uri)
                     .body(Body::empty())
                     .unwrap();
-                if let Some(extensions) = context.request_extensions() {
+                if let Some(extensions) = api_codegen_context.request_extensions() {
                     req.extensions_mut().extend(extensions);
                 }
 
-                if let Some(headers) = context.request_headers() {
+                if let Some(headers) = api_codegen_context.request_headers() {
                     req.headers_mut().extend(headers);
                 }
 
@@ -403,13 +590,13 @@ pub mod cars {
 
                 let (parts, body) = resp.into_parts();
                 let resp = responses::GetCarResponse::from_response(&parts, body).await;
-                context.set_response(parts);
+                api_codegen_context.set_response(parts);
                 resp
             }
 
             async fn delete_car(
                 &self,
-                context: &mut Context,
+                api_codegen_context: &mut Context,
                 request: requests::DeleteCarRequest,
             ) -> Result<responses::DeleteCarResponse> {
                 let mut uri = format!(
@@ -424,11 +611,11 @@ pub mod cars {
                     .uri(uri)
                     .body(Body::empty())
                     .unwrap();
-                if let Some(extensions) = context.request_extensions() {
+                if let Some(extensions) = api_codegen_context.request_extensions() {
                     req.extensions_mut().extend(extensions);
                 }
 
-                if let Some(headers) = context.request_headers() {
+                if let Some(headers) = api_codegen_context.request_headers() {
                     req.headers_mut().extend(headers);
                 }
 
@@ -436,13 +623,13 @@ pub mod cars {
 
                 let (parts, body) = resp.into_parts();
                 let resp = responses::DeleteCarResponse::from_response(&parts, body).await;
-                context.set_response(parts);
+                api_codegen_context.set_response(parts);
                 resp
             }
 
             async fn test_binary(
                 &self,
-                context: &mut Context,
+                api_codegen_context: &mut Context,
                 request: requests::TestBinaryRequest,
             ) -> Result<responses::TestBinaryResponse> {
                 let mut uri = format!(
@@ -457,11 +644,11 @@ pub mod cars {
                     .body(Body::from(request.body))
                     .map_err(|err| Error::InvalidBody(err.to_string()))?;
 
-                if let Some(extensions) = context.request_extensions() {
+                if let Some(extensions) = api_codegen_context.request_extensions() {
                     req.extensions_mut().extend(extensions);
                 }
 
-                if let Some(headers) = context.request_headers() {
+                if let Some(headers) = api_codegen_context.request_headers() {
                     req.headers_mut().extend(headers);
                 }
 
@@ -473,7 +660,7 @@ pub mod cars {
 
                 let (parts, body) = resp.into_parts();
                 let resp = responses::TestBinaryResponse::from_response(&parts, body).await;
-                context.set_response(parts);
+                api_codegen_context.set_response(parts);
                 resp
             }
         }

--- a/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
@@ -63,11 +63,11 @@ where
                 .body(Body::empty()).unwrap();
             {% endif -%}
 
-            if let Some(extensions) = context.request_extensions() {
+            if let Some(extensions) = api_codegen_context.request_extensions() {
                 req.extensions_mut().extend(extensions);
             }
 
-            if let Some(headers) = context.request_headers() {
+            if let Some(headers) = api_codegen_context.request_headers() {
                 req.headers_mut().extend(headers);
             }
 
@@ -107,7 +107,7 @@ where
 
             let (parts, body) = resp.into_parts();
             let resp = responses::{{ enum_name }}::from_response(&parts, body).await;
-            context.set_response(parts);
+            api_codegen_context.set_response(parts);
             resp
         }
     {% endfor %}

--- a/crates/lgn-api-codegen/src/rust/templates/signature.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/signature.rs.jinja
@@ -1,5 +1,5 @@
 async fn {{ route.name|snake_case }}(
     &self,
-    context: &mut Context,
+    api_codegen_context: &mut Context,
     {% if !route.has_empty_request() %}request: requests::{{ route.name|pascal_case }}Request{% endif %}
 ) -> Result<responses::{{ route.name|pascal_case }}Response>

--- a/crates/lgn-api-codegen/src/rust/templates/trait.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/trait.rs.jinja
@@ -10,3 +10,38 @@ pub trait Api {
     {% endfor %}
 {% endfor %}
 }
+
+// Blanket implementation of the Api trait for common wrapper types.
+
+#[async_trait::async_trait]
+impl<T: Api + Send + Sync> Api for std::sync::Arc<T> {
+{% for (path, routes) in api.paths %}
+    {% for route in routes %}
+        {% include "signature.rs.jinja" %} {
+            self.as_ref().{{ route.name|snake_case }}(api_codegen_context, {% if !route.has_empty_request() %}request{% endif %}).await
+        }
+    {% endfor %}
+{% endfor %}
+}
+
+#[async_trait::async_trait]
+impl<T: Api + Send + Sync + ?Sized> Api for Box<T> {
+{% for (path, routes) in api.paths %}
+    {% for route in routes %}
+        {% include "signature.rs.jinja" %} {
+            self.as_ref().{{ route.name|snake_case }}(api_codegen_context, {% if !route.has_empty_request() %}request{% endif %}).await
+        }
+    {% endfor %}
+{% endfor %}
+}
+
+#[async_trait::async_trait]
+impl<T: Api + Send + Sync + ?Sized> Api for &T {
+{% for (path, routes) in api.paths %}
+    {% for route in routes %}
+        {% include "signature.rs.jinja" %} {
+            (**self).{{ route.name|snake_case }}(api_codegen_context, {% if !route.has_empty_request() %}request{% endif %}).await
+        }
+    {% endfor %}
+{% endfor %}
+}


### PR DESCRIPTION
This PR adds blanket `Api` trait implementation for `Arc<T>`, `Box<T>` and `&T` if `T: Api`.

It also renames the `context` argument in the trait to `api_codegen_context` to avoid possible name clashes with user-defined API parameters.