### PR TITLE
Api codegen: Full support of additional properties

### DIFF
--- a/crates/lgn-api-codegen/src/api_types.rs
+++ b/crates/lgn-api-codegen/src/api_types.rs
@@ -503,6 +503,7 @@ pub struct Api {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Type {
+    Any,
     Int32,
     Int64,
     UInt32,
@@ -517,10 +518,18 @@ pub enum Type {
     Binary,
     Array(Box<Self>),
     HashSet(Box<Self>),
+    Map(Box<Self>),
     Named(OpenApiRef),
-    Enum { variants: Vec<String> },
-    Struct { fields: BTreeMap<String, Field> },
-    OneOf { types: Vec<Self> },
+    Enum {
+        variants: Vec<String>,
+    },
+    Struct {
+        fields: BTreeMap<String, Field>,
+        map: Option<Box<Self>>,
+    },
+    OneOf {
+        types: Vec<Self>,
+    },
     Box(Box<Self>),
 }
 

--- a/crates/lgn-api-codegen/src/bin/cli.rs
+++ b/crates/lgn-api-codegen/src/bin/cli.rs
@@ -17,6 +17,7 @@ pub enum Language {
     Rust,
     #[clap(name = "typescript")]
     TypeScript,
+    Python,
 }
 
 #[derive(Parser, Debug)]
@@ -91,6 +92,7 @@ fn main() -> anyhow::Result<()> {
             with_package_json: args.with_package_json,
             filename: Some(args.typescript_filename),
         }),
+        Language::Python => InternalLanguage::Python,
     };
 
     generate(internal_language, args.root, &args.openapis, &args.out_dir)?;

--- a/crates/lgn-api-codegen/src/python/filters.rs
+++ b/crates/lgn-api-codegen/src/python/filters.rs
@@ -37,6 +37,7 @@ pub fn fmt_model_name(model: &Model, ctx: &GenerationContext) -> ::askama::Resul
 #[allow(clippy::unnecessary_wraps)]
 pub fn fmt_type(type_: &Type, ctx: &GenerationContext) -> ::askama::Result<String> {
     Ok(match type_ {
+        Type::Any => "Any".to_string(),
         Type::Int32 | Type::Int64 | Type::UInt32 | Type::UInt64 => "int".to_string(),
         Type::String | Type::Bytes | Type::Binary => "str".to_string(), // at the moment the binary is passed as string
         Type::Boolean => "bool".to_string(),
@@ -46,6 +47,7 @@ pub fn fmt_type(type_: &Type, ctx: &GenerationContext) -> ::askama::Result<Strin
         Type::Array(inner) | Type::HashSet(inner) => {
             format!("list[{}]", fmt_type(inner, ctx).unwrap())
         }
+        Type::Map(inner) => format!("dict[string, {}]", fmt_type(inner, ctx).unwrap()),
         Type::Named(ref_) => fmt_model_name(ctx.get_model(ref_)?, ctx)?,
         Type::Enum { .. } | Type::Struct { .. } | Type::OneOf { .. } => {
             return Err(askama::Error::Custom(Box::new(Error::UnsupportedType(

--- a/crates/lgn-api-codegen/src/python/snapshots/lgn_api_codegen__python__tests__py_generation.snap
+++ b/crates/lgn-api-codegen/src/python/snapshots/lgn_api_codegen__python__tests__py_generation.snap
@@ -12,6 +12,7 @@ from json import JSONEncoder
 
 #used by fmt_type
 from datetime import datetime, date
+from typing import Any
 
 # TODO(kdaibov): starting with Python 3.11 we could use StrEnum
 # in that case we could remove the ModelEncoder
@@ -22,6 +23,80 @@ class ModelEncoder(JSONEncoder):
         else:
             return o.__dict__
 
+
+
+class TestAdditionalPropertiesCompositeAny200Response:
+    def __init__(
+        self,
+        name, # : str 
+        time, # : int 
+        
+        additional_properties: dict[str, Any]
+        
+    ):
+        self.name = name
+        self.time = time
+    
+        self.additional_properties = additional_properties
+    
+
+    def to_json(self):
+        return ModelEncoder().encode(self)
+
+    def from_json(body):
+        name = body['name']
+        time = body['time']
+        return TestAdditionalPropertiesCompositeAny200Response(
+            name,
+            time,
+        )
+
+    def __str__(self):
+        return ("TestAdditionalPropertiesCompositeAny200Response (\n"
+        "  name : {}\n"
+        "  time : {}\n"
+        ")"
+        ).format(
+            self.name,
+            self.time,
+        )
+
+
+class TestAdditionalPropertiesCompositeSchema200Response:
+    def __init__(
+        self,
+        name, # : str 
+        time, # : int 
+        
+        additional_properties: dict[str, Pet]
+        
+    ):
+        self.name = name
+        self.time = time
+    
+        self.additional_properties = additional_properties
+    
+
+    def to_json(self):
+        return ModelEncoder().encode(self)
+
+    def from_json(body):
+        name = body['name']
+        time = body['time']
+        return TestAdditionalPropertiesCompositeSchema200Response(
+            name,
+            time,
+        )
+
+    def __str__(self):
+        return ("TestAdditionalPropertiesCompositeSchema200Response (\n"
+        "  name : {}\n"
+        "  time : {}\n"
+        ")"
+        ).format(
+            self.name,
+            self.time,
+        )
 
 
 class TestOneOf200Response:
@@ -67,6 +142,46 @@ import abc
 
 
 # ---------- Requests -------
+
+
+class TestAdditionalPropertiesAnyRequest:
+    def __init__(
+        self,
+    ):
+        pass
+
+
+
+class TestAdditionalPropertiesCompositeAnyRequest:
+    def __init__(
+        self,
+    ):
+        pass
+
+
+
+class TestAdditionalPropertiesCompositeSchemaRequest:
+    def __init__(
+        self,
+    ):
+        pass
+
+
+
+class TestAdditionalPropertiesSchemaRequest:
+    def __init__(
+        self,
+    ):
+        pass
+
+
+
+class TestAdditionalPropertiesStringRequest:
+    def __init__(
+        self,
+    ):
+        pass
+
 
 
 class TestHeadersRequest:
@@ -160,6 +275,181 @@ class TestBinaryRequest:
 
 
 # ---------- Responses -------
+
+class TestAdditionalPropertiesAnyResponse:
+    # status_200 = 200 # dict[string, Any] # Ok.
+    
+    def __init__(self, response):
+        print("response: {}".format(response))
+        print("response.text: {}".format(response.text))
+        self.status_code = response.status_code
+        match response.status_code:
+            case 200:
+                self.json = response.json()
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(response.status_code))
+    
+    def __str__(self):
+        value = ("value", "None")
+        match self.status_code:
+            case 200:
+                value = ("json", self.json)
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(self.status_code))
+        return ("TestAdditionalPropertiesAnyResponse (\n"
+        "  status_code : {}\n"
+        "  {} : {}\n"
+        ")").format(
+            self.status_code, 
+            value[0], 
+            value[1],
+        )
+
+
+
+class TestAdditionalPropertiesCompositeAnyResponse:
+    # status_200 = 200 # TestAdditionalPropertiesCompositeAny200Response # Ok.
+    
+    def __init__(self, response):
+        print("response: {}".format(response))
+        print("response.text: {}".format(response.text))
+        self.status_code = response.status_code
+        match response.status_code:
+            case 200:
+                self.test_additional_properties_composite_any_200_response = TestAdditionalPropertiesCompositeAny200Response.from_json(response.json())
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(response.status_code))
+    
+    def __str__(self):
+        value = ("value", "None")
+        match self.status_code:
+            case 200:
+                value = ("test_additional_properties_composite_any_200_response", self.test_additional_properties_composite_any_200_response)
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(self.status_code))
+        return ("TestAdditionalPropertiesCompositeAnyResponse (\n"
+        "  status_code : {}\n"
+        "  {} : {}\n"
+        ")").format(
+            self.status_code, 
+            value[0], 
+            value[1],
+        )
+
+
+
+class TestAdditionalPropertiesCompositeSchemaResponse:
+    # status_200 = 200 # TestAdditionalPropertiesCompositeSchema200Response # Ok.
+    
+    def __init__(self, response):
+        print("response: {}".format(response))
+        print("response.text: {}".format(response.text))
+        self.status_code = response.status_code
+        match response.status_code:
+            case 200:
+                self.test_additional_properties_composite_schema_200_response = TestAdditionalPropertiesCompositeSchema200Response.from_json(response.json())
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(response.status_code))
+    
+    def __str__(self):
+        value = ("value", "None")
+        match self.status_code:
+            case 200:
+                value = ("test_additional_properties_composite_schema_200_response", self.test_additional_properties_composite_schema_200_response)
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(self.status_code))
+        return ("TestAdditionalPropertiesCompositeSchemaResponse (\n"
+        "  status_code : {}\n"
+        "  {} : {}\n"
+        ")").format(
+            self.status_code, 
+            value[0], 
+            value[1],
+        )
+
+
+
+class TestAdditionalPropertiesSchemaResponse:
+    # status_200 = 200 # dict[string, Pet] # Ok.
+    
+    def __init__(self, response):
+        print("response: {}".format(response))
+        print("response.text: {}".format(response.text))
+        self.status_code = response.status_code
+        match response.status_code:
+            case 200:
+                self.json = response.json()
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(response.status_code))
+    
+    def __str__(self):
+        value = ("value", "None")
+        match self.status_code:
+            case 200:
+                value = ("json", self.json)
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(self.status_code))
+        return ("TestAdditionalPropertiesSchemaResponse (\n"
+        "  status_code : {}\n"
+        "  {} : {}\n"
+        ")").format(
+            self.status_code, 
+            value[0], 
+            value[1],
+        )
+
+
+
+class TestAdditionalPropertiesStringResponse:
+    # status_200 = 200 # dict[string, str] # Ok.
+    
+    def __init__(self, response):
+        print("response: {}".format(response))
+        print("response.text: {}".format(response.text))
+        self.status_code = response.status_code
+        match response.status_code:
+            case 200:
+                self.json = response.json()
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(response.status_code))
+    
+    def __str__(self):
+        value = ("value", "None")
+        match self.status_code:
+            case 200:
+                value = ("json", self.json)
+                
+                pass
+            case _:
+                raise Exception("unexpected status code: {}".format(self.status_code))
+        return ("TestAdditionalPropertiesStringResponse (\n"
+        "  status_code : {}\n"
+        "  {} : {}\n"
+        ")").format(
+            self.status_code, 
+            value[0], 
+            value[1],
+        )
+
+
 
 class TestHeadersResponse:
     # status_200 = 200 # Pet # Ok.
