### PR TITLE
[api-codegen] Change inner client to a tower service.

### DIFF
--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -258,48 +258,54 @@ pub mod cars {
     pub mod client {
 
         use super::{params, requests, responses};
-        use http::{header::CONTENT_TYPE, HeaderValue};
-        use hyper::{Body, Method, Request};
+        use http::{header::CONTENT_TYPE, HeaderValue, Request, Response};
+        use http_body::Body;
+        use hyper::service::Service;
         use lgn_online::{
             codegen::{Bytes, Context},
             server::{Error, Result},
         };
+        use lgn_tracing::debug;
 
         pub struct Client<C> {
-            inner: hyper::Client<C>,
-            base_uri: String,
+            inner: C,
+            base_uri: http::Uri,
         }
 
         impl<C> Client<C> {
-            pub fn new(inner: hyper::Client<C>, base_uri: String) -> Self {
+            pub fn new(inner: C, base_uri: http::Uri) -> Self {
                 Self { inner, base_uri }
             }
         }
 
         #[async_trait::async_trait]
-        impl<C> super::Api for Client<C>
+        impl<C, ResBody> super::Api for Client<C>
         where
-            C: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+            C: Service<Request<hyper::Body>, Response = Response<ResBody>> + Clone + Send + Sync,
+            C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+            C::Future: Send,
+            ResBody: http_body::Body + Send,
+            ResBody::Data: Send,
+            ResBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         {
             async fn test_headers(
                 &self,
                 api_codegen_context: &mut Context,
                 request: requests::TestHeadersRequest,
             ) -> Result<responses::TestHeadersResponse> {
-                let mut uri = format!("{}/test-headers", self.base_uri);
+                let mut uri = format!(
+                    "{}://{}/test-headers",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap()
+                );
 
+                debug!("test_headers: {}", uri);
+
+                let body = hyper::Body::empty();
                 let mut req = Request::builder()
-                    .method(Method::GET)
+                    .method(hyper::Method::GET)
                     .uri(uri)
-                    .body(Body::empty())
-                    .unwrap();
-                if let Some(extensions) = api_codegen_context.request_extensions() {
-                    req.extensions_mut().extend(extensions);
-                }
-
-                if let Some(headers) = api_codegen_context.request_headers() {
-                    req.headers_mut().extend(headers);
-                }
+                    .body(body)?;
 
                 if let Some(x_string_header) = request.x_string_header {
                     let x_string_header =
@@ -333,11 +339,13 @@ pub mod cars {
                         })?,
                     );
                 }
-                let resp = self.inner.request(req).await?;
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
 
                 let (parts, body) = resp.into_parts();
-                let resp = responses::TestHeadersResponse::from_response(&parts, body).await;
-                api_codegen_context.set_response(parts);
+                let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+                let resp = responses::TestHeadersResponse::from_response(&parts, bytes).await;
+
                 resp
             }
 
@@ -345,26 +353,27 @@ pub mod cars {
                 &self,
                 api_codegen_context: &mut Context,
             ) -> Result<responses::TestOneOfResponse> {
-                let mut uri = format!("{}/test-one-of", self.base_uri);
+                let mut uri = format!(
+                    "{}://{}/test-one-of",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap()
+                );
 
+                debug!("test_one_of: {}", uri);
+
+                let body = hyper::Body::empty();
                 let mut req = Request::builder()
-                    .method(Method::GET)
+                    .method(hyper::Method::GET)
                     .uri(uri)
-                    .body(Body::empty())
-                    .unwrap();
-                if let Some(extensions) = api_codegen_context.request_extensions() {
-                    req.extensions_mut().extend(extensions);
-                }
+                    .body(body)?;
 
-                if let Some(headers) = api_codegen_context.request_headers() {
-                    req.headers_mut().extend(headers);
-                }
-
-                let resp = self.inner.request(req).await?;
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
 
                 let (parts, body) = resp.into_parts();
-                let resp = responses::TestOneOfResponse::from_response(&parts, body).await;
-                api_codegen_context.set_response(parts);
+                let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+                let resp = responses::TestOneOfResponse::from_response(&parts, bytes).await;
+
                 resp
             }
 
@@ -374,8 +383,9 @@ pub mod cars {
                 request: requests::GetCarsRequest,
             ) -> Result<responses::GetCarsResponse> {
                 let mut uri = format!(
-                    "{}/v1/spaces/{}/car-service/cars",
-                    self.base_uri,
+                    "{}://{}/v1/spaces/{}/car-service/cars",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap(),
                     lgn_online::codegen::encoding::to_percent_encoded_string(&request.space_id)?
                 );
 
@@ -387,24 +397,21 @@ pub mod cars {
                 if !query_string.is_empty() {
                     uri += &format!("?{}", query_string);
                 }
+                debug!("get_cars: {}", uri);
+
+                let body = hyper::Body::empty();
                 let mut req = Request::builder()
-                    .method(Method::GET)
+                    .method(hyper::Method::GET)
                     .uri(uri)
-                    .body(Body::empty())
-                    .unwrap();
-                if let Some(extensions) = api_codegen_context.request_extensions() {
-                    req.extensions_mut().extend(extensions);
-                }
+                    .body(body)?;
 
-                if let Some(headers) = api_codegen_context.request_headers() {
-                    req.headers_mut().extend(headers);
-                }
-
-                let resp = self.inner.request(req).await?;
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
 
                 let (parts, body) = resp.into_parts();
-                let resp = responses::GetCarsResponse::from_response(&parts, body).await;
-                api_codegen_context.set_response(parts);
+                let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+                let resp = responses::GetCarsResponse::from_response(&parts, bytes).await;
+
                 resp
             }
 
@@ -414,24 +421,20 @@ pub mod cars {
                 request: requests::CreateCarRequest,
             ) -> Result<responses::CreateCarResponse> {
                 let mut uri = format!(
-                    "{}/v1/spaces/{}/car-service/cars",
-                    self.base_uri,
+                    "{}://{}/v1/spaces/{}/car-service/cars",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap(),
                     lgn_online::codegen::encoding::to_percent_encoded_string(&request.space_id)?
                 );
 
+                debug!("create_car: {}", uri);
+
+                let body = hyper::Body::from(serde_json::to_string(&request.body)?);
+
                 let mut req = Request::builder()
-                    .method(Method::POST)
+                    .method(hyper::Method::POST)
                     .uri(uri)
-                    .body(Body::from(serde_json::to_string(&request.body)?))
-                    .map_err(|err| Error::Internal(format!("invalid body: {}", err)))?;
-
-                if let Some(extensions) = api_codegen_context.request_extensions() {
-                    req.extensions_mut().extend(extensions);
-                }
-
-                if let Some(headers) = api_codegen_context.request_headers() {
-                    req.headers_mut().extend(headers);
-                }
+                    .body(body)?;
 
                 req.headers_mut()
                     .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -446,11 +449,13 @@ pub mod cars {
                         })?,
                     );
                 }
-                let resp = self.inner.request(req).await?;
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
 
                 let (parts, body) = resp.into_parts();
-                let resp = responses::CreateCarResponse::from_response(&parts, body).await;
-                api_codegen_context.set_response(parts);
+                let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+                let resp = responses::CreateCarResponse::from_response(&parts, bytes).await;
+
                 resp
             }
 
