### PR TITLE
[api-codegen] Validate header names

### DIFF
--- a/crates/lgn-api-codegen/src/errors.rs
+++ b/crates/lgn-api-codegen/src/errors.rs
@@ -41,6 +41,8 @@ pub enum Error {
     InvalidOpenApiRefLocation(String),
     #[error("invalid json pointer: {0}")]
     InvalidJsonPointer(String),
+    #[error("invalid header name: {0}")]
+    InvalidHeaderName(String),
     #[error("unsupported media-type: {0}")]
     UnsupportedMediaType(String),
     #[error("unsupported type: {0}")]

--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -697,14 +697,14 @@ pub mod cars {
                     let s = h
                         .to_str()
                         .map_err(|err| {
-                            Error::Internal("invalid header: x-string-header".to_owned())
+                            Error::BadRequest(format!("invalid header: x-string-header: {}", err))
                                 .into_response()
                         })
                         .unwrap();
 
                     lgn_online::codegen::encoding::from_percent_encoded_string(s)
                         .map_err(|err| {
-                            Error::Internal("invalid header: x-string-header".to_owned())
+                            Error::BadRequest(format!("invalid header: x-string-header: {}", err))
                                 .into_response()
                         })
                         .unwrap()
@@ -717,14 +717,14 @@ pub mod cars {
                     let s = h
                         .to_str()
                         .map_err(|err| {
-                            Error::Internal("invalid header: x-bytes-header".to_owned())
+                            Error::BadRequest(format!("invalid header: x-bytes-header: {}", err))
                                 .into_response()
                         })
                         .unwrap();
 
                     lgn_online::codegen::encoding::from_percent_encoded_string(s)
                         .map_err(|err| {
-                            Error::Internal("invalid header: x-bytes-header".to_owned())
+                            Error::BadRequest(format!("invalid header: x-bytes-header: {}", err))
                                 .into_response()
                         })
                         .unwrap()
@@ -737,14 +737,14 @@ pub mod cars {
                     let s = h
                         .to_str()
                         .map_err(|err| {
-                            Error::Internal("invalid header: x-int-header".to_owned())
+                            Error::BadRequest(format!("invalid header: x-int-header: {}", err))
                                 .into_response()
                         })
                         .unwrap();
 
                     lgn_online::codegen::encoding::from_percent_encoded_string(s)
                         .map_err(|err| {
-                            Error::Internal("invalid header: x-int-header".to_owned())
+                            Error::BadRequest(format!("invalid header: x-int-header: {}", err))
                                 .into_response()
                         })
                         .unwrap()
@@ -809,13 +809,15 @@ pub mod cars {
                     let s = h
                         .to_str()
                         .map_err(|err| {
-                            Error::Internal("invalid header: span-id".to_owned()).into_response()
+                            Error::BadRequest(format!("invalid header: span-id: {}", err))
+                                .into_response()
                         })
                         .unwrap();
 
                     lgn_online::codegen::encoding::from_percent_encoded_string(s)
                         .map_err(|err| {
-                            Error::Internal("invalid header: span-id".to_owned()).into_response()
+                            Error::BadRequest(format!("invalid header: span-id: {}", err))
+                                .into_response()
                         })
                         .unwrap()
                 });

--- a/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
@@ -71,20 +71,20 @@ where
                     .map(|h| {
                         let s = h.to_str()
                         .map_err(|err| {
-                            Error::Internal("invalid header: {{ parameter.name }}".to_owned()).into_response()
+                            Error::BadRequest(format!("invalid header: {{ parameter.name }}: {}", err)).into_response()
                         })
                         .unwrap();
 
                         lgn_online::codegen::encoding::from_percent_encoded_string(s)
                         .map_err(|err| {
-                            Error::Internal("invalid header: {{ parameter.name }}".to_owned()).into_response()
+                            Error::BadRequest(format!("invalid header: {{ parameter.name }}: {}", err)).into_response()
                         })
                         .unwrap()
                 });
 
                 {% if parameter.required %}
                     if {{ param_name }}.is_none() {
-                        return Error::Internal("missing header: {{ parameter.name }}".to_owned()).into_response();
+                        return Error::BadRequest("missing header: {{ parameter.name }}".to_owned()).into_response();
                     }
                     let {{ param_name }} = {{ param_name }}.unwrap();
                 {% endif %}

--- a/crates/lgn-api-codegen/src/visitor.rs
+++ b/crates/lgn-api-codegen/src/visitor.rs
@@ -144,6 +144,12 @@ impl Visitor {
                         Type::Bytes,
                     ]);
 
+                    if http::header::HeaderName::from_lowercase(parameter_data.name.as_bytes())
+                        .is_err()
+                    {
+                        return Err(Error::InvalidHeaderName(parameter_data.name.clone()));
+                    }
+
                     parameters.header.push(self.visit_parameter(
                         &parameter.as_element_ref([&parameter_data.name], parameter_data),
                         allowed_types,
@@ -270,6 +276,10 @@ impl Visitor {
 
             for (header_name, header_ref) in &response.headers {
                 let header = response.resolve_reference_or(["headers", header_name], header_ref)?;
+
+                if http::header::HeaderName::from_lowercase(header_name.as_bytes()).is_err() {
+                    return Err(Error::InvalidHeaderName(header_name.clone()));
+                }
 
                 headers.insert(
                     header_name.clone(),

--- a/crates/lgn-content-store/apis/content_store.yaml
+++ b/crates/lgn-content-store/apis/content_store.yaml
@@ -67,14 +67,14 @@ paths:
                 type: string
                 format: byte
           headers:
-            X-Origin:
+            x-origin:
               $ref: "#/components/headers/X-Origin"
         "204":
           description: Content located at another url.
           headers:
-            X-Origin:
+            x-origin:
               $ref: "#/components/headers/X-Origin"
-            X-Url:
+            x-url:
               $ref: "#/components/headers/X-Url"
         "404":
           description: Not found.


### PR DESCRIPTION
This PR adds header names validation. We now force them to only contain lowercase characters, numerals and symbols as per the as per the HTTP/2.0 specification.

We also return `Bad Request` instead of `Internal Server Error` in case the server receives a missing or invalid header.