@@ -410,6 +700,46 @@ class TestBinaryResponse:
 class Api(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
+    def test_additional_properties_any(
+        self,
+        request: TestAdditionalPropertiesAnyRequest,
+    ) -> TestAdditionalPropertiesAnyResponse:
+        raise NotImplementedError
+    
+
+    @abc.abstractmethod
+    def test_additional_properties_composite_any(
+        self,
+        request: TestAdditionalPropertiesCompositeAnyRequest,
+    ) -> TestAdditionalPropertiesCompositeAnyResponse:
+        raise NotImplementedError
+    
+
+    @abc.abstractmethod
+    def test_additional_properties_composite_schema(
+        self,
+        request: TestAdditionalPropertiesCompositeSchemaRequest,
+    ) -> TestAdditionalPropertiesCompositeSchemaResponse:
+        raise NotImplementedError
+    
+
+    @abc.abstractmethod
+    def test_additional_properties_schema(
+        self,
+        request: TestAdditionalPropertiesSchemaRequest,
+    ) -> TestAdditionalPropertiesSchemaResponse:
+        raise NotImplementedError
+    
+
+    @abc.abstractmethod
+    def test_additional_properties_string(
+        self,
+        request: TestAdditionalPropertiesStringRequest,
+    ) -> TestAdditionalPropertiesStringResponse:
+        raise NotImplementedError
+    
+
+    @abc.abstractmethod
     def test_headers(
         self,
         request: TestHeadersRequest,
@@ -475,6 +805,111 @@ class Client(Api):
     def __init__(self, uri):
         self.uri = uri
 
+    
+    def test_additional_properties_any(
+        self,
+        request: TestAdditionalPropertiesAnyRequest,
+    ) -> TestAdditionalPropertiesAnyResponse:
+        uri = "{}/test-additional-properties-any".format(
+            self.uri,
+        )
+
+        headers = {}
+
+        print("uri: {}".format(uri))
+
+        resp = requests.get(
+            uri,
+            headers = headers,
+        )
+
+
+        return TestAdditionalPropertiesAnyResponse(resp)
+    
+    
+    def test_additional_properties_composite_any(
+        self,
+        request: TestAdditionalPropertiesCompositeAnyRequest,
+    ) -> TestAdditionalPropertiesCompositeAnyResponse:
+        uri = "{}/test-additional-properties-composite-any".format(
+            self.uri,
+        )
+
+        headers = {}
+
+        print("uri: {}".format(uri))
+
+        resp = requests.get(
+            uri,
+            headers = headers,
+        )
+
+
+        return TestAdditionalPropertiesCompositeAnyResponse(resp)
+    
+    
+    def test_additional_properties_composite_schema(
+        self,
+        request: TestAdditionalPropertiesCompositeSchemaRequest,
+    ) -> TestAdditionalPropertiesCompositeSchemaResponse:
+        uri = "{}/test-additional-properties-composite-schema".format(
+            self.uri,
+        )
+
+        headers = {}
+
+        print("uri: {}".format(uri))
+
+        resp = requests.get(
+            uri,
+            headers = headers,
+        )
+
+
+        return TestAdditionalPropertiesCompositeSchemaResponse(resp)
+    
+    
+    def test_additional_properties_schema(
+        self,
+        request: TestAdditionalPropertiesSchemaRequest,
+    ) -> TestAdditionalPropertiesSchemaResponse:
+        uri = "{}/test-additional-properties-schema".format(
+            self.uri,
+        )
+
+        headers = {}
+
+        print("uri: {}".format(uri))
+
+        resp = requests.get(
+            uri,
+            headers = headers,
+        )
+
+
+        return TestAdditionalPropertiesSchemaResponse(resp)
+    
+    
+    def test_additional_properties_string(
+        self,
+        request: TestAdditionalPropertiesStringRequest,
+    ) -> TestAdditionalPropertiesStringResponse:
+        uri = "{}/test-additional-properties-string".format(
+            self.uri,
+        )
+
+        headers = {}
+
+        print("uri: {}".format(uri))
+
+        resp = requests.get(
+            uri,
+            headers = headers,
+        )
+
+
+        return TestAdditionalPropertiesStringResponse(resp)
+    
     
     def test_headers(
         self,
@@ -682,6 +1117,7 @@ from json import JSONEncoder
 
 #used by fmt_type
 from datetime import datetime, date
+from typing import Any
 
 # TODO(kdaibov): starting with Python 3.11 we could use StrEnum
 # in that case we could remove the ModelEncoder
@@ -698,8 +1134,11 @@ class Alpha:
     def __init__(
         self,
         beta, # : Beta 
+        
+        
     ):
         self.beta = beta
+    
 
     def to_json(self):
         return ModelEncoder().encode(self)
@@ -734,7 +1173,7 @@ class Beta:
 
     def __str__(self):
         return "Beta ( value: {} )".format(self.value)
-   
+
 
 
 
@@ -747,6 +1186,8 @@ class Car:
         id, # : int 
         is_new, # : bool 
         name, # : str 
+        
+        
     ):
         self.code = code
         self.color = color
@@ -754,6 +1195,7 @@ class Car:
         self.id = id
         self.is_new = is_new
         self.name = name
+    
 
     def to_json(self):
         return ModelEncoder().encode(self)
@@ -816,7 +1258,7 @@ class Cars:
 
     def __str__(self):
         return "Cars ( value: {} )".format(self.value)
-   
+
 
 
 
@@ -850,8 +1292,11 @@ class Pet:
     def __init__(
         self,
         name, # : str 
+        
+        
     ):
         self.name = name
+    
 
     def to_json(self):
         return ModelEncoder().encode(self)

--- a/crates/lgn-api-codegen/src/python/templates/models.py.jinja
+++ b/crates/lgn-api-codegen/src/python/templates/models.py.jinja
@@ -3,6 +3,7 @@ from json import JSONEncoder
 
 #used by fmt_type
 from datetime import datetime, date
+from typing import Any
 
 # TODO(kdaibov): starting with Python 3.11 we could use StrEnum
 # in that case we could remove the ModelEncoder
@@ -49,17 +50,25 @@ class {{ model_name }}:
         return "{{ model_name }} ( value: {} )".format(self.value)
 
                 
-{% when Type::Struct with { fields } %}
+{% when Type::Struct with { fields, map } %}
 class {{ model_name }}:
     def __init__(
         self,
         {%- for field in fields.values() %}
         {{ field.name }}, # : {{ field.type_|fmt_type(ctx) }} {% if let Some(description) = field.description -%} # {{ description }}{%- endif %}
         {%- endfor %}
+        {% match map %}
+        {% when Some with (map) %}
+        additional_properties: dict[str, {{ map|fmt_type(ctx) }}]
+        {% when None %}
+        {% endmatch %}
     ):
     {%- for field in fields.values() %}
         self.{{ field.name }} = {{ field.name }}
     {%- endfor %}
+    {% if map.is_some() %}
+        self.additional_properties = additional_properties
+    {% endif %}
 
     def to_json(self):
         return ModelEncoder().encode(self)
@@ -99,7 +108,7 @@ class {{ model_name }}:
             self.{{ field.name }},
         {%- endfor %}
         )
-    
+
 {%- when t %}
 class {{ model_name }}:
     def __init__(
@@ -116,6 +125,6 @@ class {{ model_name }}:
 
     def __str__(self):
         return "{{ model_name }} ( value: {} )".format(self.value)
-   
+
 {% endmatch %}
 {% endfor %}

--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -10,6 +10,34 @@ pub mod cars {
 
     use lgn_online::codegen::Error;
 
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    pub struct TestAdditionalPropertiesCompositeAny200Response {
+        #[serde(flatten)]
+        pub __additional_properties: std::collections::BTreeMap<String, serde_json::Value>,
+
+        #[serde(rename = "name")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+
+        #[serde(rename = "time")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub time: Option<i32>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    pub struct TestAdditionalPropertiesCompositeSchema200Response {
+        #[serde(flatten)]
+        pub __additional_properties: std::collections::BTreeMap<String, super::components::Pet>,
+
+        #[serde(rename = "name")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub name: Option<String>,
+
+        #[serde(rename = "time")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub time: Option<i32>,
+    }
+
     #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
     pub enum TestOneOf200Response {
         #[serde(rename = "option1")]
@@ -30,6 +58,31 @@ pub mod cars {
 
     #[async_trait::async_trait]
     pub trait Api {
+        async fn test_additional_properties_any(
+            &self,
+            request: server::TestAdditionalPropertiesAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesAnyResponse>;
+
+        async fn test_additional_properties_composite_any(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeAnyResponse>;
+
+        async fn test_additional_properties_composite_schema(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeSchemaResponse>;
+
+        async fn test_additional_properties_schema(
+            &self,
+            request: server::TestAdditionalPropertiesSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesSchemaResponse>;
+
+        async fn test_additional_properties_string(
+            &self,
+            request: server::TestAdditionalPropertiesStringRequest,
+        ) -> Result<server::TestAdditionalPropertiesStringResponse>;
+
         async fn test_headers(
             &self,
             request: server::TestHeadersRequest,
@@ -67,6 +120,49 @@ pub mod cars {
 
     #[async_trait::async_trait]
     impl<T: Api + Send + Sync> Api for std::sync::Arc<T> {
+        async fn test_additional_properties_any(
+            &self,
+            request: server::TestAdditionalPropertiesAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesAnyResponse> {
+            self.as_ref().test_additional_properties_any(request).await
+        }
+
+        async fn test_additional_properties_composite_any(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeAnyResponse> {
+            self.as_ref()
+                .test_additional_properties_composite_any(request)
+                .await
+        }
+
+        async fn test_additional_properties_composite_schema(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeSchemaResponse> {
+            self.as_ref()
+                .test_additional_properties_composite_schema(request)
+                .await
+        }
+
+        async fn test_additional_properties_schema(
+            &self,
+            request: server::TestAdditionalPropertiesSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesSchemaResponse> {
+            self.as_ref()
+                .test_additional_properties_schema(request)
+                .await
+        }
+
+        async fn test_additional_properties_string(
+            &self,
+            request: server::TestAdditionalPropertiesStringRequest,
+        ) -> Result<server::TestAdditionalPropertiesStringResponse> {
+            self.as_ref()
+                .test_additional_properties_string(request)
+                .await
+        }
+
         async fn test_headers(
             &self,
             request: server::TestHeadersRequest,
@@ -116,6 +212,49 @@ pub mod cars {
 
     #[async_trait::async_trait]
     impl<T: Api + Send + Sync + ?Sized> Api for Box<T> {
+        async fn test_additional_properties_any(
+            &self,
+            request: server::TestAdditionalPropertiesAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesAnyResponse> {
+            self.as_ref().test_additional_properties_any(request).await
+        }
+
+        async fn test_additional_properties_composite_any(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeAnyResponse> {
+            self.as_ref()
+                .test_additional_properties_composite_any(request)
+                .await
+        }
+
+        async fn test_additional_properties_composite_schema(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeSchemaResponse> {
+            self.as_ref()
+                .test_additional_properties_composite_schema(request)
+                .await
+        }
+
+        async fn test_additional_properties_schema(
+            &self,
+            request: server::TestAdditionalPropertiesSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesSchemaResponse> {
+            self.as_ref()
+                .test_additional_properties_schema(request)
+                .await
+        }
+
+        async fn test_additional_properties_string(
+            &self,
+            request: server::TestAdditionalPropertiesStringRequest,
+        ) -> Result<server::TestAdditionalPropertiesStringResponse> {
+            self.as_ref()
+                .test_additional_properties_string(request)
+                .await
+        }
+
         async fn test_headers(
             &self,
             request: server::TestHeadersRequest,
@@ -165,6 +304,45 @@ pub mod cars {
 
     #[async_trait::async_trait]
     impl<T: Api + Send + Sync + ?Sized> Api for &T {
+        async fn test_additional_properties_any(
+            &self,
+            request: server::TestAdditionalPropertiesAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesAnyResponse> {
+            (**self).test_additional_properties_any(request).await
+        }
+
+        async fn test_additional_properties_composite_any(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeAnyRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeAnyResponse> {
+            (**self)
+                .test_additional_properties_composite_any(request)
+                .await
+        }
+
+        async fn test_additional_properties_composite_schema(
+            &self,
+            request: server::TestAdditionalPropertiesCompositeSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesCompositeSchemaResponse> {
+            (**self)
+                .test_additional_properties_composite_schema(request)
+                .await
+        }
+
+        async fn test_additional_properties_schema(
+            &self,
+            request: server::TestAdditionalPropertiesSchemaRequest,
+        ) -> Result<server::TestAdditionalPropertiesSchemaResponse> {
+            (**self).test_additional_properties_schema(request).await
+        }
+
+        async fn test_additional_properties_string(
+            &self,
+            request: server::TestAdditionalPropertiesStringRequest,
+        ) -> Result<server::TestAdditionalPropertiesStringResponse> {
+            (**self).test_additional_properties_string(request).await
+        }
+
         async fn test_headers(
             &self,
             request: server::TestHeadersRequest,
@@ -219,6 +397,241 @@ pub mod cars {
         use hyper::service::Service;
         use lgn_online::client::{Error, Result};
         use lgn_tracing::debug;
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesAnyResponse {
+            /// Ok.
+            Status200 {
+                body: std::collections::HashMap<String, serde_json::Value>,
+                extra_headers: HeaderMap,
+                extensions: Extensions,
+            },
+        }
+
+        impl TestAdditionalPropertiesAnyResponse {
+            pub(crate) async fn from_response<ResBody>(
+                resp: http::Response<ResBody>,
+            ) -> Result<Self>
+            where
+                ResBody: hyper::body::HttpBody,
+                ResBody::Error: std::error::Error,
+            {
+                let (mut parts, body) = resp.into_parts();
+
+                match parts.status.as_u16() {
+                    200 => {
+                        let bytes = hyper::body::to_bytes(body).await.map_err(|err| {
+                            Error::InvalidReply(format!("failed to read response body: {}", err))
+                        })?;
+                        let body = serde_json::from_slice(&bytes).map_err(|err| {
+                            Error::InvalidReply(format!(
+                                "failed to JSON-decode response body: {}",
+                                err
+                            ))
+                        })?;
+                        Ok(Self::Status200 {
+                            body,
+                            extra_headers: parts.headers,
+                            extensions: parts.extensions,
+                        })
+                    }
+                    status => Err(Error::InvalidReply(format!(
+                        "unexpected status code: {}",
+                        status
+                    ))),
+                }
+            }
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesCompositeAnyResponse {
+            /// Ok.
+            Status200 {
+                body: super::TestAdditionalPropertiesCompositeAny200Response,
+                extra_headers: HeaderMap,
+                extensions: Extensions,
+            },
+        }
+
+        impl TestAdditionalPropertiesCompositeAnyResponse {
+            pub(crate) async fn from_response<ResBody>(
+                resp: http::Response<ResBody>,
+            ) -> Result<Self>
+            where
+                ResBody: hyper::body::HttpBody,
+                ResBody::Error: std::error::Error,
+            {
+                let (mut parts, body) = resp.into_parts();
+
+                match parts.status.as_u16() {
+                    200 => {
+                        let bytes = hyper::body::to_bytes(body).await.map_err(|err| {
+                            Error::InvalidReply(format!("failed to read response body: {}", err))
+                        })?;
+                        let body = serde_json::from_slice(&bytes).map_err(|err| {
+                            Error::InvalidReply(format!(
+                                "failed to JSON-decode response body: {}",
+                                err
+                            ))
+                        })?;
+                        Ok(Self::Status200 {
+                            body,
+                            extra_headers: parts.headers,
+                            extensions: parts.extensions,
+                        })
+                    }
+                    status => Err(Error::InvalidReply(format!(
+                        "unexpected status code: {}",
+                        status
+                    ))),
+                }
+            }
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesCompositeSchemaResponse {
+            /// Ok.
+            Status200 {
+                body: super::TestAdditionalPropertiesCompositeSchema200Response,
+                extra_headers: HeaderMap,
+                extensions: Extensions,
+            },
+        }
+
+        impl TestAdditionalPropertiesCompositeSchemaResponse {
+            pub(crate) async fn from_response<ResBody>(
+                resp: http::Response<ResBody>,
+            ) -> Result<Self>
+            where
+                ResBody: hyper::body::HttpBody,
+                ResBody::Error: std::error::Error,
+            {
+                let (mut parts, body) = resp.into_parts();
+
+                match parts.status.as_u16() {
+                    200 => {
+                        let bytes = hyper::body::to_bytes(body).await.map_err(|err| {
+                            Error::InvalidReply(format!("failed to read response body: {}", err))
+                        })?;
+                        let body = serde_json::from_slice(&bytes).map_err(|err| {
+                            Error::InvalidReply(format!(
+                                "failed to JSON-decode response body: {}",
+                                err
+                            ))
+                        })?;
+                        Ok(Self::Status200 {
+                            body,
+                            extra_headers: parts.headers,
+                            extensions: parts.extensions,
+                        })
+                    }
+                    status => Err(Error::InvalidReply(format!(
+                        "unexpected status code: {}",
+                        status
+                    ))),
+                }
+            }
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesSchemaResponse {
+            /// Ok.
+            Status200 {
+                body: std::collections::HashMap<String, super::super::components::Pet>,
+                extra_headers: HeaderMap,
+                extensions: Extensions,
+            },
+        }
+
+        impl TestAdditionalPropertiesSchemaResponse {
+            pub(crate) async fn from_response<ResBody>(
+                resp: http::Response<ResBody>,
+            ) -> Result<Self>
+            where
+                ResBody: hyper::body::HttpBody,
+                ResBody::Error: std::error::Error,
+            {
+                let (mut parts, body) = resp.into_parts();
+
+                match parts.status.as_u16() {
+                    200 => {
+                        let bytes = hyper::body::to_bytes(body).await.map_err(|err| {
+                            Error::InvalidReply(format!("failed to read response body: {}", err))
+                        })?;
+                        let body = serde_json::from_slice(&bytes).map_err(|err| {
+                            Error::InvalidReply(format!(
+                                "failed to JSON-decode response body: {}",
+                                err
+                            ))
+                        })?;
+                        Ok(Self::Status200 {
+                            body,
+                            extra_headers: parts.headers,
+                            extensions: parts.extensions,
+                        })
+                    }
+                    status => Err(Error::InvalidReply(format!(
+                        "unexpected status code: {}",
+                        status
+                    ))),
+                }
+            }
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesStringResponse {
+            /// Ok.
+            Status200 {
+                body: std::collections::HashMap<String, String>,
+                extra_headers: HeaderMap,
+                extensions: Extensions,
+            },
+        }
+
+        impl TestAdditionalPropertiesStringResponse {
+            pub(crate) async fn from_response<ResBody>(
+                resp: http::Response<ResBody>,
+            ) -> Result<Self>
+            where
+                ResBody: hyper::body::HttpBody,
+                ResBody::Error: std::error::Error,
+            {
+                let (mut parts, body) = resp.into_parts();
+
+                match parts.status.as_u16() {
+                    200 => {
+                        let bytes = hyper::body::to_bytes(body).await.map_err(|err| {
+                            Error::InvalidReply(format!("failed to read response body: {}", err))
+                        })?;
+                        let body = serde_json::from_slice(&bytes).map_err(|err| {
+                            Error::InvalidReply(format!(
+                                "failed to JSON-decode response body: {}",
+                                err
+                            ))
+                        })?;
+                        Ok(Self::Status200 {
+                            body,
+                            extra_headers: parts.headers,
+                            extensions: parts.extensions,
+                        })
+                    }
+                    status => Err(Error::InvalidReply(format!(
+                        "unexpected status code: {}",
+                        status
+                    ))),
+                }
+            }
+        }
 
         // Request type.
 
@@ -698,6 +1111,146 @@ pub mod cars {
             ResBody::Data: Send,
             ResBody::Error: std::error::Error,
         {
+            /// Call to `test_additional_properties_any`.
+            ///
+            /// # Errors
+            ///
+            /// Returns an error in case of failure.
+            pub async fn test_additional_properties_any(
+                &self,
+            ) -> Result<TestAdditionalPropertiesAnyResponse> {
+                let mut uri = format!(
+                    "{}://{}/test-additional-properties-any",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap()
+                );
+
+                debug!("test_additional_properties_any: {}", uri);
+
+                let body = hyper::Body::empty();
+                let mut req = Request::builder()
+                    .method(hyper::Method::GET)
+                    .uri(uri)
+                    .body(body)?;
+
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
+
+                TestAdditionalPropertiesAnyResponse::from_response(resp).await
+            }
+
+            /// Call to `test_additional_properties_composite_any`.
+            ///
+            /// # Errors
+            ///
+            /// Returns an error in case of failure.
+            pub async fn test_additional_properties_composite_any(
+                &self,
+            ) -> Result<TestAdditionalPropertiesCompositeAnyResponse> {
+                let mut uri = format!(
+                    "{}://{}/test-additional-properties-composite-any",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap()
+                );
+
+                debug!("test_additional_properties_composite_any: {}", uri);
+
+                let body = hyper::Body::empty();
+                let mut req = Request::builder()
+                    .method(hyper::Method::GET)
+                    .uri(uri)
+                    .body(body)?;
+
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
+
+                TestAdditionalPropertiesCompositeAnyResponse::from_response(resp).await
+            }
+
+            /// Call to `test_additional_properties_composite_schema`.
+            ///
+            /// # Errors
+            ///
+            /// Returns an error in case of failure.
+            pub async fn test_additional_properties_composite_schema(
+                &self,
+            ) -> Result<TestAdditionalPropertiesCompositeSchemaResponse> {
+                let mut uri = format!(
+                    "{}://{}/test-additional-properties-composite-schema",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap()
+                );
+
+                debug!("test_additional_properties_composite_schema: {}", uri);
+
+                let body = hyper::Body::empty();
+                let mut req = Request::builder()
+                    .method(hyper::Method::GET)
+                    .uri(uri)
+                    .body(body)?;
+
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
+
+                TestAdditionalPropertiesCompositeSchemaResponse::from_response(resp).await
+            }
+
+            /// Call to `test_additional_properties_schema`.
+            ///
+            /// # Errors
+            ///
+            /// Returns an error in case of failure.
+            pub async fn test_additional_properties_schema(
+                &self,
+            ) -> Result<TestAdditionalPropertiesSchemaResponse> {
+                let mut uri = format!(
+                    "{}://{}/test-additional-properties-schema",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap()
+                );
+
+                debug!("test_additional_properties_schema: {}", uri);
+
+                let body = hyper::Body::empty();
+                let mut req = Request::builder()
+                    .method(hyper::Method::GET)
+                    .uri(uri)
+                    .body(body)?;
+
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
+
+                TestAdditionalPropertiesSchemaResponse::from_response(resp).await
+            }
+
+            /// Call to `test_additional_properties_string`.
+            ///
+            /// # Errors
+            ///
+            /// Returns an error in case of failure.
+            pub async fn test_additional_properties_string(
+                &self,
+            ) -> Result<TestAdditionalPropertiesStringResponse> {
+                let mut uri = format!(
+                    "{}://{}/test-additional-properties-string",
+                    self.base_uri.scheme_str().unwrap(),
+                    self.base_uri.authority().unwrap()
+                );
+
+                debug!("test_additional_properties_string: {}", uri);
+
+                let body = hyper::Body::empty();
+                let mut req = Request::builder()
+                    .method(hyper::Method::GET)
+                    .uri(uri)
+                    .body(body)?;
+
+                let mut client = self.inner.clone();
+                let resp = client.call(req).await.map_err(Into::into)?;
+
+                TestAdditionalPropertiesStringResponse::from_response(resp).await
+            }
+
             /// Call to `test_headers`.
             ///
             /// # Errors
@@ -1045,6 +1598,753 @@ pub mod cars {
         use lgn_tracing::error;
         use serde_qs::axum::QsQuery;
         use std::net::SocketAddr;
+
+        // Request type.
+
+        #[derive(Debug)]
+        pub struct TestAdditionalPropertiesAnyRequest {
+            pub parts: http::request::Parts,
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesAnyResponse {
+            /// Ok.
+            Status200(std::collections::HashMap<String, serde_json::Value>),
+            WithHeaders(HeaderMap, Box<TestAdditionalPropertiesAnyResponse>),
+            WithExtensions(Extensions, Box<TestAdditionalPropertiesAnyResponse>),
+        }
+
+        impl TestAdditionalPropertiesAnyResponse {
+            #[must_use]
+            pub fn with_headers(self, headers: http::HeaderMap) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut inner_headers, inner) => {
+                        inner_headers.extend(headers);
+                        Self::WithHeaders(inner_headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_headers(headers)))
+                    }
+                    s => Self::WithHeaders(headers, Box::new(s)),
+                }
+            }
+
+            #[must_use]
+            pub fn with_extensions(self, extensions: Extensions) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut inner_extensions, inner) => {
+                        inner_extensions.extend(extensions);
+                        Self::WithExtensions(inner_extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extensions(extensions)))
+                    }
+                    s => Self::WithExtensions(extensions, Box::new(s)),
+                }
+            }
+
+            /// Extend this response with the specified header.
+            ///
+            /// If the header already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_header(
+                self,
+                key: impl http::header::IntoHeaderName,
+                val: http::header::HeaderValue,
+            ) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithHeaders`, we just add the header to the headers
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut headers, inner) => {
+                        headers.insert(key, val);
+                        Self::WithHeaders(headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_header(key, val)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithHeaders`, so we wrap
+                        // the response in a `WithHeaders` and add the
+                        // header that way.
+                        let mut headers = HeaderMap::new();
+                        headers.insert(key, val);
+                        s.with_headers(headers)
+                    }
+                }
+            }
+
+            /// Extend this response with the specified extension.
+            ///
+            /// If the extension already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_extension<T: Send + Sync + 'static>(self, extension: T) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithExtensions`, we just add the extension to the extensions
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut extensions, inner) => {
+                        extensions.insert(extension);
+                        Self::WithExtensions(extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extension(extension)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithExtensions`, so we wrap
+                        // the response in a `WithExtensions` and add the
+                        // extension that way.
+                        let mut extensions = Extensions::new();
+                        extensions.insert(extension);
+                        s.with_extensions(extensions)
+                    }
+                }
+            }
+
+            pub(crate) fn into_response(self) -> Response {
+                match self {
+                    Self::Status200(body) => {
+                        let body = Json(body);
+                        (axum::http::StatusCode::from_u16(200).unwrap(), body).into_response()
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.headers.extend(headers);
+                        (parts, body).into_response()
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.extensions.extend(extensions);
+                        (parts, body).into_response()
+                    }
+                }
+            }
+        }
+
+        async fn test_additional_properties_any<T>(
+            Extension(api): Extension<T>,
+            parts: Parts,
+        ) -> Response
+        where
+            T: super::Api + Send + Sync + 'static,
+        {
+            let request = TestAdditionalPropertiesAnyRequest { parts };
+
+            match api.test_additional_properties_any(request).await {
+                Ok(resp) => resp.into_response(),
+                Err(err) => err.into_response(),
+            }
+        }
+
+        // Request type.
+
+        #[derive(Debug)]
+        pub struct TestAdditionalPropertiesCompositeAnyRequest {
+            pub parts: http::request::Parts,
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesCompositeAnyResponse {
+            /// Ok.
+            Status200(super::TestAdditionalPropertiesCompositeAny200Response),
+            WithHeaders(HeaderMap, Box<TestAdditionalPropertiesCompositeAnyResponse>),
+            WithExtensions(
+                Extensions,
+                Box<TestAdditionalPropertiesCompositeAnyResponse>,
+            ),
+        }
+
+        impl TestAdditionalPropertiesCompositeAnyResponse {
+            #[must_use]
+            pub fn with_headers(self, headers: http::HeaderMap) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut inner_headers, inner) => {
+                        inner_headers.extend(headers);
+                        Self::WithHeaders(inner_headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_headers(headers)))
+                    }
+                    s => Self::WithHeaders(headers, Box::new(s)),
+                }
+            }
+
+            #[must_use]
+            pub fn with_extensions(self, extensions: Extensions) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut inner_extensions, inner) => {
+                        inner_extensions.extend(extensions);
+                        Self::WithExtensions(inner_extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extensions(extensions)))
+                    }
+                    s => Self::WithExtensions(extensions, Box::new(s)),
+                }
+            }
+
+            /// Extend this response with the specified header.
+            ///
+            /// If the header already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_header(
+                self,
+                key: impl http::header::IntoHeaderName,
+                val: http::header::HeaderValue,
+            ) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithHeaders`, we just add the header to the headers
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut headers, inner) => {
+                        headers.insert(key, val);
+                        Self::WithHeaders(headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_header(key, val)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithHeaders`, so we wrap
+                        // the response in a `WithHeaders` and add the
+                        // header that way.
+                        let mut headers = HeaderMap::new();
+                        headers.insert(key, val);
+                        s.with_headers(headers)
+                    }
+                }
+            }
+
+            /// Extend this response with the specified extension.
+            ///
+            /// If the extension already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_extension<T: Send + Sync + 'static>(self, extension: T) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithExtensions`, we just add the extension to the extensions
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut extensions, inner) => {
+                        extensions.insert(extension);
+                        Self::WithExtensions(extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extension(extension)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithExtensions`, so we wrap
+                        // the response in a `WithExtensions` and add the
+                        // extension that way.
+                        let mut extensions = Extensions::new();
+                        extensions.insert(extension);
+                        s.with_extensions(extensions)
+                    }
+                }
+            }
+
+            pub(crate) fn into_response(self) -> Response {
+                match self {
+                    Self::Status200(body) => {
+                        let body = Json(body);
+                        (axum::http::StatusCode::from_u16(200).unwrap(), body).into_response()
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.headers.extend(headers);
+                        (parts, body).into_response()
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.extensions.extend(extensions);
+                        (parts, body).into_response()
+                    }
+                }
+            }
+        }
+
+        async fn test_additional_properties_composite_any<T>(
+            Extension(api): Extension<T>,
+            parts: Parts,
+        ) -> Response
+        where
+            T: super::Api + Send + Sync + 'static,
+        {
+            let request = TestAdditionalPropertiesCompositeAnyRequest { parts };
+
+            match api.test_additional_properties_composite_any(request).await {
+                Ok(resp) => resp.into_response(),
+                Err(err) => err.into_response(),
+            }
+        }
+
+        // Request type.
+
+        #[derive(Debug)]
+        pub struct TestAdditionalPropertiesCompositeSchemaRequest {
+            pub parts: http::request::Parts,
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesCompositeSchemaResponse {
+            /// Ok.
+            Status200(super::TestAdditionalPropertiesCompositeSchema200Response),
+            WithHeaders(
+                HeaderMap,
+                Box<TestAdditionalPropertiesCompositeSchemaResponse>,
+            ),
+            WithExtensions(
+                Extensions,
+                Box<TestAdditionalPropertiesCompositeSchemaResponse>,
+            ),
+        }
+
+        impl TestAdditionalPropertiesCompositeSchemaResponse {
+            #[must_use]
+            pub fn with_headers(self, headers: http::HeaderMap) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut inner_headers, inner) => {
+                        inner_headers.extend(headers);
+                        Self::WithHeaders(inner_headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_headers(headers)))
+                    }
+                    s => Self::WithHeaders(headers, Box::new(s)),
+                }
+            }
+
+            #[must_use]
+            pub fn with_extensions(self, extensions: Extensions) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut inner_extensions, inner) => {
+                        inner_extensions.extend(extensions);
+                        Self::WithExtensions(inner_extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extensions(extensions)))
+                    }
+                    s => Self::WithExtensions(extensions, Box::new(s)),
+                }
+            }
+
+            /// Extend this response with the specified header.
+            ///
+            /// If the header already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_header(
+                self,
+                key: impl http::header::IntoHeaderName,
+                val: http::header::HeaderValue,
+            ) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithHeaders`, we just add the header to the headers
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut headers, inner) => {
+                        headers.insert(key, val);
+                        Self::WithHeaders(headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_header(key, val)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithHeaders`, so we wrap
+                        // the response in a `WithHeaders` and add the
+                        // header that way.
+                        let mut headers = HeaderMap::new();
+                        headers.insert(key, val);
+                        s.with_headers(headers)
+                    }
+                }
+            }
+
+            /// Extend this response with the specified extension.
+            ///
+            /// If the extension already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_extension<T: Send + Sync + 'static>(self, extension: T) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithExtensions`, we just add the extension to the extensions
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut extensions, inner) => {
+                        extensions.insert(extension);
+                        Self::WithExtensions(extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extension(extension)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithExtensions`, so we wrap
+                        // the response in a `WithExtensions` and add the
+                        // extension that way.
+                        let mut extensions = Extensions::new();
+                        extensions.insert(extension);
+                        s.with_extensions(extensions)
+                    }
+                }
+            }
+
+            pub(crate) fn into_response(self) -> Response {
+                match self {
+                    Self::Status200(body) => {
+                        let body = Json(body);
+                        (axum::http::StatusCode::from_u16(200).unwrap(), body).into_response()
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.headers.extend(headers);
+                        (parts, body).into_response()
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.extensions.extend(extensions);
+                        (parts, body).into_response()
+                    }
+                }
+            }
+        }
+
+        async fn test_additional_properties_composite_schema<T>(
+            Extension(api): Extension<T>,
+            parts: Parts,
+        ) -> Response
+        where
+            T: super::Api + Send + Sync + 'static,
+        {
+            let request = TestAdditionalPropertiesCompositeSchemaRequest { parts };
+
+            match api
+                .test_additional_properties_composite_schema(request)
+                .await
+            {
+                Ok(resp) => resp.into_response(),
+                Err(err) => err.into_response(),
+            }
+        }
+
+        // Request type.
+
+        #[derive(Debug)]
+        pub struct TestAdditionalPropertiesSchemaRequest {
+            pub parts: http::request::Parts,
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesSchemaResponse {
+            /// Ok.
+            Status200(std::collections::HashMap<String, super::super::components::Pet>),
+            WithHeaders(HeaderMap, Box<TestAdditionalPropertiesSchemaResponse>),
+            WithExtensions(Extensions, Box<TestAdditionalPropertiesSchemaResponse>),
+        }
+
+        impl TestAdditionalPropertiesSchemaResponse {
+            #[must_use]
+            pub fn with_headers(self, headers: http::HeaderMap) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut inner_headers, inner) => {
+                        inner_headers.extend(headers);
+                        Self::WithHeaders(inner_headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_headers(headers)))
+                    }
+                    s => Self::WithHeaders(headers, Box::new(s)),
+                }
+            }
+
+            #[must_use]
+            pub fn with_extensions(self, extensions: Extensions) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut inner_extensions, inner) => {
+                        inner_extensions.extend(extensions);
+                        Self::WithExtensions(inner_extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extensions(extensions)))
+                    }
+                    s => Self::WithExtensions(extensions, Box::new(s)),
+                }
+            }
+
+            /// Extend this response with the specified header.
+            ///
+            /// If the header already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_header(
+                self,
+                key: impl http::header::IntoHeaderName,
+                val: http::header::HeaderValue,
+            ) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithHeaders`, we just add the header to the headers
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut headers, inner) => {
+                        headers.insert(key, val);
+                        Self::WithHeaders(headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_header(key, val)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithHeaders`, so we wrap
+                        // the response in a `WithHeaders` and add the
+                        // header that way.
+                        let mut headers = HeaderMap::new();
+                        headers.insert(key, val);
+                        s.with_headers(headers)
+                    }
+                }
+            }
+
+            /// Extend this response with the specified extension.
+            ///
+            /// If the extension already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_extension<T: Send + Sync + 'static>(self, extension: T) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithExtensions`, we just add the extension to the extensions
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut extensions, inner) => {
+                        extensions.insert(extension);
+                        Self::WithExtensions(extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extension(extension)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithExtensions`, so we wrap
+                        // the response in a `WithExtensions` and add the
+                        // extension that way.
+                        let mut extensions = Extensions::new();
+                        extensions.insert(extension);
+                        s.with_extensions(extensions)
+                    }
+                }
+            }
+
+            pub(crate) fn into_response(self) -> Response {
+                match self {
+                    Self::Status200(body) => {
+                        let body = Json(body);
+                        (axum::http::StatusCode::from_u16(200).unwrap(), body).into_response()
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.headers.extend(headers);
+                        (parts, body).into_response()
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.extensions.extend(extensions);
+                        (parts, body).into_response()
+                    }
+                }
+            }
+        }
+
+        async fn test_additional_properties_schema<T>(
+            Extension(api): Extension<T>,
+            parts: Parts,
+        ) -> Response
+        where
+            T: super::Api + Send + Sync + 'static,
+        {
+            let request = TestAdditionalPropertiesSchemaRequest { parts };
+
+            match api.test_additional_properties_schema(request).await {
+                Ok(resp) => resp.into_response(),
+                Err(err) => err.into_response(),
+            }
+        }
+
+        // Request type.
+
+        #[derive(Debug)]
+        pub struct TestAdditionalPropertiesStringRequest {
+            pub parts: http::request::Parts,
+        }
+
+        // Response type.
+
+        #[derive(Debug)]
+        pub enum TestAdditionalPropertiesStringResponse {
+            /// Ok.
+            Status200(std::collections::HashMap<String, String>),
+            WithHeaders(HeaderMap, Box<TestAdditionalPropertiesStringResponse>),
+            WithExtensions(Extensions, Box<TestAdditionalPropertiesStringResponse>),
+        }
+
+        impl TestAdditionalPropertiesStringResponse {
+            #[must_use]
+            pub fn with_headers(self, headers: http::HeaderMap) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut inner_headers, inner) => {
+                        inner_headers.extend(headers);
+                        Self::WithHeaders(inner_headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_headers(headers)))
+                    }
+                    s => Self::WithHeaders(headers, Box::new(s)),
+                }
+            }
+
+            #[must_use]
+            pub fn with_extensions(self, extensions: Extensions) -> Self {
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut inner_extensions, inner) => {
+                        inner_extensions.extend(extensions);
+                        Self::WithExtensions(inner_extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extensions(extensions)))
+                    }
+                    s => Self::WithExtensions(extensions, Box::new(s)),
+                }
+            }
+
+            /// Extend this response with the specified header.
+            ///
+            /// If the header already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_header(
+                self,
+                key: impl http::header::IntoHeaderName,
+                val: http::header::HeaderValue,
+            ) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithHeaders`, we just add the header to the headers
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithHeaders(mut headers, inner) => {
+                        headers.insert(key, val);
+                        Self::WithHeaders(headers, inner)
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        Self::WithExtensions(extensions, Box::new(inner.with_header(key, val)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithHeaders`, so we wrap
+                        // the response in a `WithHeaders` and add the
+                        // header that way.
+                        let mut headers = HeaderMap::new();
+                        headers.insert(key, val);
+                        s.with_headers(headers)
+                    }
+                }
+            }
+
+            /// Extend this response with the specified extension.
+            ///
+            /// If the extension already existed, it will be overwritten
+            /// silently.
+            #[must_use]
+            pub fn with_extension<T: Send + Sync + 'static>(self, extension: T) -> Self {
+                // Optimization: if the response chain already contains a
+                // `WithExtensions`, we just add the extension to the extensions
+                // map instead of re-boxing the whole thing.
+                #[allow(clippy::match_wildcard_for_single_variants)]
+                match self {
+                    Self::WithExtensions(mut extensions, inner) => {
+                        extensions.insert(extension);
+                        Self::WithExtensions(extensions, inner)
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        Self::WithHeaders(headers, Box::new(inner.with_extension(extension)))
+                    }
+                    s => {
+                        // If we get here, we traversed the entire response
+                        // chain without finding a `WithExtensions`, so we wrap
+                        // the response in a `WithExtensions` and add the
+                        // extension that way.
+                        let mut extensions = Extensions::new();
+                        extensions.insert(extension);
+                        s.with_extensions(extensions)
+                    }
+                }
+            }
+
+            pub(crate) fn into_response(self) -> Response {
+                match self {
+                    Self::Status200(body) => {
+                        let body = Json(body);
+                        (axum::http::StatusCode::from_u16(200).unwrap(), body).into_response()
+                    }
+                    Self::WithHeaders(headers, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.headers.extend(headers);
+                        (parts, body).into_response()
+                    }
+                    Self::WithExtensions(extensions, inner) => {
+                        let (mut parts, body) = inner.into_response().into_parts();
+                        parts.extensions.extend(extensions);
+                        (parts, body).into_response()
+                    }
+                }
+            }
+        }
+
+        async fn test_additional_properties_string<T>(
+            Extension(api): Extension<T>,
+            parts: Parts,
+        ) -> Response
+        where
+            T: super::Api + Send + Sync + 'static,
+        {
+            let request = TestAdditionalPropertiesStringRequest { parts };
+
+            match api.test_additional_properties_string(request).await {
+                Ok(resp) => resp.into_response(),
+                Err(err) => err.into_response(),
+            }
+        }
 
         // Request type.
 
@@ -2306,6 +3606,26 @@ pub mod cars {
             T: super::Api + Clone + Send + Sync + 'static,
         {
             router
+                .route(
+                    "/test-additional-properties-any",
+                    routing::get(test_additional_properties_any::<T>),
+                )
+                .route(
+                    "/test-additional-properties-composite-any",
+                    routing::get(test_additional_properties_composite_any::<T>),
+                )
+                .route(
+                    "/test-additional-properties-composite-schema",
+                    routing::get(test_additional_properties_composite_schema::<T>),
+                )
+                .route(
+                    "/test-additional-properties-schema",
+                    routing::get(test_additional_properties_schema::<T>),
+                )
+                .route(
+                    "/test-additional-properties-string",
+                    routing::get(test_additional_properties_string::<T>),
+                )
                 .route("/test-headers", routing::get(test_headers::<T>))
                 .route("/test-one-of", routing::get(test_one_of::<T>))
                 .route(

--- a/crates/lgn-api-codegen/src/rust/templates/models.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/models.rs.jinja
@@ -71,9 +71,15 @@ use lgn_online::codegen::Error;
                     Option{{loop.index}}({{ type_|fmt_type(ctx, module_path) }}),
                 {%- endfor -%}
             }
-        {% when Type::Struct with { fields } %}
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+        {% when Type::Struct with { fields, map } %}
+            {{ map|fmt_struct_derive }}
             pub struct {{ model|fmt_model_name(ctx) }} {
+                {% match map %}
+                {% when Some with (map) %}
+                #[serde(flatten)]
+                pub __additional_properties: std::collections::BTreeMap<String, {{ map|fmt_type(ctx, module_path) }}>,
+                {% when None %}
+                {% endmatch %}
                 {% for field in fields.values() %}
                     {% if let Some(description) = field.description -%}/// {{ description }}{%- endif %}
                     #[serde(rename = "{{ field.name }}")]

--- a/crates/lgn-api-codegen/src/typescript/filters.rs
+++ b/crates/lgn-api-codegen/src/typescript/filters.rs
@@ -17,6 +17,7 @@ pub fn fmt_type(
     module_path: &ModulePath,
 ) -> ::askama::Result<String> {
     Ok(match type_ {
+        Type::Any => "any".to_string(),
         Type::Int32 | Type::UInt32 | Type::Float32 => "number".to_string(),
         Type::Int64 | Type::UInt64 | Type::Float64 => "bigint".to_string(),
         Type::String => "string".to_string(),
@@ -25,6 +26,10 @@ pub fn fmt_type(
         Type::DateTime | Type::Date => "Date".to_string(),
         Type::Array(inner) => format!("{}[]", fmt_type(inner, ctx, module_path).unwrap()),
         Type::HashSet(inner) => format!("Set<{}>", fmt_type(inner, ctx, module_path).unwrap()),
+        Type::Map(inner) => format!(
+            "Record<string, {}>",
+            fmt_type(inner, ctx, module_path).unwrap()
+        ),
         Type::Named(ref_) => {
             let ref_module_path = ctx.ref_loc_to_typescript_module_path(ref_.ref_location())?;
 

--- a/crates/lgn-api-codegen/src/typescript/snapshots/lgn_api_codegen__typescript__tests__ts_index_generation.snap
+++ b/crates/lgn-api-codegen/src/typescript/snapshots/lgn_api_codegen__typescript__tests__ts_index_generation.snap
@@ -80,6 +80,20 @@ export abstract class ApiClient {
 // Models and API from: cars
 
 export namespace Cars {
+  export type TestAdditionalPropertiesCompositeAny200Response = {
+    [key: string]: any;
+  } & {
+    name?: string;
+    time?: number;
+  };
+
+  export type TestAdditionalPropertiesCompositeSchema200Response = {
+    [key: string]: Components.Pet;
+  } & {
+    name?: string;
+    time?: number;
+  };
+
   export type TestOneOf200Response =
     | { type: "option1"; value: Components.Pet }
     | { type: "option2"; value: Components.Car }
@@ -88,6 +102,16 @@ export namespace Cars {
   // ---------- Api ----------
 
   export interface Api {
+    testAdditionalPropertiesAny(): Promise<TestAdditionalPropertiesAnyResponse>;
+
+    testAdditionalPropertiesCompositeAny(): Promise<TestAdditionalPropertiesCompositeAnyResponse>;
+
+    testAdditionalPropertiesCompositeSchema(): Promise<TestAdditionalPropertiesCompositeSchemaResponse>;
+
+    testAdditionalPropertiesSchema(): Promise<TestAdditionalPropertiesSchemaResponse>;
+
+    testAdditionalPropertiesString(): Promise<TestAdditionalPropertiesStringResponse>;
+
     testHeaders(input: {
       headers: {
         "x-string-header"?: string;
@@ -160,6 +184,79 @@ export namespace Cars {
       this.#baseUri = baseUri;
     }
 
+    async testAdditionalPropertiesAny(): Promise<TestAdditionalPropertiesAnyResponse> {
+      const url = new URL(`${this.#baseUri}/test-additional-properties-any`);
+
+      const headers = new Headers();
+
+      const response = await this.performRequest(url.toString(), {
+        method: "GET",
+        headers,
+      });
+
+      return TestAdditionalPropertiesAnyResponse.fromResponse(response);
+    }
+
+    async testAdditionalPropertiesCompositeAny(): Promise<TestAdditionalPropertiesCompositeAnyResponse> {
+      const url = new URL(
+        `${this.#baseUri}/test-additional-properties-composite-any`
+      );
+
+      const headers = new Headers();
+
+      const response = await this.performRequest(url.toString(), {
+        method: "GET",
+        headers,
+      });
+
+      return TestAdditionalPropertiesCompositeAnyResponse.fromResponse(
+        response
+      );
+    }
+
+    async testAdditionalPropertiesCompositeSchema(): Promise<TestAdditionalPropertiesCompositeSchemaResponse> {
+      const url = new URL(
+        `${this.#baseUri}/test-additional-properties-composite-schema`
+      );
+
+      const headers = new Headers();
+
+      const response = await this.performRequest(url.toString(), {
+        method: "GET",
+        headers,
+      });
+
+      return TestAdditionalPropertiesCompositeSchemaResponse.fromResponse(
+        response
+      );
+    }
+
+    async testAdditionalPropertiesSchema(): Promise<TestAdditionalPropertiesSchemaResponse> {
+      const url = new URL(`${this.#baseUri}/test-additional-properties-schema`);
+
+      const headers = new Headers();
+
+      const response = await this.performRequest(url.toString(), {
+        method: "GET",
+        headers,
+      });
+
+      return TestAdditionalPropertiesSchemaResponse.fromResponse(response);
+    }
+
+    async testAdditionalPropertiesString(): Promise<TestAdditionalPropertiesStringResponse> {
+      const url = new URL(`${this.#baseUri}/test-additional-properties-string`);
+
+      const headers = new Headers();
+
+      const response = await this.performRequest(url.toString(), {
+        method: "GET",
+        headers,
+      });
+
+      return TestAdditionalPropertiesStringResponse.fromResponse(response);
+    }
+
     async testHeaders(input: {
       headers: {
         "x-string-header"?: string;
@@ -171,7 +268,7 @@ export namespace Cars {
 
       const headers = new Headers();
 
-      if ("x-string-header" in input.headers) {
+      if (input.headers["x-string-header"]) {
         headers.set(
           "x-string-header",
 
@@ -179,7 +276,7 @@ export namespace Cars {
         );
       }
 
-      if ("x-bytes-header" in input.headers) {
+      if (input.headers["x-bytes-header"]) {
         headers.set(
           "x-bytes-header",
 
@@ -187,7 +284,7 @@ export namespace Cars {
         );
       }
 
-      if ("x-int-header" in input.headers) {
+      if (input.headers["x-int-header"]) {
         headers.set(
           "x-int-header",
 
@@ -270,7 +367,7 @@ export namespace Cars {
 
       headers.set("Content-Type", "application/json");
 
-      if ("span-id" in input.headers) {
+      if (input.headers["span-id"]) {
         headers.set(
           "span-id",
 
@@ -368,6 +465,121 @@ export namespace Cars {
   };
 
   // ---------- Responses ----------
+
+  export type TestAdditionalPropertiesAnyResponse = {
+    /** Ok. */ type: "200";
+    value: Record<string, any>;
+  };
+
+  export const TestAdditionalPropertiesAnyResponse = {
+    async fromResponse(
+      response: Response
+    ): Promise<TestAdditionalPropertiesAnyResponse> {
+      switch (response.status) {
+        case 200: {
+          return {
+            type: "200",
+            value: await response.json(),
+          };
+        }
+        default: {
+          throw new InternalError(`unexpected status code: ${response.status}`);
+        }
+      }
+    },
+  };
+
+  export type TestAdditionalPropertiesCompositeAnyResponse = {
+    /** Ok. */ type: "200";
+    value: TestAdditionalPropertiesCompositeAny200Response;
+  };
+
+  export const TestAdditionalPropertiesCompositeAnyResponse = {
+    async fromResponse(
+      response: Response
+    ): Promise<TestAdditionalPropertiesCompositeAnyResponse> {
+      switch (response.status) {
+        case 200: {
+          return {
+            type: "200",
+            value: await response.json(),
+          };
+        }
+        default: {
+          throw new InternalError(`unexpected status code: ${response.status}`);
+        }
+      }
+    },
+  };
+
+  export type TestAdditionalPropertiesCompositeSchemaResponse = {
+    /** Ok. */ type: "200";
+    value: TestAdditionalPropertiesCompositeSchema200Response;
+  };
+
+  export const TestAdditionalPropertiesCompositeSchemaResponse = {
+    async fromResponse(
+      response: Response
+    ): Promise<TestAdditionalPropertiesCompositeSchemaResponse> {
+      switch (response.status) {
+        case 200: {
+          return {
+            type: "200",
+            value: await response.json(),
+          };
+        }
+        default: {
+          throw new InternalError(`unexpected status code: ${response.status}`);
+        }
+      }
+    },
+  };
+
+  export type TestAdditionalPropertiesSchemaResponse = {
+    /** Ok. */ type: "200";
+    value: Record<string, Components.Pet>;
+  };
+
+  export const TestAdditionalPropertiesSchemaResponse = {
+    async fromResponse(
+      response: Response
+    ): Promise<TestAdditionalPropertiesSchemaResponse> {
+      switch (response.status) {
+        case 200: {
+          return {
+            type: "200",
+            value: await response.json(),
+          };
+        }
+        default: {
+          throw new InternalError(`unexpected status code: ${response.status}`);
+        }
+      }
+    },
+  };
+
+  export type TestAdditionalPropertiesStringResponse = {
+    /** Ok. */ type: "200";
+    value: Record<string, string>;
+  };
+
+  export const TestAdditionalPropertiesStringResponse = {
+    async fromResponse(
+      response: Response
+    ): Promise<TestAdditionalPropertiesStringResponse> {
+      switch (response.status) {
+        case 200: {
+          return {
+            type: "200",
+            value: await response.json(),
+          };
+        }
+        default: {
+          throw new InternalError(`unexpected status code: ${response.status}`);
+        }
+      }
+    },
+  };
 
   export type TestHeadersResponse = {
     /** Ok. */ type: "200";

--- a/crates/lgn-api-codegen/src/typescript/templates/client.ts.jinja
+++ b/crates/lgn-api-codegen/src/typescript/templates/client.ts.jinja
@@ -60,7 +60,7 @@ export class Client extends ApiClient implements Api {
                                 {% endif %}
                             ); 
                         {% else %}
-                            if ("{{ parameter.name }}" in input.headers) {
+                            if (input.headers["{{ parameter.name }}"]) {
                                 headers.set(
                                     "{{ parameter.name }}",
                                     {% if parameter.type_ == Type::String %}

--- a/crates/lgn-api-codegen/src/typescript/templates/models.ts.jinja
+++ b/crates/lgn-api-codegen/src/typescript/templates/models.ts.jinja
@@ -13,8 +13,12 @@
                     | { type: "option{{loop.index}}", value: {{ type_|fmt_type(ctx, module_path) }} }
                 {%- endfor -%}
             );
-        {% when Type::Struct with { fields } %}
-            export type {{ model|fmt_model_name(ctx) }} = {
+        {% when Type::Struct with { fields, map } %}
+            export type {{ model|fmt_model_name(ctx) }} =
+                {% match map %}
+                {% when Some with (map) %}{ [key: string]: {{ map|fmt_type(ctx, module_path) }} } &
+                {% when None %}
+                {% endmatch %} {
                 {% for field in fields.values() %}
                     {% if let Some(description) = field.description -%}/** {{ description }} */{%- endif %}
                     {%- if field.required -%}

--- a/crates/lgn-online/src/codegen/mod.rs
+++ b/crates/lgn-online/src/codegen/mod.rs
@@ -2,6 +2,7 @@ pub mod encoding;
 mod errors;
 
 mod bytes;
+
 pub use errors::{Error, Result};
 
 pub use self::bytes::Bytes;

--- a/npm-pkgs/lgn-editor-gui/benchmarks/vite.config.js
+++ b/npm-pkgs/lgn-editor-gui/benchmarks/vite.config.js
@@ -37,9 +37,7 @@ export default defineConfig({
     }),
     svelte({ hot: false }),
     viteTsProto({
-      modules: [
-        { name: "@lgn/proto-editor", glob: "*.proto" },
-      ],
+      modules: [{ name: "@lgn/proto-editor", glob: "*.proto" }],
     }),
   ],
 });

--- a/npm-pkgs/lgn-editor-gui/src/api/index.ts
+++ b/npm-pkgs/lgn-editor-gui/src/api/index.ts
@@ -1,6 +1,7 @@
 import type { Observable } from "rxjs";
 
 import { Log } from "@lgn/apis/log";
+import { Runtime } from "@lgn/apis/runtime";
 import {
   EditorClientImpl,
   GrpcWebImpl as EditorImpl,
@@ -20,11 +21,7 @@ import {
   UploadRawFileResponse,
 } from "@lgn/proto-editor/dist/source_control";
 import { addAuthToClient } from "@lgn/web-client/src/lib/client";
-import { Runtime } from "@lgn/apis";
 import log from "@lgn/web-client/src/lib/log";
-
-import { blobToJson, jsonToBlob } from "../lib/api";
-import { addAuthToClient } from "../lib/client";
 
 import { formatProperties } from "../components/propertyGrid/lib/propertyGrid";
 import type {
@@ -33,7 +30,7 @@ import type {
 } from "../components/propertyGrid/lib/propertyGrid";
 
 const defaultGrpcEditorServerURL = "http://[::1]:50051";
-const defaultGrpcRuntimeServerURL = "http://[::1]:50052";
+// const defaultGrpcRuntimeServerURL = "http://[::1]:50052";
 const defaultRestEditorServerURL = "http://[::1]:5051";
 const defaultRestRuntimeServerURL = "http://[::1]:5052";
 
@@ -52,7 +49,7 @@ let runtimeLogStreamClient: Log.Client;
 
 export function initApiClient({
   grpcEditorServerUrl = defaultGrpcEditorServerURL,
-  grpcRuntimeServerUrl = defaultGrpcRuntimeServerURL,
+  // grpcRuntimeServerUrl = defaultGrpcRuntimeServerURL,
   restEditorServerUrl = defaultRestEditorServerURL,
   restRuntimeServerUrl = defaultRestRuntimeServerURL,
   accessTokenCookieName,
@@ -83,9 +80,10 @@ export function initApiClient({
     })
   );
 
-  runtimeClient = addAuthToClient(new Runtime.Client(
-    {baseUri: restEditorServerUrl,
-  }));
+  runtimeClient = addAuthToClient(
+    new Runtime.Client({ baseUri: restEditorServerUrl }),
+    accessTokenCookieName
+  );
 
   editorLogStreamClient = addAuthToClient(
     new Log.Client({ baseUri: restEditorServerUrl }),
@@ -418,7 +416,7 @@ export async function loadRuntimeManifest({
 }) {
   return runtimeClient.loadManifest({
     params: { "space-id": "0", "workspace-id": "0" },
-    body: jsonToBlob( manifestId )
+    body: new Blob([manifestId]),
   });
 }
 
@@ -429,12 +427,12 @@ export async function loadRuntimeRootAsset({
 }) {
   return runtimeClient.loadRootAsset({
     params: { "space-id": "0", "workspace-id": "0" },
-    body: jsonToBlob( rootAssetId )
+    body: new Blob([rootAssetId]),
   });
 }
 
 export async function pauseRuntime() {
   return runtimeClient.pause({
-    params: { "space-id": "0", "workspace-id": "0" }
+    params: { "space-id": "0", "workspace-id": "0" },
   });
 }

--- a/npm-pkgs/lgn-editor-gui/vite.config.js
+++ b/npm-pkgs/lgn-editor-gui/vite.config.js
@@ -19,9 +19,7 @@ const plugins = [
     extensions: [".ts", ".svelte"],
   }),
   viteTsProto({
-    modules: [
-      { name: "@lgn/proto-editor", glob: "*.proto" },
-    ],
+    modules: [{ name: "@lgn/proto-editor", glob: "*.proto" }],
   }),
   viteApiCodegen({
     path: "../../crates/lgn-streamer/apis",
@@ -51,6 +49,7 @@ const plugins = [
       "../../crates/lgn-governance/apis/space.yaml": "Space",
       "../../crates/lgn-governance/apis/workspace.yaml": "Workspace",
     },
+    filename: "runtime",
   }),
   // viteWasmPack({
   //   crates: [

--- a/npm-pkgs/lgn-runtime-gui/package.json
+++ b/npm-pkgs/lgn-runtime-gui/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@lgn/vite-plugin-api-codegen": "workspace:^0.1.0",
-    "@lgn/vite-plugin-ts-proto": "workspace:^0.1.0",
     "@sveltejs/vite-plugin-svelte": "1.0.0-next.47",
     "@swc/core": "^1.2.196",
     "@testing-library/jest-dom": "^5.16.4",

--- a/npm-pkgs/lgn-runtime-gui/vite.config.js
+++ b/npm-pkgs/lgn-runtime-gui/vite.config.js
@@ -4,7 +4,6 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 import viteApiCodegen from "@lgn/vite-plugin-api-codegen";
-import viteTsProto from "@lgn/vite-plugin-ts-proto";
 
 process.env.VITE_CONSOLE_LOG_LEVEL = "debug";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,7 +229,7 @@ importers:
       postcss-load-config: 4.0.1_postcss@8.4.14
       prettier: 2.6.2
       prettier-plugin-svelte: 2.7.0_kkjbqzpydplecjtkxrgomroeru
-      puppeteer: 14.3.0
+      puppeteer: 14.4.0
       replace-in-file: 6.3.5
       rimraf: 3.0.2
       svelte: 3.48.0
@@ -383,7 +383,6 @@ importers:
     specifiers:
       '@improbable-eng/grpc-web': ^0.15.0
       '@lgn/vite-plugin-api-codegen': workspace:^0.1.0
-      '@lgn/vite-plugin-ts-proto': workspace:^0.1.0
       '@lgn/web-client': ^0.1.0
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.47
       '@swc/core': ^1.2.196
@@ -443,7 +442,6 @@ importers:
       uuid-random: 1.3.2
     devDependencies:
       '@lgn/vite-plugin-api-codegen': link:../vite-plugin-api-codegen
-      '@lgn/vite-plugin-ts-proto': link:../vite-plugin-ts-proto
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.47_svelte@3.48.0+vite@2.9.9
       '@swc/core': 1.2.196
       '@testing-library/jest-dom': 5.16.4
@@ -4410,8 +4408,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /puppeteer/14.3.0:
-    resolution: {integrity: sha512-pDtg1+vyw1UPIhUjh2/VW1HUdQnaZJHfMacrJciR3AVm+PBiqdCEcFeFb3UJ/CDEQlHOClm3/WFa7IjY25zIGg==}
+  /puppeteer/14.4.0:
+    resolution: {integrity: sha512-hAXoJX7IAmnRBwf4VrowoRdrS8hqWZsGuQ1Dg5R0AwDK5juaxnNO/obySo9+ytyF7pp9/VsmIA9yFE1GLSouCQ==}
     engines: {node: '>=14.1.0'}
     requiresBuild: true
     dependencies:

--- a/tests/api-codegen/cars.yaml
+++ b/tests/api-codegen/cars.yaml
@@ -100,6 +100,76 @@ paths:
             schema:
               type: string
               format: binary
+  /test-additional-properties-string:
+    get:
+      operationId: testAdditionalPropertiesString
+      responses:
+        "200":
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+  /test-additional-properties-schema:
+    get:
+      operationId: testAdditionalPropertiesSchema
+      responses:
+        "200":
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "./components.yaml#/schemas/Pet"
+  /test-additional-properties-any:
+    get:
+      operationId: testAdditionalPropertiesAny
+      responses:
+        "200":
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+  /test-additional-properties-composite-any:
+    get:
+      operationId: testAdditionalPropertiesCompositeAny
+      responses:
+        "200":
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  time:
+                    type: integer
+                    format: uint32
+                additionalProperties: true
+  /test-additional-properties-composite-schema:
+    get:
+      operationId: testAdditionalPropertiesCompositeSchema
+      responses:
+        "200":
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  time:
+                    type: integer
+                    format: uint32
+                additionalProperties:
+                  $ref: "./components.yaml#/schemas/Pet"
   /test-one-of:
     get:
       operationId: testOneOf

--- a/tests/api-codegen/src/api_impl.rs
+++ b/tests/api-codegen/src/api_impl.rs
@@ -1,13 +1,24 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    net::SocketAddr,
+    sync::Arc,
+};
 
 use crate::api::cars::{
     self,
     server::{
         CreateCarRequest, CreateCarResponse, DeleteCarRequest, DeleteCarResponse, GetCarRequest,
-        GetCarResponse, GetCarsRequest, GetCarsResponse, TestBinaryRequest, TestBinaryResponse,
+        GetCarResponse, GetCarsRequest, GetCarsResponse, TestAdditionalPropertiesAnyRequest,
+        TestAdditionalPropertiesAnyResponse, TestAdditionalPropertiesCompositeAnyRequest,
+        TestAdditionalPropertiesCompositeAnyResponse,
+        TestAdditionalPropertiesCompositeSchemaRequest,
+        TestAdditionalPropertiesCompositeSchemaResponse, TestAdditionalPropertiesSchemaRequest,
+        TestAdditionalPropertiesSchemaResponse, TestAdditionalPropertiesStringRequest,
+        TestAdditionalPropertiesStringResponse, TestBinaryRequest, TestBinaryResponse,
         TestHeadersRequest, TestHeadersResponse, TestOneOfRequest, TestOneOfResponse,
     },
-    Api,
+    Api, TestAdditionalPropertiesCompositeAny200Response,
+    TestAdditionalPropertiesCompositeSchema200Response,
 };
 use crate::api::components;
 use axum::extract::ConnectInfo;
@@ -86,5 +97,74 @@ impl Api for ApiImpl {
                 resp
             },
         )
+    }
+
+    async fn test_additional_properties_any(
+        &self,
+        _request: TestAdditionalPropertiesAnyRequest,
+    ) -> Result<TestAdditionalPropertiesAnyResponse> {
+        Ok(TestAdditionalPropertiesAnyResponse::Status200(
+            HashMap::from([(
+                "foo".to_string(),
+                serde_json::Value::String("bar".to_string()),
+            )]),
+        ))
+    }
+
+    async fn test_additional_properties_schema(
+        &self,
+        _request: TestAdditionalPropertiesSchemaRequest,
+    ) -> Result<TestAdditionalPropertiesSchemaResponse> {
+        Ok(TestAdditionalPropertiesSchemaResponse::Status200(
+            HashMap::from([(
+                "foo".to_string(),
+                components::Pet {
+                    name: Some("Cat".to_string()),
+                },
+            )]),
+        ))
+    }
+
+    async fn test_additional_properties_string(
+        &self,
+        _request: TestAdditionalPropertiesStringRequest,
+    ) -> Result<TestAdditionalPropertiesStringResponse> {
+        Ok(TestAdditionalPropertiesStringResponse::Status200(
+            HashMap::from([("foo".to_string(), "bar".to_string())]),
+        ))
+    }
+
+    async fn test_additional_properties_composite_any(
+        &self,
+        _request: TestAdditionalPropertiesCompositeAnyRequest,
+    ) -> Result<TestAdditionalPropertiesCompositeAnyResponse> {
+        Ok(TestAdditionalPropertiesCompositeAnyResponse::Status200(
+            TestAdditionalPropertiesCompositeAny200Response {
+                name: Some("foo".to_string()),
+                time: Some(42),
+                __additional_properties: BTreeMap::from([(
+                    "foo".to_string(),
+                    serde_json::Value::String("bar".to_string()),
+                )]),
+            },
+        ))
+    }
+
+    async fn test_additional_properties_composite_schema(
+        &self,
+        _request: TestAdditionalPropertiesCompositeSchemaRequest,
+    ) -> Result<TestAdditionalPropertiesCompositeSchemaResponse> {
+        Ok(TestAdditionalPropertiesCompositeSchemaResponse::Status200(
+            TestAdditionalPropertiesCompositeSchema200Response {
+                name: Some("foo".to_string()),
+                time: Some(42),
+                __additional_properties: BTreeMap::from([(
+                    "foo".to_string(),
+                    components::Pet {
+                        name: Some("Cat".to_string()),
+                    },
+                )]),
+            },
+        ))
     }
 }


### PR DESCRIPTION
In the end of the day this pr fully supports the [additionalProperties](https://swagger.io/docs/specification/data-models/dictionaries/) feature and not just some cases.

Here is what the codegen does when the value of `additionalProperties` is
- [x] `true` - map string -> any
- [x] `false` - _noop_
- [x] some schema - map string -> schema
- [x] `true` + `properties` is provided - struct + flatten `__additional_properties`: map string -> any
- [x] `false` + `properties` is provided - same as without the `additionalProperties` option
- [x] some schema - struct + flatten `__additional_properties`: map string -> schema

@kirdaybov The support for the Python is rather limited for now as I wasn't too sure what you'd like to generate.

@ereOn I had to compromise in Rust to find a type that could feat the "any" type. There are many constraints (Clone, Hash, Deserialize, PartialEq/Ord, etc...) and unfortunately a supertrait that'd require all the above constraints would not work (since Deserialize requires Self to be Sized). We could _almost_ use `serde_json::Value` but it doesn't implement Hash (https://github.com/serde-rs/json/issues/720 and https://github.com/serde-rs/json/issues/747). So instead I created a new 
`JsonValue` newtype that wraps `serde_json::Value` and implements Hash (it's fine except for null).

What do you think?