@@ -460,30 +465,28 @@ pub mod cars {
                 request: requests::GetCarRequest,
             ) -> Result<responses::GetCarResponse> {
                 let mut uri = format!(
-                    "{}/v1/spaces/{}/car-service/cars/{}",
-                    self.base_uri,
+                    "{}://{}/v1/spaces/{}/car-service/cars/{}",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap(),
                     lgn_online::codegen::encoding::to_percent_encoded_string(&request.space_id)?,
                     lgn_online::codegen::encoding::to_percent_encoded_string(&request.car_id)?
                 );
 
+                debug!("get_car: {}", uri);
+
+                let body = hyper::Body::empty();
                 let mut req = Request::builder()
-                    .method(Method::GET)
+                    .method(hyper::Method::GET)
                     .uri(uri)
-                    .body(Body::empty())
-                    .unwrap();
-                if let Some(extensions) = api_codegen_context.request_extensions() {
-                    req.extensions_mut().extend(extensions);
-                }
+                    .body(body)?;
 
-                if let Some(headers) = api_codegen_context.request_headers() {
-                    req.headers_mut().extend(headers);
-                }
-
-                let resp = self.inner.request(req).await?;
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
 
                 let (parts, body) = resp.into_parts();
-                let resp = responses::GetCarResponse::from_response(&parts, body).await;
-                api_codegen_context.set_response(parts);
+                let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+                let resp = responses::GetCarResponse::from_response(&parts, bytes).await;
+
                 resp
             }
 
