### PR TITLE
[api-codegen] Removed generators

### DIFF
--- a/crates/lgn-api-codegen/src/lib.rs
+++ b/crates/lgn-api-codegen/src/lib.rs
@@ -15,14 +15,10 @@ pub(crate) mod rust;
 pub(crate) mod typescript;
 pub(crate) mod visitor;
 
-use api_types::GenerationContext;
 pub use api_types::{Language, ModulePath, RustOptions, TypeScriptOptions};
 use errors::{Error, Result};
 use openapi_loader::{OpenApi, OpenApiElement, OpenApiLoader, OpenApiRefLocation};
-use python::PythonGenerator;
-use rust::RustGenerator;
 use std::path::{Path, PathBuf};
-use typescript::TypeScriptGenerator;
 use visitor::Visitor;
 
 /// Generates the code for the specificed language and the specified APIs.
@@ -37,38 +33,17 @@ use visitor::Visitor;
 ///
 /// If the generation fails to complete.
 pub fn generate(
-    mut language: Language,
+    language: Language,
     root: impl AsRef<Path>,
     openapis: impl IntoIterator<Item = impl AsRef<str>>,
     output_dir: impl AsRef<Path>,
 ) -> Result<Vec<PathBuf>> {
-    let generator = load_generator_for_language(&language);
-
     let root = if root.as_ref().is_relative() {
         std::env::current_dir()?.join(root)
     } else {
         root.as_ref().to_path_buf()
     }
     .canonicalize()?;
-
-    if let Some(rust_options) = language.rust_options_mut() {
-        // Make sure the Rust module mappings are absolute and canonicalized.
-        rust_options.module_mappings = rust_options
-            .module_mappings
-            .iter()
-            .map(|(p, module)| {
-                Ok((
-                    if p.is_relative() {
-                        std::env::current_dir()?.join(&p)
-                    } else {
-                        p.clone()
-                    }
-                    .canonicalize()?,
-                    module.clone(),
-                ))
-            })
-            .collect::<Result<_>>()?;
-    };
 
     let loader = OpenApiLoader::default();
 
@@ -82,29 +57,17 @@ pub fn generate(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let ctx = GenerationContext::new(root, language);
-    let ctx = Visitor::new(ctx).visit(&openapis)?;
+    let ctx = Visitor::new(root).visit(&openapis)?;
 
-    generator.generate(&ctx, output_dir.as_ref())?;
+    language.generate(ctx, output_dir.as_ref())?;
 
     Ok(loader.get_all_files())
 }
 
 #[macro_export]
 macro_rules! generate {
-    (Rust, $root:expr, $openapis:expr $(, module_mappings => $module_mappings:expr)? $(,)?) => {{
-        let mut language = lgn_api_codegen::Language::Rust(lgn_api_codegen::RustOptions::default());
-
-        $(
-            language.module_mappings = $module_mappings.iter().map(|(k, v)| (std::path::PathBuf::from(k), lgn_api_codegen::ModulePath::from_absolute_rust_module_path(*v))).collect();
-        )?;
-
-        match lgn_api_codegen::generate(
-            language,
-            $root,
-            $openapis,
-            std::env::var("OUT_DIR")?,
-        ) {
+    ($lang:expr, $root:expr, $openapis:expr$(,)?) => {{
+        match lgn_api_codegen::generate($lang, $root, $openapis, std::env::var("OUT_DIR")?) {
             Ok(files) => {
                 for file in files {
                     println!("cargo:rerun-if-changed={}", file.display());
@@ -115,33 +78,4 @@ macro_rules! generate {
             Err(err) => Err(err),
         }
     }};
-    (Python, $root:expr, $openapis:expr) => {{
-        match lgn_api_codegen::generate(
-            lgn_api_codegen::Language::Python,
-            $root,
-            $openapis,
-            std::env::var("OUT_DIR")?,
-        ) {
-            Ok(files) => {
-                for file in files {
-                    println!("cargo:rerun-if-changed={}", file.display());
-                }
-
-                Ok(())
-            }
-            Err(err) => Err(err),
-        }
-    }};
-}
-
-pub(crate) trait Generator {
-    fn generate(&self, ctx: &GenerationContext, output_dir: &Path) -> Result<()>;
-}
-
-fn load_generator_for_language(language: &Language) -> Box<dyn Generator> {
-    match language {
-        Language::Rust(_) => Box::new(RustGenerator::default()),
-        Language::TypeScript(_) => Box::new(TypeScriptGenerator::default()),
-        Language::Python => Box::new(PythonGenerator::default()),
-    }
 }

--- a/crates/lgn-api-codegen/src/rust/filters.rs
+++ b/crates/lgn-api-codegen/src/rust/filters.rs
@@ -1,11 +1,13 @@
 pub use crate::filters::*;
 use crate::{
-    api_types::{GenerationContext, Model, ModelOrigin, ModulePath, Parameter, Path, Type},
+    api_types::{Model, ModelOrigin, ModulePath, Parameter, Path, Type},
     errors::Error,
 };
 use convert_case::{Case, Casing};
 use lazy_static::lazy_static;
 use regex::Regex;
+
+use super::RustGenerationContext;
 
 const KEYWORDS: &[&str] = &[
     "abstract", "as", "async", "await", "become", "box", "break", "const", "continue", "crate",
@@ -16,7 +18,7 @@ const KEYWORDS: &[&str] = &[
 ];
 
 #[allow(clippy::unnecessary_wraps)]
-pub fn fmt_model_name(model: &Model, ctx: &GenerationContext) -> ::askama::Result<String> {
+pub fn fmt_model_name(model: &Model, ctx: &RustGenerationContext) -> ::askama::Result<String> {
     Ok(match &model.origin {
         ModelOrigin::Schemas => model.ref_.json_pointer().type_name().to_string(),
         ModelOrigin::ObjectProperty { object_pointer } => {
@@ -43,7 +45,7 @@ pub fn fmt_model_name(model: &Model, ctx: &GenerationContext) -> ::askama::Resul
 #[allow(clippy::unnecessary_wraps)]
 pub fn fmt_type(
     type_: &Type,
-    ctx: &GenerationContext,
+    ctx: &RustGenerationContext,
     module_path: &ModulePath,
 ) -> ::askama::Result<String> {
     Ok(match type_ {
@@ -130,7 +132,7 @@ pub fn join_names(params: &[Parameter]) -> ::askama::Result<String> {
 #[allow(clippy::unnecessary_wraps)]
 pub fn join_types(
     params: &[Parameter],
-    ctx: &GenerationContext,
+    ctx: &RustGenerationContext,
     module_path: &ModulePath,
 ) -> ::askama::Result<String> {
     let joined = params
@@ -161,7 +163,7 @@ fn is_keyword(name: &str) -> bool {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{api_types::Language, RustOptions};
+    use crate::{api_types::GenerationContext, RustOptions};
 
     use super::*;
 
@@ -185,8 +187,7 @@ mod tests {
 
     #[test]
     fn test_join_types() {
-        let ctx =
-            GenerationContext::new(PathBuf::from("/"), Language::Rust(RustOptions::default()));
+        let ctx = GenerationContext::new(PathBuf::from("/")).with_options(RustOptions::default());
         let module_path = "foo/bar".parse().unwrap();
 
         let p1 = Parameter {

--- a/crates/lgn-api-codegen/src/rust/templates/lib.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/lib.rs.jinja
@@ -1,7 +1,5 @@
 // Auto-generated file.
 
-{% for (module_path, location_ctx) in ctx.as_modules()? %}
-{% if module_path.is_relative() %}
+{% for (module_path, location_ctx) in ctx.as_local_rust_modules()? %}
 {% include "location_context.rs.jinja" %}
-{% endif %}
 {% endfor %}

--- a/crates/lgn-api-codegen/src/typescript/filters.rs
+++ b/crates/lgn-api-codegen/src/typescript/filters.rs
@@ -4,14 +4,16 @@ use regex::{Captures, Regex};
 
 pub use crate::filters::*;
 use crate::{
-    api_types::{GenerationContext, Model, ModelOrigin, ModulePath, Parameter, Path, Type},
+    api_types::{Model, ModelOrigin, ModulePath, Parameter, Path, Type},
     errors::Error,
 };
+
+use super::TypeScriptGenerationContext;
 
 #[allow(clippy::unnecessary_wraps)]
 pub fn fmt_type(
     type_: &Type,
-    ctx: &GenerationContext,
+    ctx: &TypeScriptGenerationContext,
     module_path: &ModulePath,
 ) -> ::askama::Result<String> {
     Ok(match type_ {
@@ -24,7 +26,7 @@ pub fn fmt_type(
         Type::Array(inner) => format!("{}[]", fmt_type(inner, ctx, module_path).unwrap()),
         Type::HashSet(inner) => format!("Set<{}>", fmt_type(inner, ctx, module_path).unwrap()),
         Type::Named(ref_) => {
-            let ref_module_path = ctx.ref_loc_to_rust_module_path(ref_.ref_location())?;
+            let ref_module_path = ctx.ref_loc_to_module_path(ref_.ref_location())?;
 
             fmt_module_path(
                 &ref_module_path
@@ -81,7 +83,10 @@ pub fn fmt_ts_path(path: &Path, parameters: &[Parameter]) -> ::askama::Result<St
 }
 
 #[allow(clippy::unnecessary_wraps)]
-pub fn fmt_model_name(model: &Model, ctx: &GenerationContext) -> ::askama::Result<String> {
+pub fn fmt_model_name(
+    model: &Model,
+    ctx: &TypeScriptGenerationContext,
+) -> ::askama::Result<String> {
     let name = match &model.origin {
         ModelOrigin::Schemas => model.ref_.json_pointer().type_name().to_string(),
         ModelOrigin::ObjectProperty { object_pointer } => {

--- a/crates/lgn-api-codegen/src/typescript/mod.rs
+++ b/crates/lgn-api-codegen/src/typescript/mod.rs
@@ -14,7 +14,7 @@ use which::which;
 use crate::{
     api_types::{GenerationContext, MediaType, Type},
     errors::Error,
-    Generator, Result, TypeScriptOptions,
+    Language, Result, TypeScriptOptions,
 };
 
 mod filters;
@@ -22,136 +22,120 @@ mod filters;
 #[derive(askama::Template)]
 #[template(path = "index.ts.jinja", escape = "none")]
 struct TypeScriptIndexTemplate<'a> {
-    pub ctx: &'a GenerationContext,
+    pub ctx: &'a TypeScriptGenerationContext,
 }
 
 #[derive(askama::Template)]
 #[template(path = "package.json.jinja", escape = "none")]
 struct TypeScriptPackageTemplate;
 
-#[derive(Default)]
-pub(crate) struct TypeScriptGenerator {
-    // prettier_config_path: Option<PathBuf>,
-    // with_package_json: bool,
-    // skip_format: bool,
-}
+pub type TypeScriptGenerationContext = GenerationContext<TypeScriptOptions>;
 
-impl TypeScriptGenerator {
-    fn generate_index_content(
-        &self,
-        ctx: &GenerationContext,
-        options: &TypeScriptOptions,
-    ) -> Result<String> {
-        let mut content = TypeScriptIndexTemplate { ctx }.render()?;
+fn format_typescript<'a, 'b>(
+    options: &TypeScriptOptions,
+    content: &'a str,
+    temp_file_name: &'b str,
+) -> Result<Cow<'a, str>> {
+    let prettier_config_path = options
+        .prettier_config_path
+        .clone()
+        .map(|path| path.to_string_lossy().into_owned());
 
-        if !options.skip_format {
-            content = self.format(options, &content, "index.ts")?.into_owned();
+    let dir =
+        tempdir().map_err(|_err| Error::TypeScriptFormat(anyhow!("couldn't create a tmp dir")))?;
+
+    let file_path = dir.path().join(temp_file_name);
+
+    let mut file = File::create(&file_path)?;
+
+    write!(file, "{}", content)
+        .map_err(|_err| Error::TypeScriptFormat(anyhow!("couldn't write content to tmp file")))?;
+
+    let binary_path = match which("npx") {
+        Err(_) => return Ok(content.into()),
+        Ok(path) => path,
+    };
+
+    let mut command = Command::new(binary_path);
+
+    let tmp_file_path = file_path.as_path().to_string_lossy();
+
+    let mut args = vec![
+        "--yes",
+        "prettier",
+        "--loglevel",
+        "silent",
+        "--write",
+        &tmp_file_path,
+    ];
+
+    match prettier_config_path {
+        None => args.push("--no-config"),
+        Some(ref path) => {
+            args.push("--config");
+            args.push(path);
         }
+    };
 
-        Ok(content)
-    }
+    command.args(&args);
 
-    fn generate_package_content(&self, options: &TypeScriptOptions) -> Result<String> {
-        let mut content = TypeScriptPackageTemplate.render()?;
+    let status = command.status().map_err(|error| {
+        Error::TypeScriptFormat(anyhow!(
+            "npx prettier command was not successful: {}",
+            error
+        ))
+    })?;
 
-        if !options.skip_format {
-            content = self.format(options, &content, "package.json")?.into_owned();
-        }
+    if status.success() {
+        let formatted_content = read_to_string(&file_path)
+            .map_err(|_err| Error::TypeScriptFormat(anyhow!("couldn't read tmp file")))?;
 
-        Ok(content)
-    }
-
-    #[allow(clippy::unused_self)]
-    fn format<'a, 'b>(
-        &self,
-        options: &TypeScriptOptions,
-        content: &'a str,
-        temp_file_name: &'b str,
-    ) -> Result<Cow<'a, str>> {
-        let prettier_config_path = options
-            .prettier_config_path
-            .clone()
-            .map(|path| path.to_string_lossy().into_owned());
-
-        let dir = tempdir()
-            .map_err(|_err| Error::TypeScriptFormat(anyhow!("couldn't create a tmp dir")))?;
-
-        let file_path = dir.path().join(temp_file_name);
-
-        let mut file = File::create(&file_path)?;
-
-        write!(file, "{}", content).map_err(|_err| {
-            Error::TypeScriptFormat(anyhow!("couldn't write content to tmp file"))
-        })?;
-
-        let binary_path = match which("npx") {
-            Err(_) => return Ok(content.into()),
-            Ok(path) => path,
-        };
-
-        let mut command = Command::new(binary_path);
-
-        let tmp_file_path = file_path.as_path().to_string_lossy();
-
-        let mut args = vec![
-            "--yes",
-            "prettier",
-            "--loglevel",
-            "silent",
-            "--write",
-            &tmp_file_path,
-        ];
-
-        match prettier_config_path {
-            None => args.push("--no-config"),
-            Some(ref path) => {
-                args.push("--config");
-                args.push(path);
-            }
-        };
-
-        command.args(&args);
-
-        let status = command.status().map_err(|error| {
-            Error::TypeScriptFormat(anyhow!(
-                "npx prettier command was not successful: {}",
-                error
-            ))
-        })?;
-
-        if status.success() {
-            let formatted_content = read_to_string(&file_path)
-                .map_err(|_err| Error::TypeScriptFormat(anyhow!("couldn't read tmp file")))?;
-
-            Ok(formatted_content.into())
-        } else {
-            Err(Error::TypeScriptFormat(anyhow!(
-                "npx prettier command was not successful: {}",
-                status
-            )))
-        }
+        Ok(formatted_content.into())
+    } else {
+        Err(Error::TypeScriptFormat(anyhow!(
+            "npx prettier command was not successful: {}",
+            status
+        )))
     }
 }
 
-impl Generator for TypeScriptGenerator {
-    fn generate(&self, ctx: &GenerationContext, output_dir: &Path) -> Result<()> {
-        let default_options = TypeScriptOptions::default();
+fn generate_index_content(ctx: &TypeScriptGenerationContext) -> Result<String> {
+    let mut content = TypeScriptIndexTemplate { ctx }.render()?;
 
-        let options = ctx
-            .language
-            .type_script_options()
-            .unwrap_or(&default_options);
+    if !ctx.options.skip_format {
+        content = format_typescript(&ctx.options, &content, "index.ts")?.into_owned();
+    }
 
+    Ok(content)
+}
+
+fn generate_package_content(options: &TypeScriptOptions) -> Result<String> {
+    let mut content = TypeScriptPackageTemplate.render()?;
+
+    if !options.skip_format {
+        content = format_typescript(options, &content, "package.json")?.into_owned();
+    }
+
+    Ok(content)
+}
+
+impl Language {
+    pub(crate) fn generate_typescript(
+        ctx: GenerationContext,
+        options: TypeScriptOptions,
+        output_dir: &Path,
+    ) -> Result<()> {
         std::fs::create_dir_all(output_dir)?;
 
+        let ctx = ctx.with_options(options);
         let output_file = output_dir.join("index.ts");
-        let content = self.generate_index_content(ctx, options)?;
+        let content = generate_index_content(&ctx)?;
 
         std::fs::write(output_file, content)?;
 
-        if options.with_package_json {
+        if ctx.options.with_package_json {
             let output_file = output_dir.join("package.json");
-            let content = self.generate_package_content(options)?;
+            let content = generate_package_content(&ctx.options)?;
 
             std::fs::write(output_file, content)?;
         }
@@ -164,9 +148,7 @@ impl Generator for TypeScriptGenerator {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{
-        api_types::Language, openapi_loader::OpenApiRefLocation, visitor::Visitor, OpenApiLoader,
-    };
+    use crate::{openapi_loader::OpenApiRefLocation, visitor::Visitor, OpenApiLoader};
 
     use super::*;
 
@@ -180,20 +162,18 @@ mod tests {
         let openapi = loader
             .load_openapi(OpenApiRefLocation::new(&root, "cars.yaml".into()))
             .unwrap();
-        let ctx = GenerationContext::new(root, Language::TypeScript(TypeScriptOptions::default()));
-        let ctx = Visitor::new(ctx).visit(&[openapi.clone()]).unwrap();
-        let content = TypeScriptGenerator::default()
-            .generate_index_content(&ctx, &TypeScriptOptions::default())
-            .unwrap();
+        let ctx = Visitor::new(root)
+            .visit(&[openapi.clone()])
+            .unwrap()
+            .with_options(TypeScriptOptions::default());
+        let content = generate_index_content(&ctx).unwrap();
 
         insta::assert_snapshot!(content);
     }
 
     #[test]
     fn test_ts_package_generation() {
-        let content = TypeScriptGenerator::default()
-            .generate_package_content(&TypeScriptOptions::default())
-            .unwrap();
+        let content = generate_package_content(&TypeScriptOptions::default()).unwrap();
 
         insta::assert_snapshot!(content);
     }

--- a/crates/lgn-api-codegen/src/visitor.rs
+++ b/crates/lgn-api-codegen/src/visitor.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::PathBuf};
 
 use indexmap::IndexMap;
 
@@ -14,12 +14,14 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Visitor {
-    pub ctx: GenerationContext,
+    ctx: GenerationContext,
 }
 
 impl Visitor {
-    pub fn new(ctx: GenerationContext) -> Self {
-        Self { ctx }
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            ctx: GenerationContext::new(root),
+        }
     }
 
     pub fn visit(mut self, openapis: &[OpenApi<'_>]) -> Result<GenerationContext> {
@@ -596,9 +598,8 @@ impl Visitor {
 #[cfg(test)]
 mod tests {
     use crate::{
-        api_types::{Content, Language, LocationContext, MediaType, Path},
+        api_types::{Content, LocationContext, MediaType, Path},
         openapi_loader::{JsonPointer, OpenApiLoader},
-        RustOptions,
     };
 
     use super::*;
@@ -754,12 +755,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api.yaml", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -831,10 +829,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut v = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ));
+        let mut v = Visitor::new(std::env::current_dir().unwrap());
 
         assert_eq!(
             v.resolve_array(&array).unwrap(),
@@ -857,10 +852,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut v = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ));
+        let mut v = Visitor::new(std::env::current_dir().unwrap());
 
         assert_eq!(
             v.resolve_array(&array).unwrap(),
@@ -896,12 +888,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -982,12 +971,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -1059,12 +1045,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/schemas/MyStruct"
@@ -1179,12 +1162,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let my_struct_ref = oas
             .ref_()
@@ -1294,12 +1274,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let my_struct_ref = oas.ref_().join(
             "/components/requestBodies/Pet/content/application~1json/schema"
@@ -1444,12 +1421,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let my_struct_ref = oas
             .ref_()
@@ -1552,12 +1526,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas])
-        .unwrap_err();
+        Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas])
+            .unwrap_err();
     }
 
     #[test]
@@ -1604,12 +1575,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let response_ref = oas.ref_().join(
             "/paths/~1test-one-of/get/responses/200/content/application~1json/schema"
@@ -1677,12 +1645,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let expected_route = Route {
             name: "testHeaders".to_string(),
@@ -1772,12 +1737,9 @@ mod tests {
             ..openapiv3::OpenAPI::default()
         };
         let oas: OpenApi<'_> = loader.import("api", &api).unwrap();
-        let ctx = Visitor::new(GenerationContext::new(
-            std::env::current_dir().unwrap(),
-            Language::Rust(RustOptions::default()),
-        ))
-        .visit(&[oas.clone()])
-        .unwrap();
+        let ctx = Visitor::new(std::env::current_dir().unwrap())
+            .visit(&[oas.clone()])
+            .unwrap();
 
         let expected_route = Route {
             name: "foo".to_string(),

--- a/crates/lgn-governance/build.rs
+++ b/crates/lgn-governance/build.rs
@@ -1,11 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=migrations");
 
+    let options = lgn_api_codegen::RustOptions::default();
     lgn_api_codegen::generate!(
-        Rust,
+        lgn_api_codegen::Language::Rust(options),
         "../../apis",
         ["space", "session", "user", "permission"],
-        //module_mappings => [("../../apis/common.yaml", "lgn_common::foo"),],
     )?;
 
     println!("cargo:rerun-if-changed=migrations");

--- a/tests/api-codegen/build.rs
+++ b/tests/api-codegen/build.rs
@@ -1,6 +1,10 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    lgn_api_codegen::generate!(Rust, ".", ["cars"])?;
-    lgn_api_codegen::generate!(Python, ".", ["cars"])?;
+    lgn_api_codegen::generate!(
+        lgn_api_codegen::Language::Rust(lgn_api_codegen::RustOptions::default()),
+        ".",
+        ["cars"]
+    )?;
+    lgn_api_codegen::generate!(lgn_api_codegen::Language::Python, ".", ["cars"])?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR refactors a bit how language-specific options are passed around and made available to the templates.

It also fixes the module mapping feature that was recently broken.