@@ -493,30 +496,28 @@ pub mod cars {
                 request: requests::DeleteCarRequest,
             ) -> Result<responses::DeleteCarResponse> {
                 let mut uri = format!(
-                    "{}/v1/spaces/{}/car-service/cars/{}",
-                    self.base_uri,
+                    "{}://{}/v1/spaces/{}/car-service/cars/{}",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap(),
                     lgn_online::codegen::encoding::to_percent_encoded_string(&request.space_id)?,
                     lgn_online::codegen::encoding::to_percent_encoded_string(&request.car_id)?
                 );
 
+                debug!("delete_car: {}", uri);
+
+                let body = hyper::Body::empty();
                 let mut req = Request::builder()
-                    .method(Method::DELETE)
+                    .method(hyper::Method::DELETE)
                     .uri(uri)
-                    .body(Body::empty())
-                    .unwrap();
-                if let Some(extensions) = api_codegen_context.request_extensions() {
-                    req.extensions_mut().extend(extensions);
-                }
+                    .body(body)?;
 
-                if let Some(headers) = api_codegen_context.request_headers() {
-                    req.headers_mut().extend(headers);
-                }
-
-                let resp = self.inner.request(req).await?;
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
 
                 let (parts, body) = resp.into_parts();
-                let resp = responses::DeleteCarResponse::from_response(&parts, body).await;
-                api_codegen_context.set_response(parts);
+                let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+                let resp = responses::DeleteCarResponse::from_response(&parts, bytes).await;
+
                 resp
             }
 
@@ -526,34 +527,32 @@ pub mod cars {
                 request: requests::TestBinaryRequest,
             ) -> Result<responses::TestBinaryResponse> {
                 let mut uri = format!(
-                    "{}/v1/spaces/{}/car-service/test-binary",
-                    self.base_uri,
+                    "{}://{}/v1/spaces/{}/car-service/test-binary",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap(),
                     lgn_online::codegen::encoding::to_percent_encoded_string(&request.space_id)?
                 );
 
+                debug!("test_binary: {}", uri);
+
+                let body = hyper::Body::from(request.body);
+
                 let mut req = Request::builder()
-                    .method(Method::POST)
+                    .method(hyper::Method::POST)
                     .uri(uri)
-                    .body(Body::from(request.body))
-                    .map_err(|err| Error::Internal(format!("invalid body: {}", err)))?;
-
-                if let Some(extensions) = api_codegen_context.request_extensions() {
-                    req.extensions_mut().extend(extensions);
-                }
-
-                if let Some(headers) = api_codegen_context.request_headers() {
-                    req.headers_mut().extend(headers);
-                }
+                    .body(body)?;
 
                 req.headers_mut().insert(
                     CONTENT_TYPE,
                     HeaderValue::from_static("application/octet-stream"),
                 );
-                let resp = self.inner.request(req).await?;
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
 
                 let (parts, body) = resp.into_parts();
-                let resp = responses::TestBinaryResponse::from_response(&parts, body).await;
-                api_codegen_context.set_response(parts);
+                let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+                let resp = responses::TestBinaryResponse::from_response(&parts, bytes).await;
+
                 resp
             }
         }
@@ -1096,7 +1095,7 @@ pub mod cars {
 
             pub(crate) async fn from_response(
                 parts: &http::response::Parts,
-                body: hyper::Body,
+                bytes: bytes::Bytes,
             ) -> Result<Self> {
                 match parts.status.as_u16() {
                     200 => {
@@ -1130,7 +1129,6 @@ pub mod cars {
                             .map_err(|e| {
                                 Error::Internal(format!("invalid header: x-string-header: {}", e))
                             })?;
-                        let bytes = hyper::body::to_bytes(body).await?;
                         let body = serde_json::from_slice(&bytes)?;
                         Ok(Self::Status200 {
                             x_bytes_header:
@@ -1174,11 +1172,10 @@ pub mod cars {
 
             pub(crate) async fn from_response(
                 parts: &http::response::Parts,
-                body: hyper::Body,
+                bytes: bytes::Bytes,
             ) -> Result<Self> {
                 match parts.status.as_u16() {
                     200 => {
-                        let bytes = hyper::body::to_bytes(body).await?;
                         let body = serde_json::from_slice(&bytes)?;
                         Ok(Self::Status200(body))
                     }
@@ -1208,11 +1205,10 @@ pub mod cars {
 
             pub(crate) async fn from_response(
                 parts: &http::response::Parts,
-                body: hyper::Body,
+                bytes: bytes::Bytes,
             ) -> Result<Self> {
                 match parts.status.as_u16() {
                     200 => {
-                        let bytes = hyper::body::to_bytes(body).await?;
                         let body = serde_json::from_slice(&bytes)?;
                         Ok(Self::Status200(body))
                     }
@@ -1239,7 +1235,7 @@ pub mod cars {
 
             pub(crate) async fn from_response(
                 parts: &http::response::Parts,
-                _body: hyper::Body,
+                _bytes: bytes::Bytes,
             ) -> Result<Self> {
                 match parts.status.as_u16() {
                     201 => Ok(Self::Status201),
@@ -1272,11 +1268,10 @@ pub mod cars {
 
             pub(crate) async fn from_response(
                 parts: &http::response::Parts,
-                body: hyper::Body,
+                bytes: bytes::Bytes,
             ) -> Result<Self> {
                 match parts.status.as_u16() {
                     200 => {
-                        let bytes = hyper::body::to_bytes(body).await?;
                         let body = serde_json::from_slice(&bytes)?;
                         Ok(Self::Status200(body))
                     }
@@ -1308,7 +1303,7 @@ pub mod cars {
 
             pub(crate) async fn from_response(
                 parts: &http::response::Parts,
-                _body: hyper::Body,
+                _bytes: bytes::Bytes,
             ) -> Result<Self> {
                 match parts.status.as_u16() {
                     200 => Ok(Self::Status200),
@@ -1340,11 +1335,10 @@ pub mod cars {
 
             pub(crate) async fn from_response(
                 parts: &http::response::Parts,
-                body: hyper::Body,
+                bytes: bytes::Bytes,
             ) -> Result<Self> {
                 match parts.status.as_u16() {
                     200 => {
-                        let bytes = hyper::body::to_bytes(body).await?;
                         let body = bytes.into();
                         Ok(Self::Status200(body))
                     }

--- a/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
@@ -1,18 +1,19 @@
 use super::{params, responses, requests};
-use http::{header::CONTENT_TYPE, HeaderValue};
-use hyper::{Body, Method, Request};
+use http::{header::CONTENT_TYPE, HeaderValue, Request, Response};
+use hyper::service::Service;
 use lgn_online::{
     codegen::{Bytes, Context},
     server::{Error, Result},
 };
+use lgn_tracing::debug;
 
 pub struct Client<C> {
-    inner: hyper::Client<C>,
-    base_uri: String,
+    inner: C,
+    base_uri: http::Uri,
 }
 
-impl<C> Client<C> {
-    pub fn new(inner: hyper::Client<C>, base_uri: String) -> Self {
+impl<C> Client<C>{
+    pub fn new(inner: C, base_uri: http::Uri) -> Self {
         Self {
             inner,
             base_uri,
@@ -21,17 +22,24 @@ impl<C> Client<C> {
 }
 
 #[async_trait::async_trait]
-impl<C> super::Api for Client<C>
+impl<C, ResBody> super::Api for Client<C>
 where
-    C: hyper::client::connect::Connect + Clone + Send + Sync + 'static, {
+    C: Service<Request<hyper::Body>, Response = Response<ResBody>> + Clone + Send + Sync,
+    C::Error: Into<lgn_online::server::StdError>,
+    C::Future: Send,
+    ResBody: hyper::body::HttpBody + Send,
+    ResBody::Data: Send,
+    ResBody::Error: Into<lgn_online::server::StdError>,
+{
 {% for (path, routes) in api.paths %}
     {% for route in routes %}
         {% let enum_name = "{}Response"|format(route.name|pascal_case) %}
 
         {% include "signature.rs.jinja" %}{
             let mut uri = format!(
-                "{}{{ path|fmt_rust_path }}",
-                self.base_uri
+                "{}://{}{{ path|fmt_rust_path }}",
+                self.base_uri.scheme_str().unwrap(),
+                self.base_uri.authority().unwrap()
                 {% for parameter in route.parameters.path -%}
                     , lgn_online::codegen::encoding::to_percent_encoded_string(&request.{{ parameter.name|snake_case }})?
                 {% endfor -%}
@@ -49,22 +57,23 @@ where
                 }
             {% endif -%}
 
-            let mut req = Request::builder()
-                .method(Method::{{ route.method|uppercase }})
-                .uri(uri)
+            debug!("{{ route.name|snake_case }}: {}", uri);
+
             {% if let Some(request_body) = route.request_body %}
                 {% match request_body.content.media_type %}
                     {% when MediaType::Json %}
-                        .body(Body::from(serde_json::to_string(&request.body)?))
-                            .map_err(|err| Error::Internal(format!("invalid body: {}", err)))?;
+                        let body = hyper::Body::from(serde_json::to_string(&request.body)?);
                     {% when MediaType::Bytes %}
-                        .body(Body::from(request.body)).map_err(|err| {
-                            Error::Internal(format!("invalid body: {}", err))
-                        })?;
+                        let body = hyper::Body::from(request.body);
                 {% endmatch %}
             {% else %}
-                .body(Body::empty()).unwrap();
+                let body = hyper::Body::empty();
             {% endif -%}
+
+            let mut req = Request::builder()
+                .method(hyper::Method::{{ route.method|uppercase }})
+                .uri(uri)
+                .body(body)?;
 
             if let Some(extensions) = api_codegen_context.request_extensions() {
                 req.extensions_mut().extend(extensions);
@@ -106,11 +115,14 @@ where
                 {% endfor -%}
             {% endif -%}
 
-            let resp = self.inner.request(req).await?;
+            let mut client = self.inner.clone();
+            let resp = client.call(req).await.map_err(Into::into)?;
 
             let (parts, body) = resp.into_parts();
-            let resp = responses::{{ enum_name }}::from_response(&parts, body).await;
+            let bytes = hyper::body::to_bytes(body).await.map_err(Into::into)?;
+            let resp = responses::{{ enum_name }}::from_response(&parts, bytes).await;
             api_codegen_context.set_response(parts);
+
             resp
         }
     {% endfor %}

--- a/crates/lgn-api-codegen/src/rust/templates/responses.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/responses.rs.jinja
@@ -94,7 +94,7 @@ use http::HeaderValue;
                 }
             }
 
-            pub(crate) async fn from_response(parts: &http::response::Parts, {% if route.has_no_responses_content() %}_{% endif %}body: hyper::Body) -> Result<Self> {
+            pub(crate) async fn from_response(parts: &http::response::Parts, {% if route.has_no_responses_content() %}_{% endif %}bytes: bytes::Bytes) -> Result<Self> {
                 {% if route.responses.is_empty() %}
                     Err(Error::Internal(format!(
                         "unexpected status code: {}",
@@ -116,7 +116,6 @@ use http::HeaderValue;
                                         {% endfor -%}
 
                                         {% if let Some(content) = response.content -%}
-                                            let bytes = hyper::body::to_bytes(body).await?;
                                             let body = {% match content.media_type -%}
                                                             {% when MediaType::Json -%}
                                                                 serde_json::from_slice(&bytes)?;
@@ -134,7 +133,6 @@ use http::HeaderValue;
                                             {% endif -%}
                                         })
                                     {%- else if let Some(content) = response.content -%}
-                                        let bytes = hyper::body::to_bytes(body).await?;
                                         let body = {% match content.media_type -%}
                                                         {% when MediaType::Json -%}
                                                             serde_json::from_slice(&bytes)?;

--- a/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
@@ -26,7 +26,7 @@ where
     T: super::Api + Clone + Send + Sync + 'static,
 {
     router
-    {% for (path, routes) in api.paths %}
+    {%- for (path, routes) in api.paths -%}
         .route("{{ path|fmt_axum_path }}",
             {% for route in routes -%}
                 {% if loop.first %}routing::{% else %}.{% endif -%}

--- a/crates/lgn-online/src/client/mod.rs
+++ b/crates/lgn-online/src/client/mod.rs
@@ -1,0 +1,48 @@
+use std::task::{Context, Poll};
+
+use http::{Request, Response};
+use tower::Service;
+
+/// A generic `OpenApi` client.
+#[derive(Clone, Debug)]
+pub struct GenericApiClient<C> {
+    inner: C,
+}
+
+impl<C, ReqBody, ResBody> Service<Request<ReqBody>> for GenericApiClient<C>
+where
+    C: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = C::Response;
+    type Error = C::Error;
+    type Future = C::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+// A default `Hyper` client.
+pub type HyperClient = GenericApiClient<
+    hyper::Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>, hyper::Body>,
+>;
+
+impl Default for HyperClient {
+    fn default() -> Self {
+        let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_or_http()
+            .enable_http2()
+            .build();
+        let client = hyper::Client::builder()
+            .pool_max_idle_per_host(std::usize::MAX)
+            .pool_idle_timeout(None)
+            .build(https_connector);
+
+        Self { inner: client }
+    }
+}

--- a/crates/lgn-online/src/codegen/mod.rs
+++ b/crates/lgn-online/src/codegen/mod.rs
@@ -1,6 +1,7 @@
+pub mod encoding;
+
 mod bytes;
 mod context;
-pub mod encoding;
 
 pub use self::bytes::Bytes;
 pub use context::Context;

--- a/crates/lgn-online/src/lib.rs
+++ b/crates/lgn-online/src/lib.rs
@@ -3,6 +3,7 @@
 // crate-specific lint exceptions:
 #![allow(clippy::implicit_hasher, clippy::missing_errors_doc)]
 
+pub mod client;
 pub mod cloud;
 pub mod codegen;
 pub mod grpc;

--- a/crates/lgn-online/src/server/errors.rs
+++ b/crates/lgn-online/src/server/errors.rs
@@ -6,6 +6,8 @@ use axum::{
 };
 use lgn_tracing::error;
 
+pub type StdError = Box<dyn std::error::Error + Send + Sync>;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("internal: {0}")]
@@ -37,6 +39,18 @@ impl From<serde_qs::Error> for Error {
 impl From<crate::codegen::encoding::Error> for Error {
     fn from(err: crate::codegen::encoding::Error) -> Self {
         Self::Internal(format!("encoding: {}", err))
+    }
+}
+
+impl From<StdError> for Error {
+    fn from(err: StdError) -> Self {
+        Self::Internal(format!("generic: {}", err))
+    }
+}
+
+impl From<http::Error> for Error {
+    fn from(err: http::Error) -> Self {
+        Self::Internal(format!("http: {}", err))
     }
 }
 

--- a/crates/lgn-online/src/server/mod.rs
+++ b/crates/lgn-online/src/server/mod.rs
@@ -1,6 +1,6 @@
 mod errors;
 
-pub use errors::{Error, ErrorExt, Result};
+pub use errors::{Error, ErrorExt, Result, StdError};
 
 use std::{sync::Arc, time::Duration};
 

--- a/tests/api-codegen/src/main.rs
+++ b/tests/api-codegen/src/main.rs
@@ -7,14 +7,11 @@ use std::net::SocketAddr;
 
 use api_codegen::{api::cars::server, api_impl::ApiImpl};
 use axum::Router;
-use lgn_online::server::RouterExt;
 
 #[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
+async fn main() -> anyhow::Result<()> {
     let api = ApiImpl::default();
-
-    let router = Router::new().apply_development_router_options();
-    let router = server::register_routes(router, api);
+    let router = server::register_routes(Router::new(), api);
 
     let addr = "127.0.0.1:3000".parse().unwrap();
     println!("Server listening on http://{}", addr);


### PR DESCRIPTION
This PR changes the `api-codegen` inner client to be compatible with a tower service, so we can reuse the `AuthenticatedClient` wrapper to inject the authorization header into the requests.