### PR TITLE
Store indices in volatile provider

### DIFF
--- a/crates/lgn-asset-registry/src/lib.rs
+++ b/crates/lgn-asset-registry/src/lib.rs
@@ -97,10 +97,11 @@ impl AssetRegistryPlugin {
         if load_all_assets_from_manifest {
             if let Ok(resources) = world.resource::<TokioAsyncRuntime>().block_on(async {
                 let manifest = ResourceIndex::new_shared_with_id(
+                    Arc::clone(&data_provider),
                     new_resource_type_and_id_indexer(),
                     manifest_id.clone(),
                 );
-                manifest.enumerate_resources(&data_provider).await
+                manifest.enumerate_resources().await
             }) {
                 let mut config = world.resource_mut::<AssetRegistrySettings>();
 

--- a/crates/lgn-asset-registry/src/lib.rs
+++ b/crates/lgn-asset-registry/src/lib.rs
@@ -97,7 +97,7 @@ impl AssetRegistryPlugin {
         if load_all_assets_from_manifest {
             if let Ok(resources) = world.resource::<TokioAsyncRuntime>().block_on(async {
                 let manifest = ResourceIndex::new_shared_with_id(
-                    Arc::clone(&data_provider),
+                    data_provider,
                     new_resource_type_and_id_indexer(),
                     manifest_id.clone(),
                 );

--- a/crates/lgn-content-store/src/indexing/resource_index.rs
+++ b/crates/lgn-content-store/src/indexing/resource_index.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tokio_stream::StreamExt;
 
 use crate::Provider;
@@ -16,6 +18,7 @@ pub struct ResourceIndex<Indexer>
 where
     Indexer: BasicIndexer + Sync,
 {
+    provider: Arc<Provider>,
     indexer: Indexer,
     tree_id: TreeIdentifierType, // to do: maybe generic, supporting TreeIdentifierAccessor trait (implemented for TreeIdentifier and SharedTreeIdentifier)
 }
@@ -24,29 +27,43 @@ impl<Indexer> ResourceIndex<Indexer>
 where
     Indexer: BasicIndexer + Sync,
 {
-    pub async fn new_exclusive(indexer: Indexer, provider: &Provider) -> Self {
-        let tree_id = empty_tree_id(provider).await.unwrap();
-        Self::new_exclusive_with_id(indexer, tree_id)
+    pub async fn new_exclusive(provider: Arc<Provider>, indexer: Indexer) -> Self {
+        let tree_id = empty_tree_id(&provider).await.unwrap();
+        Self::new_exclusive_with_id(provider, indexer, tree_id)
     }
 
-    pub fn new_exclusive_with_id(indexer: Indexer, tree_id: TreeIdentifier) -> Self {
+    pub fn new_exclusive_with_id(
+        provider: Arc<Provider>,
+        indexer: Indexer,
+        tree_id: TreeIdentifier,
+    ) -> Self {
         Self {
+            provider,
             indexer,
             tree_id: TreeIdentifierType::Exclusive(tree_id),
         }
     }
 
-    pub async fn new_shared(indexer: Indexer, provider: &Provider) -> Self {
-        let tree_id = empty_tree_id(provider).await.unwrap();
-        Self::new_shared_with_raw_id(indexer, tree_id)
+    pub async fn new_shared(provider: Arc<Provider>, indexer: Indexer) -> Self {
+        let tree_id = empty_tree_id(&provider).await.unwrap();
+        Self::new_shared_with_raw_id(provider, indexer, tree_id)
     }
 
-    pub fn new_shared_with_raw_id(indexer: Indexer, tree_id: TreeIdentifier) -> Self {
-        Self::new_shared_with_id(indexer, SharedTreeIdentifier::new(tree_id))
+    pub fn new_shared_with_raw_id(
+        provider: Arc<Provider>,
+        indexer: Indexer,
+        tree_id: TreeIdentifier,
+    ) -> Self {
+        Self::new_shared_with_id(provider, indexer, SharedTreeIdentifier::new(tree_id))
     }
 
-    pub fn new_shared_with_id(indexer: Indexer, shared_tree_id: SharedTreeIdentifier) -> Self {
+    pub fn new_shared_with_id(
+        provider: Arc<Provider>,
+        indexer: Indexer,
+        shared_tree_id: SharedTreeIdentifier,
+    ) -> Self {
         Self {
+            provider,
             indexer,
             tree_id: TreeIdentifierType::Shared(shared_tree_id),
         }
@@ -88,14 +105,10 @@ where
     ///
     /// If the specified index key is invalid or the tree is corrupted, an error
     /// will be returned.
-    pub async fn get_identifier(
-        &self,
-        provider: &Provider,
-        index_key: &IndexKey,
-    ) -> Result<Option<ResourceIdentifier>> {
+    pub async fn get_identifier(&self, index_key: &IndexKey) -> Result<Option<ResourceIdentifier>> {
         let leaf_node = self
             .indexer
-            .get_leaf(provider, &self.id(), index_key)
+            .get_leaf(&self.provider, &self.id(), index_key)
             .await?;
 
         match leaf_node {
@@ -120,14 +133,13 @@ where
     /// will be returned.
     pub async fn add_resource(
         &mut self,
-        provider: &Provider,
         index_key: &IndexKey,
         resource_id: ResourceIdentifier,
     ) -> Result<()> {
         let tree_id = self
             .indexer
             .add_leaf(
-                provider,
+                &self.provider,
                 &self.id(),
                 index_key,
                 TreeLeafNode::Resource(resource_id),
@@ -157,14 +169,13 @@ where
     /// will be returned.
     pub async fn replace_resource(
         &mut self,
-        provider: &Provider,
         index_key: &IndexKey,
         resource_id: ResourceIdentifier,
     ) -> Result<ResourceIdentifier> {
         let (tree_id, leaf_node) = self
             .indexer
             .replace_leaf(
-                provider,
+                &self.provider,
                 &self.id(),
                 index_key,
                 TreeLeafNode::Resource(resource_id),
@@ -193,14 +204,10 @@ where
     ///
     /// If the specified index key is invalid or the tree is corrupted, an error
     /// will be returned.
-    pub async fn remove_resource(
-        &mut self,
-        provider: &Provider,
-        index_key: &IndexKey,
-    ) -> Result<ResourceIdentifier> {
+    pub async fn remove_resource(&mut self, index_key: &IndexKey) -> Result<ResourceIdentifier> {
         let (tree_id, leaf_node) = self
             .indexer
-            .remove_leaf(provider, &self.id(), index_key)
+            .remove_leaf(&self.provider, &self.id(), index_key)
             .await?;
         self.set_id(tree_id);
 
@@ -221,12 +228,9 @@ where
     /// # Errors
     ///
     /// If the tree cannot be read, an error will be returned.
-    pub async fn enumerate_resources(
-        &self,
-        provider: &Provider,
-    ) -> Result<Vec<(IndexKey, ResourceIdentifier)>> {
+    pub async fn enumerate_resources(&self) -> Result<Vec<(IndexKey, ResourceIdentifier)>> {
         self.indexer
-            .enumerate_leaves(provider, &self.id())
+            .enumerate_leaves(&self.provider, &self.id())
             .await?
             .map(|(key, leaf_res)| match leaf_res {
                 Ok(leaf) => match leaf {

--- a/crates/lgn-data-build-cli/src/data-build/main.rs
+++ b/crates/lgn-data-build-cli/src/data-build/main.rs
@@ -99,6 +99,7 @@ async fn main() -> Result<(), String> {
                 &repository_name,
                 &branch_name,
                 Arc::clone(&source_control_content_provider),
+                Arc::clone(&data_content_provider),
             )
             .await
             .map_err(|e| format!("failed to open project {}", e))?;
@@ -155,6 +156,7 @@ async fn main() -> Result<(), String> {
                 &repository_name,
                 &branch_name,
                 Arc::clone(&source_control_content_provider),
+                Arc::clone(&data_content_provider),
             )
             .await
             .map_err(|e| e.to_string())?;
@@ -216,7 +218,7 @@ async fn main() -> Result<(), String> {
 
             if runtime_flag {
                 let manifest_id = output
-                    .into_rt_manifest(&data_content_provider, |_| true)
+                    .into_rt_manifest(data_content_provider, |_| true)
                     .await;
                 println!("{}", manifest_id);
             } else {

--- a/crates/lgn-data-build-cli/src/scrape/config.rs
+++ b/crates/lgn-data-build-cli/src/scrape/config.rs
@@ -50,6 +50,7 @@ impl Config {
             repository_name,
             branch_name,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .map_err(|e| e.to_string())?;

--- a/crates/lgn-data-build-cli/src/scrape/main.rs
+++ b/crates/lgn-data-build-cli/src/scrape/main.rs
@@ -432,6 +432,7 @@ async fn main() -> Result<(), String> {
                 &repository_name,
                 &branch_name,
                 source_control_content_provider,
+                data_content_provider,
             )
             .await
             .map_err(|e| e.to_string())?;

--- a/crates/lgn-data-build-cli/tests/tests.rs
+++ b/crates/lgn-data-build-cli/tests/tests.rs
@@ -54,6 +54,7 @@ async fn build_device() {
         &repository_name,
         branch_name,
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
     )
     .await
     .expect("new project");
@@ -254,6 +255,7 @@ async fn no_intermediate_resource() {
             &repository_name,
             branch_name,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("new project");
@@ -374,6 +376,7 @@ async fn with_intermediate_resource() {
             &repository_name,
             branch_name,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("new project");

--- a/crates/lgn-data-build-cli/tests/tests.rs
+++ b/crates/lgn-data-build-cli/tests/tests.rs
@@ -74,7 +74,7 @@ async fn build_device() {
         edit.content = initial_content.to_string();
         resource.apply(edit, &resources);
 
-        let source_id = project
+        project
             .add_resource(
                 ResourcePathName::new("test_source"),
                 refs_resource::TestResource::TYPE,
@@ -82,11 +82,7 @@ async fn build_device() {
                 &resources,
             )
             .await
-            .expect("adding the resource");
-
-        project.commit("add resource").await.expect("committing");
-
-        source_id
+            .expect("adding the resource")
     };
 
     let target_dir = {
@@ -197,8 +193,6 @@ async fn build_device() {
             .save_resource(source_id, resource, &resources)
             .await
             .expect("successful save");
-
-        project.commit("save resource").await.expect("committing");
     }
 
     registry.update();
@@ -270,7 +264,7 @@ async fn no_intermediate_resource() {
                 .new_resource(refs_resource::TestResource::TYPE)
                 .expect("new resource");
 
-            let resource_id = project
+            project
                 .add_resource(
                     ResourcePathName::new("test_source"),
                     refs_resource::TestResource::TYPE,
@@ -278,11 +272,7 @@ async fn no_intermediate_resource() {
                     &resources,
                 )
                 .await
-                .expect("adding the resource");
-
-            project.commit("add resource").await.expect("committing");
-
-            resource_id
+                .expect("adding the resource")
         };
 
         let mut build = DataBuildOptions::new(
@@ -391,7 +381,7 @@ async fn with_intermediate_resource() {
                 .new_resource(text_resource::TextResource::TYPE)
                 .expect("new resource");
 
-            let resource_id = project
+            project
                 .add_resource(
                     ResourcePathName::new("test_source"),
                     text_resource::TextResource::TYPE,
@@ -399,11 +389,7 @@ async fn with_intermediate_resource() {
                     &resources,
                 )
                 .await
-                .expect("adding the resource");
-
-            project.commit("add resource").await.expect("committing");
-
-            resource_id
+                .expect("adding the resource")
         };
 
         let mut build = DataBuildOptions::new_with_sqlite_output(

--- a/crates/lgn-data-build/src/databuild.rs
+++ b/crates/lgn-data-build/src/databuild.rs
@@ -168,6 +168,7 @@ impl DataBuild {
                     )
                     .add_device_source_cas(
                         Arc::clone(&config.source_control_content_provider),
+                        Arc::clone(&config.data_content_provider),
                         project.source_manifest_id(),
                     );
 

--- a/crates/lgn-data-build/src/databuild.rs
+++ b/crates/lgn-data-build/src/databuild.rs
@@ -264,7 +264,7 @@ impl DataBuild {
     #[allow(clippy::type_complexity)]
     async fn compile_node(
         output_index: &OutputIndex,
-        data_provider: &Provider,
+        data_provider: Arc<Provider>,
         source_manifest_id: &SharedTreeIdentifier,
         runtime_manifest_id: &SharedTreeIdentifier,
         compile_node: &ResourcePathId,
@@ -689,7 +689,7 @@ impl DataBuild {
                     node_hash.insert(compile_node_index, (context_hash, source_hash));
 
                     let output_index = &self.output_index;
-                    let data_content_provider = &self.data_content_provider;
+                    let data_content_provider = Arc::clone(&self.data_content_provider);
                     let source_manifest_id = &self.source_manifest_id;
                     let runtime_manifest_id = &self.runtime_manifest_id;
                     let resources = self.compilers.registry();
@@ -948,7 +948,7 @@ impl DataBuild {
     }
 
     /// Returns data content provider
-    pub fn get_provider(&self) -> &Provider {
+    pub fn get_provider(&self) -> &Arc<Provider> {
         &self.data_content_provider
     }
 }

--- a/crates/lgn-data-build/src/lib.rs
+++ b/crates/lgn-data-build/src/lib.rs
@@ -190,9 +190,6 @@ pub enum Error {
     /// Output database error.
     #[error("Database Error: '{0}'")]
     Database(#[source] sqlx::Error),
-    /// Project has uncommited changes
-    #[error("Project has uncommited changes.")]
-    ProjectNotCommitted,
 }
 
 mod asset_file_writer;

--- a/crates/lgn-data-build/src/source_index.rs
+++ b/crates/lgn-data-build/src/source_index.rs
@@ -327,10 +327,6 @@ impl SourceIndex {
     }
 
     pub async fn source_pull(&mut self, project: &Project, version: &str) -> Result<(), Error> {
-        if !project.get_pending_changes().await?.is_empty() {
-            return Err(Error::ProjectNotCommitted);
-        }
-
         let root_checksum = SourceChecksum(project.root_checksum());
 
         if let Some((current_checksum, _source_index)) = &self.current {
@@ -519,11 +515,6 @@ mod tests {
                 .await
                 .expect("adding the resource");
 
-            project
-                .commit("add resource")
-                .await
-                .expect("successful commit");
-
             (resource_id, resource_handle)
         };
 
@@ -563,11 +554,6 @@ mod tests {
                 .await
                 .expect("successful save");
 
-            project
-                .commit("save resource")
-                .await
-                .expect("successful commit");
-
             source_index.source_pull(&project, version).await.unwrap();
             current_checksum(&source_index)
         };
@@ -585,10 +571,6 @@ mod tests {
                 .delete_resource(resource_id)
                 .await
                 .expect("removed resource");
-            project
-                .commit("delete resource")
-                .await
-                .expect("successful commit");
             source_index.source_pull(&project, version).await.unwrap();
             // TODO: fix test, main index id changes event though content returns to "empty"
             // assert_eq!(current_checksum(&source_index), first_entry_checksum);

--- a/crates/lgn-data-build/src/source_index.rs
+++ b/crates/lgn-data-build/src/source_index.rs
@@ -468,18 +468,19 @@ mod tests {
     #[tokio::test]
     async fn source_index_cache() {
         let work_dir = tempfile::tempdir().unwrap();
-        let source_control_content_provider = Arc::new(Provider::new_in_memory());
-
-        let mut project =
-            Project::new_with_remote_mock(&work_dir.path(), source_control_content_provider)
-                .await
-                .expect("failed to create a project");
-
         let data_provider = Arc::new(Provider::new_in_memory());
+
+        let mut project = Project::new_with_remote_mock(
+            &work_dir.path(),
+            Arc::new(Provider::new_in_memory()),
+            Arc::clone(&data_provider),
+        )
+        .await
+        .expect("failed to create a project");
 
         let version = "0.0.1";
 
-        let mut source_index = SourceIndex::new(data_provider);
+        let mut source_index = SourceIndex::new(Arc::clone(&data_provider));
 
         let _first_entry_checksum = {
             source_index.source_pull(&project, version).await.unwrap();

--- a/crates/lgn-data-build/src/source_index.rs
+++ b/crates/lgn-data-build/src/source_index.rs
@@ -480,7 +480,7 @@ mod tests {
 
         let version = "0.0.1";
 
-        let mut source_index = SourceIndex::new(Arc::clone(&data_provider));
+        let mut source_index = SourceIndex::new(data_provider);
 
         let _first_entry_checksum = {
             source_index.source_pull(&project, version).await.unwrap();

--- a/crates/lgn-data-build/src/test_compile.rs
+++ b/crates/lgn-data-build/src/test_compile.rs
@@ -122,6 +122,7 @@ mod tests {
         let mut project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("failed to create a project");
@@ -264,11 +265,15 @@ mod tests {
     async fn setup_project(
         project_dir: impl AsRef<Path>,
         source_control_content_provider: Arc<Provider>,
+        data_content_provider: Arc<Provider>,
     ) -> (Project, [ResourceTypeAndId; 5]) {
-        let mut project =
-            Project::new_with_remote_mock(project_dir.as_ref(), source_control_content_provider)
-                .await
-                .expect("failed to create a project");
+        let mut project = Project::new_with_remote_mock(
+            project_dir.as_ref(),
+            source_control_content_provider,
+            data_content_provider,
+        )
+        .await
+        .expect("failed to create a project");
 
         let resources = setup_registry().await;
 
@@ -321,6 +326,7 @@ mod tests {
         let mut project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("failed to create a project");
@@ -433,8 +439,12 @@ mod tests {
         let (project_dir, output_dir, source_control_content_provider, data_content_provider) =
             setup_dir(&work_dir);
 
-        let (mut project, resource_list) =
-            setup_project(&project_dir, Arc::clone(&source_control_content_provider)).await;
+        let (mut project, resource_list) = setup_project(
+            &project_dir,
+            Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
+        )
+        .await;
         let root_resource = resource_list[0];
 
         let mut build = DataBuildOptions::new_with_sqlite_output(
@@ -545,6 +555,7 @@ mod tests {
         let mut project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("failed to create a project");
@@ -808,6 +819,7 @@ mod tests {
         let mut project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("new project");
@@ -921,6 +933,7 @@ mod tests {
         let mut project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("new project");

--- a/crates/lgn-data-build/src/test_compile.rs
+++ b/crates/lgn-data-build/src/test_compile.rs
@@ -98,10 +98,6 @@ mod tests {
             .save_resource(resource_id, &handle, &resources)
             .await
             .expect("failed to save resource");
-        project
-            .commit("change resource")
-            .await
-            .expect("failed to commit");
     }
 
     fn test_env() -> CompilationEnv {
@@ -141,10 +137,6 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            project
-                .commit("add resource")
-                .await
-                .expect("failed to commit");
 
             (resource_id, resource_handle)
         };
@@ -200,10 +192,6 @@ mod tests {
                 .save_resource(resource_id, &resource_handle, &resources)
                 .await
                 .unwrap();
-            project
-                .commit("save resource")
-                .await
-                .expect("failed to commit");
         }
 
         // ..re-compile changed resource..
@@ -309,8 +297,6 @@ mod tests {
         )
         .await;
 
-        project.commit("setup project").await.unwrap();
-
         (project, [res_a, res_b, res_c, res_d, res_e])
     }
 
@@ -339,7 +325,7 @@ mod tests {
             let mut edit = resource_handle.instantiate(&resources).unwrap();
             edit.content = source_magic_value.clone();
             resource_handle.apply(edit, &resources);
-            let source_id = project
+            project
                 .add_resource(
                     ResourcePathName::new("resource"),
                     text_resource::TextResource::TYPE,
@@ -347,9 +333,7 @@ mod tests {
                     &resources,
                 )
                 .await
-                .unwrap();
-            project.commit("added resource").await.unwrap();
-            source_id
+                .unwrap()
         };
 
         let mut build = DataBuildOptions::new_with_sqlite_output(
@@ -569,7 +553,7 @@ mod tests {
             edit.text_list = magic_list.clone();
             resource_handle.apply(edit, &resources);
 
-            let source_id = project
+            project
                 .add_resource(
                     ResourcePathName::new("resource"),
                     multitext_resource::MultiTextResource::TYPE,
@@ -577,11 +561,7 @@ mod tests {
                     &resources,
                 )
                 .await
-                .unwrap();
-
-            project.commit("add resource").await.unwrap();
-
-            source_id
+                .unwrap()
         };
 
         let mut build = DataBuildOptions::new_with_sqlite_output(
@@ -713,8 +693,6 @@ mod tests {
                 .await
                 .expect("successful save");
 
-            project.commit("change text_1").await.unwrap();
-
             build.source_pull(&project).await.expect("pulled change");
         }
 
@@ -758,8 +736,6 @@ mod tests {
                 .save_resource(source_id, &handle, &resources)
                 .await
                 .expect("successful save");
-
-            project.commit("change text_0 and text_1").await.unwrap();
 
             build.source_pull(&project).await.expect("pulled change");
         }
@@ -856,7 +832,7 @@ mod tests {
                 vec![ResourcePathId::from(child_id).push(refs_asset::RefsAsset::TYPE)];
             parent_handle.apply(parent, &resources);
 
-            let parent_id = project
+            project
                 .add_resource(
                     ResourcePathName::new("parent"),
                     refs_resource::TestResource::TYPE,
@@ -864,11 +840,7 @@ mod tests {
                     &resources,
                 )
                 .await
-                .unwrap();
-
-            project.commit("create parent and child").await.unwrap();
-
-            parent_id
+                .unwrap()
         };
 
         let mut build = DataBuildOptions::new_with_sqlite_output(
@@ -961,7 +933,7 @@ mod tests {
                 .push(ResourcePathId::from(child_id).push(refs_asset::RefsAsset::TYPE));
             child_handle.apply(edit, &resources);
 
-            let parent_id = project
+            project
                 .add_resource(
                     ResourcePathName::new("parent"),
                     refs_resource::TestResource::TYPE,
@@ -969,11 +941,7 @@ mod tests {
                     &resources,
                 )
                 .await
-                .unwrap();
-
-            project.commit("add parent and child").await.unwrap();
-
-            parent_id
+                .unwrap()
         };
 
         let mut build = DataBuildOptions::new_with_sqlite_output(

--- a/crates/lgn-data-build/src/test_general.rs
+++ b/crates/lgn-data-build/src/test_general.rs
@@ -57,6 +57,7 @@ mod tests {
             &repository_name,
             branch_name,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await;
 
@@ -81,14 +82,14 @@ mod tests {
             project_dir,
             output_dir,
             _repository_index,
-            _source_control_content_provider,
+            source_control_content_provider,
             data_content_provider,
         ) = setup_dir(&work_dir).await;
 
-        let source_control_content_provider = Arc::new(Provider::new_in_memory());
         let project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("failed to create a project");

--- a/crates/lgn-data-build/src/test_general.rs
+++ b/crates/lgn-data-build/src/test_general.rs
@@ -100,7 +100,7 @@ mod tests {
         {
             let _build = DataBuildOptions::new(
                 db_uri.clone(),
-                Arc::clone(&source_control_content_provider),
+                source_control_content_provider,
                 data_content_provider,
                 CompilerRegistryOptions::default(),
             )

--- a/crates/lgn-data-build/src/test_source_pull.rs
+++ b/crates/lgn-data-build/src/test_source_pull.rs
@@ -47,6 +47,7 @@ mod tests {
         let mut project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("failed to create a project");
@@ -95,6 +96,7 @@ mod tests {
         let mut project = Project::new_with_remote_mock(
             &project_dir,
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
         )
         .await
         .expect("failed to create a project");

--- a/crates/lgn-data-build/src/test_source_pull.rs
+++ b/crates/lgn-data-build/src/test_source_pull.rs
@@ -64,7 +64,6 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            project.commit("add resource").await.unwrap();
             resource_id
         });
 
@@ -134,8 +133,6 @@ mod tests {
                 )
                 .await
                 .unwrap();
-
-            project.commit("added parent and child").await.unwrap();
 
             (
                 ResourcePathId::from(child_id),

--- a/crates/lgn-data-compiler-remote/src/compiler_node/remote_data_executor.rs
+++ b/crates/lgn-data-compiler-remote/src/compiler_node/remote_data_executor.rs
@@ -20,7 +20,7 @@ pub struct CompileMessage {
 
 #[allow(dead_code)]
 async fn deploy_remotely(
-    provider: &Provider,
+    provider: Arc<Provider>,
     full_file_path: &Path,
     strip_prefix: &Path,
     files_to_package: Arc<RwLock<Vec<(String, Identifier)>>>,
@@ -40,7 +40,7 @@ async fn deploy_remotely(
 pub(crate) async fn collect_local_resources(
     executable: &Path,
     build_script: &CompilerCompileCmd,
-    data_provider: &Provider,
+    data_provider: Arc<Provider>,
 ) -> Result<String, CompilerError> {
     let files_to_package: Arc<RwLock<Vec<(String, Identifier)>>> =
         Arc::new(RwLock::new(Vec::new()));

--- a/crates/lgn-data-compiler-remote/src/compiler_node/remote_stub.rs
+++ b/crates/lgn-data-compiler-remote/src/compiler_node/remote_stub.rs
@@ -53,7 +53,7 @@ impl CompilerStub for RemoteCompilerStub {
         dependencies: &[ResourcePathId],
         derived_deps: &[CompiledResource],
         _registry: Arc<AssetRegistry>,
-        data_provider: &Provider,
+        data_provider: Arc<Provider>,
         source_manifest_id: &SharedTreeIdentifier,
         _runtime_manifest_id: &SharedTreeIdentifier,
         env: &CompilationEnv,

--- a/crates/lgn-data-compiler/src/compiler_api.rs
+++ b/crates/lgn-data-compiler/src/compiler_api.rs
@@ -182,7 +182,7 @@ pub struct CompilerContext<'a> {
     /// Compilation environment.
     pub env: &'a CompilationEnv,
     /// Content-addressable storage of compilation output.
-    pub provider: &'a Provider,
+    pub provider: Arc<Provider>,
 }
 
 impl CompilerContext<'_> {
@@ -366,7 +366,7 @@ impl CompilerDescriptor {
         dependencies: &[ResourcePathId],
         _derived_deps: &[CompiledResource],
         registry: Arc<AssetRegistry>,
-        provider: &Provider,
+        provider: Arc<Provider>,
         env: &CompilationEnv,
     ) -> Result<CompilationOutput, CompilerError> {
         let transform = compile_path
@@ -500,7 +500,7 @@ async fn run(command: Commands, compilers: CompilerRegistry) -> Result<(), Compi
                 };
 
                 let manifest = manifest
-                    .into_rt_manifest(&data_provider, |_rpid| true)
+                    .into_rt_manifest(Arc::clone(&data_provider), |_rpid| true)
                     .await;
 
                 SharedTreeIdentifier::new(manifest)
@@ -535,7 +535,7 @@ async fn run(command: Commands, compilers: CompilerRegistry) -> Result<(), Compi
                     &dependencies,
                     &derived_deps,
                     shell.registry(),
-                    &data_provider,
+                    data_provider,
                     &source_manifest_id,
                     &runtime_manifest_id,
                     &env,

--- a/crates/lgn-data-compiler/src/compiler_api.rs
+++ b/crates/lgn-data-compiler/src/compiler_api.rs
@@ -515,6 +515,7 @@ async fn run(command: Commands, compilers: CompilerRegistry) -> Result<(), Compi
                     .add_device_cas(Arc::clone(&data_provider), runtime_manifest_id.clone())
                     .add_device_source_cas(
                         Arc::clone(&source_provider),
+                        Arc::clone(&data_provider),
                         source_manifest_id.clone(),
                     ); // todo: filter dependencies only
 

--- a/crates/lgn-data-compiler/src/compiler_node/binary_stub.rs
+++ b/crates/lgn-data-compiler/src/compiler_node/binary_stub.rs
@@ -49,7 +49,7 @@ impl CompilerStub for BinCompilerStub {
         dependencies: &[ResourcePathId],
         derived_deps: &[CompiledResource],
         _registry: Arc<AssetRegistry>,
-        _provider: &Provider,
+        _provider: Arc<Provider>,
         source_manifest_id: &SharedTreeIdentifier,
         _runtime_manifest_id: &SharedTreeIdentifier,
         env: &CompilationEnv,

--- a/crates/lgn-data-compiler/src/compiler_node/compiler_registry.rs
+++ b/crates/lgn-data-compiler/src/compiler_node/compiler_registry.rs
@@ -42,7 +42,7 @@ pub trait CompilerStub: Send + Sync {
         dependencies: &[ResourcePathId],
         derived_deps: &[CompiledResource],
         registry: Arc<AssetRegistry>,
-        provider: &Provider,
+        provider: Arc<Provider>,
         source_manifest_id: &SharedTreeIdentifier,
         runtime_manifest_id: &SharedTreeIdentifier,
         env: &CompilationEnv,

--- a/crates/lgn-data-compiler/src/compiler_node/inproc_stub.rs
+++ b/crates/lgn-data-compiler/src/compiler_node/inproc_stub.rs
@@ -53,7 +53,7 @@ impl CompilerStub for InProcessCompilerStub {
         dependencies: &[ResourcePathId],
         derived_deps: &[CompiledResource],
         registry: Arc<AssetRegistry>,
-        provider: &Provider,
+        provider: Arc<Provider>,
         _source_manifest_id: &SharedTreeIdentifier,
         runtime_manifest_id: &SharedTreeIdentifier,
         env: &CompilationEnv,
@@ -63,7 +63,9 @@ impl CompilerStub for InProcessCompilerStub {
         let manifest = CompiledResources {
             compiled_resources: derived_deps.to_vec(),
         };
-        let manifest_id = manifest.into_rt_manifest(provider, |_rpid| true).await;
+        let manifest_id = manifest
+            .into_rt_manifest(Arc::clone(&provider), |_rpid| true)
+            .await;
         runtime_manifest_id.write(manifest_id);
 
         let result = self

--- a/crates/lgn-data-compiler/src/compiler_node/mod.rs
+++ b/crates/lgn-data-compiler/src/compiler_node/mod.rs
@@ -200,7 +200,7 @@ mod tests {
                     &[],
                     &[],
                     registry,
-                    &data_content_provider,
+                    data_content_provider,
                     &source_manifest_id,
                     &runtime_manifest_id,
                     &env,

--- a/crates/lgn-data-compiler/tests/command.rs
+++ b/crates/lgn-data-compiler/tests/command.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use lgn_content_store::{
     indexing::{ResourceExists, ResourceReader, TreeIdentifier},
     Config, Provider,
@@ -12,7 +14,7 @@ mod common;
 
 async fn create_test_resource(
     id: ResourceTypeAndId,
-    provider: &Provider,
+    provider: Arc<Provider>,
     content: &str,
 ) -> TreeIdentifier {
     let mut proc = refs_resource::TestResourceProc {};
@@ -68,9 +70,11 @@ async fn command_compiler_hash() {
 
 #[tokio::test]
 async fn command_compile() {
-    let persistent_content_provider = Config::load_and_instantiate_persistent_provider()
-        .await
-        .unwrap();
+    let persistent_content_provider = Arc::new(
+        Config::load_and_instantiate_persistent_provider()
+            .await
+            .unwrap(),
+    );
 
     let content = "test content";
 
@@ -79,7 +83,7 @@ async fn command_compile() {
         id: ResourceId::new(),
     };
     let source_manifest_id =
-        create_test_resource(source, &persistent_content_provider, content).await;
+        create_test_resource(source, persistent_content_provider, content).await;
 
     let exe_path = common::compiler_exe("test-refs");
     assert!(exe_path.exists());

--- a/crates/lgn-data-compiler/tests/command.rs
+++ b/crates/lgn-data-compiler/tests/command.rs
@@ -14,7 +14,8 @@ mod common;
 
 async fn create_test_resource(
     id: ResourceTypeAndId,
-    provider: Arc<Provider>,
+    persistent_provider: &Provider,
+    volatile_provider: Arc<Provider>,
     content: &str,
 ) -> TreeIdentifier {
     let mut proc = refs_resource::TestResourceProc {};
@@ -25,7 +26,14 @@ async fn create_test_resource(
         .unwrap()
         .content = String::from(content);
 
-    common::write_resource(id, provider, &proc, resource.as_ref()).await
+    common::write_resource(
+        id,
+        persistent_provider,
+        volatile_provider,
+        &proc,
+        resource.as_ref(),
+    )
+    .await
 }
 
 #[tokio::test]
@@ -70,8 +78,11 @@ async fn command_compiler_hash() {
 
 #[tokio::test]
 async fn command_compile() {
-    let persistent_content_provider = Arc::new(
-        Config::load_and_instantiate_persistent_provider()
+    let persistent_content_provider = Config::load_and_instantiate_persistent_provider()
+        .await
+        .unwrap();
+    let volatile_content_provider = Arc::new(
+        Config::load_and_instantiate_volatile_provider()
             .await
             .unwrap(),
     );
@@ -82,8 +93,13 @@ async fn command_compile() {
         kind: refs_resource::TestResource::TYPE,
         id: ResourceId::new(),
     };
-    let source_manifest_id =
-        create_test_resource(source, persistent_content_provider, content).await;
+    let source_manifest_id = create_test_resource(
+        source,
+        &persistent_content_provider,
+        volatile_content_provider,
+        content,
+    )
+    .await;
 
     let exe_path = common::compiler_exe("test-refs");
     assert!(exe_path.exists());

--- a/crates/lgn-data-compiler/tests/common/mod.rs
+++ b/crates/lgn-data-compiler/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf};
+use std::{env, path::PathBuf, sync::Arc};
 
 use lgn_content_store::{
     indexing::{ResourceIndex, ResourceWriter, TreeIdentifier},
@@ -37,7 +37,7 @@ pub fn test_env() -> CompilationEnv {
 
 pub async fn write_resource(
     id: ResourceTypeAndId,
-    provider: &Provider,
+    provider: Arc<Provider>,
     proc: &impl ResourceProcessor,
     resource: &dyn Resource,
 ) -> TreeIdentifier {
@@ -57,9 +57,9 @@ pub async fn write_resource(
         .expect("write to content-store");
 
     let mut source_manifest =
-        ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), provider).await;
+        ResourceIndex::new_exclusive(provider, new_resource_type_and_id_indexer()).await;
     source_manifest
-        .add_resource(provider, &id.into(), resource_id)
+        .add_resource(&id.into(), resource_id)
         .await
         .expect("write manifest to content-store");
     source_manifest.id()

--- a/crates/lgn-data-compiler/tests/common/mod.rs
+++ b/crates/lgn-data-compiler/tests/common/mod.rs
@@ -37,7 +37,8 @@ pub fn test_env() -> CompilationEnv {
 
 pub async fn write_resource(
     id: ResourceTypeAndId,
-    provider: Arc<Provider>,
+    persistent_provider: &Provider,
+    volatile_provider: Arc<Provider>,
     proc: &impl ResourceProcessor,
     resource: &dyn Resource,
 ) -> TreeIdentifier {
@@ -51,13 +52,13 @@ pub async fn write_resource(
     proc.write_resource(resource, &mut bytes)
         .expect("write to memory");
 
-    let resource_id = provider
+    let resource_id = persistent_provider
         .write_resource_from_bytes(&bytes.into_inner())
         .await
         .expect("write to content-store");
 
     let mut source_manifest =
-        ResourceIndex::new_exclusive(provider, new_resource_type_and_id_indexer()).await;
+        ResourceIndex::new_exclusive(volatile_provider, new_resource_type_and_id_indexer()).await;
     source_manifest
         .add_resource(&id.into(), resource_id)
         .await

--- a/crates/lgn-data-compiler/tests/compile.rs
+++ b/crates/lgn-data-compiler/tests/compile.rs
@@ -27,8 +27,11 @@ fn find_compiler() {
 
 #[tokio::test]
 async fn compile_atoi() {
-    let persistent_content_provider = Arc::new(
-        lgn_content_store::Config::load_and_instantiate_persistent_provider()
+    let persistent_content_provider = Config::load_and_instantiate_persistent_provider()
+        .await
+        .unwrap();
+    let volatile_content_provider = Arc::new(
+        Config::load_and_instantiate_volatile_provider()
             .await
             .unwrap(),
     );
@@ -50,8 +53,14 @@ async fn compile_atoi() {
 
         resource.content = source_magic_value.clone();
 
-        let source_manifest_id =
-            common::write_resource(source, persistent_content_provider, &proc, resource).await;
+        let source_manifest_id = common::write_resource(
+            source,
+            &persistent_content_provider,
+            volatile_content_provider,
+            &proc,
+            resource,
+        )
+        .await;
 
         (source, source_manifest_id)
     };
@@ -105,8 +114,11 @@ async fn compile_atoi() {
 
 #[tokio::test]
 async fn compile_intermediate() {
-    let persistent_content_provider = Arc::new(
-        lgn_content_store::Config::load_and_instantiate_persistent_provider()
+    let persistent_content_provider = Config::load_and_instantiate_persistent_provider()
+        .await
+        .unwrap();
+    let volatile_content_provider = Arc::new(
+        Config::load_and_instantiate_volatile_provider()
             .await
             .unwrap(),
     );
@@ -126,8 +138,14 @@ async fn compile_intermediate() {
 
         resource.content = source_magic_value.clone();
 
-        let source_manifest_id =
-            common::write_resource(source, persistent_content_provider, &proc, resource).await;
+        let source_manifest_id = common::write_resource(
+            source,
+            &persistent_content_provider,
+            volatile_content_provider,
+            &proc,
+            resource,
+        )
+        .await;
 
         (source, source_manifest_id)
     };
@@ -203,8 +221,11 @@ async fn compile_intermediate() {
 
 #[tokio::test]
 async fn compile_multi_resource() {
-    let persistent_content_provider = Arc::new(
-        lgn_content_store::Config::load_and_instantiate_persistent_provider()
+    let persistent_content_provider = Config::load_and_instantiate_persistent_provider()
+        .await
+        .unwrap();
+    let volatile_content_provider = Arc::new(
+        Config::load_and_instantiate_volatile_provider()
             .await
             .unwrap(),
     );
@@ -224,8 +245,14 @@ async fn compile_multi_resource() {
 
         resource.text_list = source_text_list.clone();
 
-        let source_manifest_id =
-            common::write_resource(source, persistent_content_provider, &proc, resource).await;
+        let source_manifest_id = common::write_resource(
+            source,
+            &persistent_content_provider,
+            volatile_content_provider,
+            &proc,
+            resource,
+        )
+        .await;
 
         (source, source_manifest_id)
     };
@@ -290,8 +317,11 @@ async fn compile_multi_resource() {
 
 #[tokio::test]
 async fn compile_base64() {
-    let persistent_content_provider = Arc::new(
-        lgn_content_store::Config::load_and_instantiate_persistent_provider()
+    let persistent_content_provider = Config::load_and_instantiate_persistent_provider()
+        .await
+        .unwrap();
+    let volatile_content_provider = Arc::new(
+        Config::load_and_instantiate_volatile_provider()
             .await
             .unwrap(),
     );
@@ -314,8 +344,14 @@ async fn compile_base64() {
 
         resource.content = source_binary_value;
 
-        let source_manifest_id =
-            common::write_resource(source, persistent_content_provider, &proc, resource).await;
+        let source_manifest_id = common::write_resource(
+            source,
+            &persistent_content_provider,
+            volatile_content_provider,
+            &proc,
+            resource,
+        )
+        .await;
 
         (source, source_manifest_id)
     };

--- a/crates/lgn-data-compiler/tests/compile.rs
+++ b/crates/lgn-data-compiler/tests/compile.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use binary_resource::BinaryResource;
 use integer_asset::{IntegerAsset, IntegerAssetLoader};
 use lgn_content_store::{
@@ -25,10 +27,11 @@ fn find_compiler() {
 
 #[tokio::test]
 async fn compile_atoi() {
-    let persistent_content_provider =
+    let persistent_content_provider = Arc::new(
         lgn_content_store::Config::load_and_instantiate_persistent_provider()
             .await
-            .unwrap();
+            .unwrap(),
+    );
 
     let source_magic_value = String::from("47");
 
@@ -48,7 +51,7 @@ async fn compile_atoi() {
         resource.content = source_magic_value.clone();
 
         let source_manifest_id =
-            common::write_resource(source, &persistent_content_provider, &proc, resource).await;
+            common::write_resource(source, persistent_content_provider, &proc, resource).await;
 
         (source, source_manifest_id)
     };
@@ -102,10 +105,11 @@ async fn compile_atoi() {
 
 #[tokio::test]
 async fn compile_intermediate() {
-    let persistent_content_provider =
+    let persistent_content_provider = Arc::new(
         lgn_content_store::Config::load_and_instantiate_persistent_provider()
             .await
-            .unwrap();
+            .unwrap(),
+    );
 
     let source_magic_value = String::from("47");
 
@@ -123,7 +127,7 @@ async fn compile_intermediate() {
         resource.content = source_magic_value.clone();
 
         let source_manifest_id =
-            common::write_resource(source, &persistent_content_provider, &proc, resource).await;
+            common::write_resource(source, persistent_content_provider, &proc, resource).await;
 
         (source, source_manifest_id)
     };
@@ -199,10 +203,11 @@ async fn compile_intermediate() {
 
 #[tokio::test]
 async fn compile_multi_resource() {
-    let persistent_content_provider =
+    let persistent_content_provider = Arc::new(
         lgn_content_store::Config::load_and_instantiate_persistent_provider()
             .await
-            .unwrap();
+            .unwrap(),
+    );
 
     let source_text_list = vec![String::from("hello"), String::from("world")];
 
@@ -220,7 +225,7 @@ async fn compile_multi_resource() {
         resource.text_list = source_text_list.clone();
 
         let source_manifest_id =
-            common::write_resource(source, &persistent_content_provider, &proc, resource).await;
+            common::write_resource(source, persistent_content_provider, &proc, resource).await;
 
         (source, source_manifest_id)
     };
@@ -285,10 +290,11 @@ async fn compile_multi_resource() {
 
 #[tokio::test]
 async fn compile_base64() {
-    let persistent_content_provider =
+    let persistent_content_provider = Arc::new(
         lgn_content_store::Config::load_and_instantiate_persistent_provider()
             .await
-            .unwrap();
+            .unwrap(),
+    );
 
     let source_binary_value = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
     let expected_base64_value = String::from("AQIDBAUGBwgJ");
@@ -309,7 +315,7 @@ async fn compile_base64() {
         resource.content = source_binary_value;
 
         let source_manifest_id =
-            common::write_resource(source, &persistent_content_provider, &proc, resource).await;
+            common::write_resource(source, persistent_content_provider, &proc, resource).await;
 
         (source, source_manifest_id)
     };

--- a/crates/lgn-data-offline/src/resource/project.rs
+++ b/crates/lgn-data-offline/src/resource/project.rs
@@ -139,13 +139,15 @@ impl Project {
         repository_index: impl RepositoryIndex,
         repository_name: &RepositoryName,
         branch_name: &str,
-        source_control_content_provider: Arc<Provider>,
+        persistent_provider: Arc<Provider>,
+        volatile_provider: Arc<Provider>,
     ) -> Result<Self, Error> {
         let workspace = Workspace::new(
             repository_index,
             repository_name,
             branch_name,
-            source_control_content_provider,
+            persistent_provider,
+            volatile_provider,
             new_resource_type_and_id_indexer(),
         )
         .await?;
@@ -159,7 +161,8 @@ impl Project {
     /// Same as [`Self::new`] but it creates an origin source control index at ``project_dir/remote``.
     pub async fn new_with_remote_mock(
         project_dir: impl AsRef<Path>,
-        source_control_content_provider: Arc<Provider>,
+        persistent_provider: Arc<Provider>,
+        volatile_provider: Arc<Provider>,
     ) -> Result<Self, Error> {
         let remote_dir = project_dir.as_ref().join("remote");
         let repository_index = LocalRepositoryIndex::new(remote_dir).await?;
@@ -171,7 +174,8 @@ impl Project {
             repository_index,
             &repository_name,
             "main",
-            source_control_content_provider,
+            persistent_provider,
+            volatile_provider,
         )
         .await
     }
@@ -897,10 +901,13 @@ mod tests {
     #[tokio::test]
     async fn local_changes() {
         let root = tempfile::tempdir().unwrap();
-        let provider = Arc::new(Provider::new_in_memory());
-        let mut project = Project::new_with_remote_mock(root.path(), provider)
-            .await
-            .expect("new project");
+        let mut project = Project::new_with_remote_mock(
+            root.path(),
+            Arc::new(Provider::new_in_memory()),
+            Arc::new(Provider::new_in_memory()),
+        )
+        .await
+        .expect("new project");
         let _resources = create_actor(&mut project).await;
 
         assert_eq!(project.get_pending_changes().await.unwrap().len(), 5);
@@ -909,10 +916,13 @@ mod tests {
     #[tokio::test]
     async fn commit() {
         let root = tempfile::tempdir().unwrap();
-        let provider = Arc::new(Provider::new_in_memory());
-        let mut project = Project::new_with_remote_mock(root.path(), provider)
-            .await
-            .expect("new project");
+        let mut project = Project::new_with_remote_mock(
+            root.path(),
+            Arc::new(Provider::new_in_memory()),
+            Arc::new(Provider::new_in_memory()),
+        )
+        .await
+        .expect("new project");
         let resources = create_actor(&mut project).await;
 
         let actor_id = project
@@ -964,10 +974,13 @@ mod tests {
     #[tokio::test]
     async fn change_to_previous() {
         let root = tempfile::tempdir().unwrap();
-        let provider = Arc::new(Provider::new_in_memory());
-        let mut project = Project::new_with_remote_mock(root.path(), provider)
-            .await
-            .expect("new project");
+        let mut project = Project::new_with_remote_mock(
+            root.path(),
+            Arc::new(Provider::new_in_memory()),
+            Arc::new(Provider::new_in_memory()),
+        )
+        .await
+        .expect("new project");
         let resources = create_actor(&mut project).await;
 
         let actor_id = project
@@ -1009,10 +1022,13 @@ mod tests {
     #[tokio::test]
     async fn immediate_dependencies() {
         let root = tempfile::tempdir().unwrap();
-        let provider = Arc::new(Provider::new_in_memory());
-        let mut project = Project::new_with_remote_mock(root.path(), provider)
-            .await
-            .expect("new project");
+        let mut project = Project::new_with_remote_mock(
+            root.path(),
+            Arc::new(Provider::new_in_memory()),
+            Arc::new(Provider::new_in_memory()),
+        )
+        .await
+        .expect("new project");
         let _resources = create_actor(&mut project).await;
 
         let top_level_resource = project
@@ -1049,10 +1065,13 @@ mod tests {
     #[tokio::test]
     async fn rename() {
         let root = tempfile::tempdir().unwrap();
-        let provider = Arc::new(Provider::new_in_memory());
-        let mut project = Project::new_with_remote_mock(root.path(), provider)
-            .await
-            .expect("new project");
+        let mut project = Project::new_with_remote_mock(
+            root.path(),
+            Arc::new(Provider::new_in_memory()),
+            Arc::new(Provider::new_in_memory()),
+        )
+        .await
+        .expect("new project");
         let resources = create_actor(&mut project).await;
         assert!(project.commit("rename test").await.is_ok());
         create_sky_material(&mut project, &resources).await;

--- a/crates/lgn-data-offline/src/vfs/mod.rs
+++ b/crates/lgn-data-offline/src/vfs/mod.rs
@@ -13,19 +13,22 @@ pub trait AddDeviceSourceCas {
     #[must_use]
     fn add_device_source_cas(
         self,
-        _provider: Arc<Provider>,
-        _manifest_id: SharedTreeIdentifier,
+        persistent_provider: Arc<Provider>,
+        volatile_provider: Arc<Provider>,
+        manifest_id: SharedTreeIdentifier,
     ) -> Self;
 }
 
 impl AddDeviceSourceCas for AssetRegistryOptions {
     fn add_device_source_cas(
         self,
-        provider: Arc<Provider>,
+        persistent_provider: Arc<Provider>,
+        volatile_provider: Arc<Provider>,
         manifest_id: SharedTreeIdentifier,
     ) -> Self {
         self.add_device(Box::new(source_cas_device::SourceCasDevice::new(
-            provider,
+            persistent_provider,
+            volatile_provider,
             manifest_id,
         )))
     }

--- a/crates/lgn-data-offline/src/vfs/source_cas_device.rs
+++ b/crates/lgn-data-offline/src/vfs/source_cas_device.rs
@@ -15,7 +15,6 @@ use crate::resource::deserialize_and_skip_metadata;
 /// manifest access table.
 pub(crate) struct SourceCasDevice {
     persistent_provider: Arc<Provider>,
-    volatile_provider: Arc<Provider>,
     manifest: ResourceIndex<ResourceTypeAndIdIndexer>,
 }
 
@@ -25,13 +24,14 @@ impl SourceCasDevice {
         volatile_provider: Arc<Provider>,
         manifest_id: SharedTreeIdentifier,
     ) -> Self {
+        let manifest = ResourceIndex::new_shared_with_id(
+            volatile_provider,
+            new_resource_type_and_id_indexer(),
+            manifest_id,
+        );
         Self {
             persistent_provider,
-            volatile_provider,
-            manifest: ResourceIndex::new_shared_with_id(
-                new_resource_type_and_id_indexer(),
-                manifest_id,
-            ),
+            manifest,
         }
     }
 }
@@ -39,11 +39,7 @@ impl SourceCasDevice {
 #[async_trait]
 impl Device for SourceCasDevice {
     async fn load(&mut self, type_id: ResourceTypeAndId) -> Option<Vec<u8>> {
-        if let Ok(Some(resource_id)) = self
-            .manifest
-            .get_identifier(&self.volatile_provider, &type_id.into())
-            .await
-        {
+        if let Ok(Some(resource_id)) = self.manifest.get_identifier(&type_id.into()).await {
             if let Ok(resource_bytes) = self
                 .persistent_provider
                 .read_resource_as_bytes(&resource_id)

--- a/crates/lgn-data-offline/src/vfs/source_cas_device.rs
+++ b/crates/lgn-data-offline/src/vfs/source_cas_device.rs
@@ -14,14 +14,20 @@ use crate::resource::deserialize_and_skip_metadata;
 /// Content addressable storage device. Resources are accessed through a
 /// manifest access table.
 pub(crate) struct SourceCasDevice {
-    provider: Arc<Provider>,
+    persistent_provider: Arc<Provider>,
+    volatile_provider: Arc<Provider>,
     manifest: ResourceIndex<ResourceTypeAndIdIndexer>,
 }
 
 impl SourceCasDevice {
-    pub(crate) fn new(provider: Arc<Provider>, manifest_id: SharedTreeIdentifier) -> Self {
+    pub(crate) fn new(
+        persistent_provider: Arc<Provider>,
+        volatile_provider: Arc<Provider>,
+        manifest_id: SharedTreeIdentifier,
+    ) -> Self {
         Self {
-            provider,
+            persistent_provider,
+            volatile_provider,
             manifest: ResourceIndex::new_shared_with_id(
                 new_resource_type_and_id_indexer(),
                 manifest_id,
@@ -35,10 +41,14 @@ impl Device for SourceCasDevice {
     async fn load(&mut self, type_id: ResourceTypeAndId) -> Option<Vec<u8>> {
         if let Ok(Some(resource_id)) = self
             .manifest
-            .get_identifier(&self.provider, &type_id.into())
+            .get_identifier(&self.volatile_provider, &type_id.into())
             .await
         {
-            if let Ok(resource_bytes) = self.provider.read_resource_as_bytes(&resource_id).await {
+            if let Ok(resource_bytes) = self
+                .persistent_provider
+                .read_resource_as_bytes(&resource_id)
+                .await
+            {
                 let mut reader = std::io::Cursor::new(resource_bytes);
 
                 // skip over the pre-pended metadata

--- a/crates/lgn-data-runtime/src/asset_loader.rs
+++ b/crates/lgn-data-runtime/src/asset_loader.rs
@@ -696,8 +696,11 @@ mod tests {
 
     async fn setup_test() -> (ResourceTypeAndId, AssetLoaderStub, AssetLoaderIO) {
         let data_provider = Arc::new(Provider::new_in_memory());
-        let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &data_provider).await;
+        let mut manifest = ResourceIndex::new_exclusive(
+            Arc::clone(&data_provider),
+            new_resource_type_and_id_indexer(),
+        )
+        .await;
 
         let asset_id = {
             let type_id = ResourceTypeAndId {
@@ -710,7 +713,7 @@ mod tests {
                 .unwrap();
 
             manifest
-                .add_resource(&data_provider, &type_id.into(), provider_id)
+                .add_resource(&type_id.into(), provider_id)
                 .await
                 .unwrap();
 
@@ -779,8 +782,11 @@ mod tests {
     #[tokio::test]
     async fn load_no_dependencies() {
         let data_provider = Arc::new(Provider::new_in_memory());
-        let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &data_provider).await;
+        let mut manifest = ResourceIndex::new_exclusive(
+            Arc::clone(&data_provider),
+            new_resource_type_and_id_indexer(),
+        )
+        .await;
 
         let asset_id = {
             let type_id = ResourceTypeAndId {
@@ -792,7 +798,7 @@ mod tests {
                 .await
                 .unwrap();
             manifest
-                .add_resource(&data_provider, &type_id.into(), provider_id)
+                .add_resource(&type_id.into(), provider_id)
                 .await
                 .unwrap();
             type_id
@@ -850,8 +856,11 @@ mod tests {
     #[tokio::test]
     async fn load_failed_dependency() {
         let data_provider = Arc::new(Provider::new_in_memory());
-        let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &data_provider).await;
+        let mut manifest = ResourceIndex::new_exclusive(
+            Arc::clone(&data_provider),
+            new_resource_type_and_id_indexer(),
+        )
+        .await;
 
         let parent_id = ResourceTypeAndId {
             kind: test_asset::TestAsset::TYPE,
@@ -864,7 +873,7 @@ mod tests {
                 .await
                 .unwrap();
             manifest
-                .add_resource(&data_provider, &parent_id.into(), provider_id)
+                .add_resource(&parent_id.into(), provider_id)
                 .await
                 .unwrap();
             parent_id
@@ -910,8 +919,11 @@ mod tests {
     #[tokio::test]
     async fn load_with_dependency() {
         let data_provider = Arc::new(Provider::new_in_memory());
-        let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &data_provider).await;
+        let mut manifest = ResourceIndex::new_exclusive(
+            Arc::clone(&data_provider),
+            new_resource_type_and_id_indexer(),
+        )
+        .await;
 
         let parent_content = "parent";
 
@@ -927,7 +939,6 @@ mod tests {
         let asset_id = {
             manifest
                 .add_resource(
-                    &data_provider,
                     &child_id.into(),
                     data_provider
                         .write_resource_from_bytes(&test_asset::tests::BINARY_ASSETFILE)
@@ -941,7 +952,7 @@ mod tests {
                 .await
                 .unwrap();
             manifest
-                .add_resource(&data_provider, &parent_id.into(), provider_id)
+                .add_resource(&parent_id.into(), provider_id)
                 .await
                 .unwrap();
 
@@ -1027,8 +1038,11 @@ mod tests {
     #[tokio::test]
     async fn reload_no_dependencies() {
         let data_provider = Arc::new(Provider::new_in_memory());
-        let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &data_provider).await;
+        let mut manifest = ResourceIndex::new_exclusive(
+            Arc::clone(&data_provider),
+            new_resource_type_and_id_indexer(),
+        )
+        .await;
 
         let asset_id = {
             let type_id = ResourceTypeAndId {
@@ -1040,7 +1054,7 @@ mod tests {
                 .await
                 .unwrap();
             manifest
-                .add_resource(&data_provider, &type_id.into(), provider_id)
+                .add_resource(&type_id.into(), provider_id)
                 .await
                 .unwrap();
             type_id

--- a/crates/lgn-data-runtime/src/asset_loader.rs
+++ b/crates/lgn-data-runtime/src/asset_loader.rs
@@ -721,7 +721,7 @@ mod tests {
         };
 
         let (loader, mut io) = create_loader(vec![Box::new(vfs::CasDevice::new(
-            Arc::clone(&data_provider),
+            data_provider,
             SharedTreeIdentifier::new(manifest.id()),
         ))]);
         io.register_loader(

--- a/crates/lgn-data-runtime/src/asset_registry.rs
+++ b/crates/lgn-data-runtime/src/asset_registry.rs
@@ -775,8 +775,11 @@ mod tests {
 
     async fn setup_singular_asset_test(content: &[u8]) -> (ResourceTypeAndId, Arc<AssetRegistry>) {
         let data_provider = Arc::new(Provider::new_in_memory());
-        let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &data_provider).await;
+        let mut manifest = ResourceIndex::new_exclusive(
+            Arc::clone(&data_provider),
+            new_resource_type_and_id_indexer(),
+        )
+        .await;
 
         let asset_id = {
             let type_id = ResourceTypeAndId {
@@ -788,7 +791,7 @@ mod tests {
                 .await
                 .unwrap();
             manifest
-                .add_resource(&data_provider, &type_id.into(), provider_id)
+                .add_resource(&type_id.into(), provider_id)
                 .await
                 .unwrap();
 
@@ -806,8 +809,11 @@ mod tests {
 
     async fn setup_dependency_test() -> (ResourceTypeAndId, ResourceTypeAndId, Arc<AssetRegistry>) {
         let data_provider = Arc::new(Provider::new_in_memory());
-        let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &data_provider).await;
+        let mut manifest = ResourceIndex::new_exclusive(
+            Arc::clone(&data_provider),
+            new_resource_type_and_id_indexer(),
+        )
+        .await;
 
         const BINARY_PARENT_ASSETFILE: [u8; 100] = [
             97, 115, 102, 116, // header (asft)
@@ -842,7 +848,6 @@ mod tests {
         let parent_id = {
             manifest
                 .add_resource(
-                    &data_provider,
                     &child_id.into(),
                     data_provider
                         .write_resource_from_bytes(&BINARY_CHILD_ASSETFILE)
@@ -860,7 +865,7 @@ mod tests {
                 id: ResourceId::new_explicit(2),
             };
             manifest
-                .add_resource(&data_provider, &type_id.into(), provider_id)
+                .add_resource(&type_id.into(), provider_id)
                 .await
                 .unwrap();
             type_id

--- a/crates/lgn-data-runtime/src/vfs/build_device.rs
+++ b/crates/lgn-data-runtime/src/vfs/build_device.rs
@@ -38,7 +38,8 @@ impl BuildDevice {
         force_recompile: bool,
     ) -> Self {
         let mut manifest =
-            ResourceIndex::new_exclusive(new_resource_type_and_id_indexer(), &provider).await;
+            ResourceIndex::new_exclusive(Arc::clone(&provider), new_resource_type_and_id_indexer())
+                .await;
         if let Some(manifest_id) = manifest_id {
             manifest.set_id(manifest_id);
         }
@@ -54,11 +55,7 @@ impl BuildDevice {
     }
 
     async fn load_internal(&self, type_id: ResourceTypeAndId) -> Option<Vec<u8>> {
-        if let Ok(Some(resource_id)) = self
-            .manifest
-            .get_identifier(&self.provider, &type_id.into())
-            .await
-        {
+        if let Ok(Some(resource_id)) = self.manifest.get_identifier(&type_id.into()).await {
             if let Ok(resource_bytes) = self.provider.read_resource_as_bytes(&resource_id).await {
                 return Some(resource_bytes);
             }

--- a/crates/lgn-data-runtime/src/vfs/cas_device.rs
+++ b/crates/lgn-data-runtime/src/vfs/cas_device.rs
@@ -18,24 +18,19 @@ pub(crate) struct CasDevice {
 
 impl CasDevice {
     pub(crate) fn new(provider: Arc<Provider>, manifest_id: SharedTreeIdentifier) -> Self {
-        Self {
-            provider,
-            manifest: ResourceIndex::new_shared_with_id(
-                new_resource_type_and_id_indexer(),
-                manifest_id,
-            ),
-        }
+        let manifest = ResourceIndex::new_shared_with_id(
+            Arc::clone(&provider),
+            new_resource_type_and_id_indexer(),
+            manifest_id,
+        );
+        Self { provider, manifest }
     }
 }
 
 #[async_trait]
 impl Device for CasDevice {
     async fn load(&mut self, type_id: ResourceTypeAndId) -> Option<Vec<u8>> {
-        if let Ok(Some(resource_id)) = self
-            .manifest
-            .get_identifier(&self.provider, &type_id.into())
-            .await
-        {
+        if let Ok(Some(resource_id)) = self.manifest.get_identifier(&type_id.into()).await {
             if let Ok(resource_bytes) = self.provider.read_resource_as_bytes(&resource_id).await {
                 return Some(resource_bytes);
             }

--- a/crates/lgn-data-transaction/src/build_manager.rs
+++ b/crates/lgn-data-transaction/src/build_manager.rs
@@ -70,9 +70,10 @@ impl BuildManager {
 
         let derived_id = Self::get_derived_id(resource_id);
 
+        let data_provider = Arc::clone(self.build.get_provider());
         let indexer = new_resource_type_and_id_indexer();
         let start_manifest = ResourceIndex::new_exclusive_with_id(
-            Arc::clone(self.build.get_provider()),
+            Arc::clone(&data_provider),
             indexer.clone(),
             self.runtime_manifest_id.read(),
         )
@@ -86,7 +87,6 @@ impl BuildManager {
             .await
         {
             Ok(output) => {
-                let data_provider = Arc::clone(self.build.get_provider());
                 let runtime_manifest_id = output
                     .into_rt_manifest(Arc::clone(&data_provider), |_rpid| true)
                     .await;

--- a/crates/lgn-data-transaction/src/build_manager.rs
+++ b/crates/lgn-data-transaction/src/build_manager.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use lgn_content_store::indexing::{ResourceIndex, ResourceWriter, SharedTreeIdentifier};
 use lgn_data_build::{DataBuild, DataBuildOptions, Error};
 use lgn_data_compiler::{compiler_api::CompilationEnv, Locale, Platform, Target};
@@ -69,10 +71,13 @@ impl BuildManager {
         let derived_id = Self::get_derived_id(resource_id);
 
         let indexer = new_resource_type_and_id_indexer();
-        let start_manifest =
-            ResourceIndex::new_exclusive_with_id(indexer.clone(), self.runtime_manifest_id.read())
-                .enumerate_resources(self.build.get_provider())
-                .await?;
+        let start_manifest = ResourceIndex::new_exclusive_with_id(
+            Arc::clone(self.build.get_provider()),
+            indexer.clone(),
+            self.runtime_manifest_id.read(),
+        )
+        .enumerate_resources()
+        .await?;
 
         self.build.source_pull(project).await?;
         match self
@@ -81,13 +86,17 @@ impl BuildManager {
             .await
         {
             Ok(output) => {
-                let data_provider = self.build.get_provider();
-                let runtime_manifest_id =
-                    output.into_rt_manifest(data_provider, |_rpid| true).await;
-                let runtime_manifest =
-                    ResourceIndex::new_exclusive_with_id(indexer.clone(), runtime_manifest_id)
-                        .enumerate_resources(data_provider)
-                        .await?;
+                let data_provider = Arc::clone(self.build.get_provider());
+                let runtime_manifest_id = output
+                    .into_rt_manifest(Arc::clone(&data_provider), |_rpid| true)
+                    .await;
+                let runtime_manifest = ResourceIndex::new_exclusive_with_id(
+                    Arc::clone(&data_provider),
+                    indexer.clone(),
+                    runtime_manifest_id,
+                )
+                .enumerate_resources()
+                .await?;
 
                 let mut added_resources = Vec::new();
                 let mut changed_resources = Vec::new();
@@ -115,17 +124,18 @@ impl BuildManager {
                 );
 
                 let mut runtime_manifest = ResourceIndex::new_exclusive_with_id(
+                    Arc::clone(&data_provider),
                     indexer.clone(),
                     self.runtime_manifest_id.read(),
                 );
                 for (index_key, resource_id) in added_resources {
                     runtime_manifest
-                        .add_resource(data_provider, &index_key, resource_id)
+                        .add_resource(&index_key, resource_id)
                         .await?;
                 }
                 for (index_key, resource_id, old_resource_id) in &changed_resources {
                     let replaced_id = runtime_manifest
-                        .replace_resource(data_provider, index_key, resource_id.clone())
+                        .replace_resource(index_key, resource_id.clone())
                         .await?;
                     assert_eq!(&replaced_id, old_resource_id);
 

--- a/crates/lgn-editor-srv/src/tests/test_resource_browser.rs
+++ b/crates/lgn-editor-srv/src/tests/test_resource_browser.rs
@@ -75,12 +75,14 @@ pub(crate) async fn setup_project(project_dir: impl AsRef<Path>) -> Arc<Mutex<Tr
     std::fs::create_dir_all(&build_dir).unwrap();
 
     let source_control_content_provider = Arc::new(Provider::new_in_memory());
-    let project =
-        Project::new_with_remote_mock(&project_dir, Arc::clone(&source_control_content_provider))
-            .await
-            .expect("failed to create a project");
-
     let data_content_provider = Arc::new(Provider::new_in_memory());
+    let project = Project::new_with_remote_mock(
+        &project_dir,
+        Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
+    )
+    .await
+    .expect("failed to create a project");
 
     let runtime_manifest_id =
         SharedTreeIdentifier::new(empty_tree_id(&data_content_provider).await.unwrap());

--- a/crates/lgn-editor-srv/src/tests/test_resource_browser.rs
+++ b/crates/lgn-editor-srv/src/tests/test_resource_browser.rs
@@ -91,6 +91,7 @@ pub(crate) async fn setup_project(project_dir: impl AsRef<Path>) -> Arc<Mutex<Tr
         )
         .add_device_source_cas(
             Arc::clone(&source_control_content_provider),
+            Arc::clone(&data_content_provider),
             project.source_manifest_id(),
         );
     sample_data::offline::add_loaders(&mut asset_registry);

--- a/crates/lgn-resource-registry/src/lib.rs
+++ b/crates/lgn-resource-registry/src/lib.rs
@@ -71,6 +71,7 @@ impl ResourceRegistryPlugin {
                 &settings.source_control_repository_name,
                 &settings.source_control_branch_name,
                 Arc::clone(&source_control_content_provider),
+                Arc::clone(&data_content_provider),
             )
             .await
             .unwrap();

--- a/crates/lgn-source-control/src/workspace.rs
+++ b/crates/lgn-source-control/src/workspace.rs
@@ -238,7 +238,7 @@ where
         Indexer: BasicIndexer + Sync,
         F: Fn(&IndexKey) -> String,
     {
-        if let Ok(contents) = index.enumerate_resources(&self.transaction).await {
+        if let Ok(contents) = index.enumerate_resources().await {
             match resource_id {
                 Some(resource_id) => {
                     if let Some((index_key, resource_id)) = contents

--- a/crates/lgn-source-control/src/workspace.rs
+++ b/crates/lgn-source-control/src/workspace.rs
@@ -7,7 +7,6 @@ use lgn_content_store::{
     },
     Provider,
 };
-use lgn_tracing::error;
 use tokio_stream::StreamExt;
 
 use crate::{
@@ -21,7 +20,8 @@ where
     MainIndexer: BasicIndexer + Clone + Sync,
 {
     index: Box<dyn Index>,
-    transaction: Provider,
+    persistent_provider: Arc<Provider>,
+    volatile_provider: Arc<Provider>,
     branch_name: String,
     main_index: ResourceIndex<MainIndexer>,
     path_index: ResourceIndex<StringPathIndexer>,
@@ -71,25 +71,30 @@ where
         repository_index: impl RepositoryIndex,
         repository_name: &RepositoryName,
         branch_name: &str,
-        provider: Arc<Provider>,
+        persistent_provider: Arc<Provider>,
+        volatile_provider: Arc<Provider>,
         main_indexer: MainIndexer,
     ) -> Result<Self> {
         let index = repository_index.load_repository(repository_name).await?;
         let branch = index.get_branch(branch_name).await?;
         let commit = index.get_commit(branch.head).await?;
-
+        let main_index = ResourceIndex::new_shared_with_raw_id(
+            Arc::clone(&volatile_provider),
+            main_indexer,
+            commit.main_index_tree_id,
+        );
+        let path_index = ResourceIndex::new_exclusive_with_id(
+            Arc::clone(&volatile_provider),
+            StringPathIndexer::default(),
+            commit.path_index_tree_id,
+        );
         Ok(Self {
             index,
-            transaction: provider.begin_transaction_in_memory(),
+            persistent_provider,
+            volatile_provider,
             branch_name: branch_name.to_owned(),
-            main_index: ResourceIndex::new_shared_with_raw_id(
-                main_indexer,
-                commit.main_index_tree_id,
-            ),
-            path_index: ResourceIndex::new_exclusive_with_id(
-                StringPathIndexer::default(),
-                commit.path_index_tree_id,
-            ),
+            main_index,
+            path_index,
         })
     }
 
@@ -117,11 +122,6 @@ where
         let current_branch = self.get_current_branch().await?;
 
         self.index.get_commit(current_branch.head).await
-    }
-
-    /// Get the current transaction/provider
-    pub fn get_provider(&self) -> &Provider {
-        &self.transaction
     }
 
     pub async fn get_resource_identifier(
@@ -154,7 +154,7 @@ where
         Indexer: BasicIndexer + Sync,
     {
         index
-            .get_identifier(&self.transaction, id)
+            .get_identifier(id)
             .await
             .map_err(Error::ContentStoreIndexing)
     }
@@ -198,24 +198,28 @@ where
     }
 
     pub async fn load_resource_by_id(&self, resource_id: &ResourceIdentifier) -> Result<Vec<u8>> {
-        Ok(self.transaction.read_resource_as_bytes(resource_id).await?)
+        Ok(self
+            .persistent_provider
+            .read_resource_as_bytes(resource_id)
+            .await?)
     }
 
     pub async fn get_committed_resources(&self) -> Result<Vec<(IndexKey, ResourceIdentifier)>> {
         let commit = self.get_current_commit().await?;
         let commit_manifest = ResourceIndex::new_exclusive_with_id(
+            Arc::clone(&self.volatile_provider),
             self.main_index.indexer().clone(),
             commit.main_index_tree_id,
         );
         commit_manifest
-            .enumerate_resources(&self.transaction)
+            .enumerate_resources()
             .await
             .map_err(Error::ContentStoreIndexing)
     }
 
     pub async fn get_resources(&self) -> Result<Vec<(IndexKey, ResourceIdentifier)>> {
         self.main_index
-            .enumerate_resources(&self.transaction)
+            .enumerate_resources()
             .await
             .map_err(Error::ContentStoreIndexing)
     }
@@ -279,13 +283,16 @@ where
         path: &str,
         contents: &[u8],
     ) -> Result<ResourceIdentifier> {
-        let resource_identifier = self.transaction.write_resource_from_bytes(contents).await?;
+        let resource_identifier = self
+            .persistent_provider
+            .write_resource_from_bytes(contents)
+            .await?;
 
         self.main_index
-            .add_resource(&self.transaction, id, resource_identifier.clone())
+            .add_resource(id, resource_identifier.clone())
             .await?;
         self.path_index
-            .add_resource(&self.transaction, &path.into(), resource_identifier.clone())
+            .add_resource(&path.into(), resource_identifier.clone())
             .await?;
 
         #[cfg(feature = "verbose")]
@@ -309,7 +316,10 @@ where
         contents: &[u8],
         old_identifier: &ResourceIdentifier,
     ) -> Result<ResourceIdentifier> {
-        let resource_identifier = self.transaction.write_resource_from_bytes(contents).await?;
+        let resource_identifier = self
+            .persistent_provider
+            .write_resource_from_bytes(contents)
+            .await?;
 
         if &resource_identifier != old_identifier {
             // content has changed
@@ -327,15 +337,17 @@ where
             // update indices
             let _replaced_id = self
                 .main_index
-                .replace_resource(&self.transaction, id, resource_identifier.clone())
+                .replace_resource(id, resource_identifier.clone())
                 .await?;
             let _replaced_id = self
                 .path_index
-                .replace_resource(&self.transaction, &path.into(), resource_identifier.clone())
+                .replace_resource(&path.into(), resource_identifier.clone())
                 .await?;
 
             // unwrite previous resource content from content-store
-            self.transaction.unwrite_resource(old_identifier).await?;
+            self.persistent_provider
+                .unwrite_resource(old_identifier)
+                .await?;
 
             #[cfg(feature = "verbose")]
             {
@@ -360,7 +372,10 @@ where
         contents: &[u8],
         old_identifier: &ResourceIdentifier,
     ) -> Result<ResourceIdentifier> {
-        let resource_identifier = self.transaction.write_resource_from_bytes(contents).await?;
+        let resource_identifier = self
+            .persistent_provider
+            .write_resource_from_bytes(contents)
+            .await?;
 
         if &resource_identifier != old_identifier {
             // content has changed
@@ -378,26 +393,21 @@ where
             // update indices
             let replaced_id = self
                 .main_index
-                .replace_resource(&self.transaction, id, resource_identifier.clone())
+                .replace_resource(id, resource_identifier.clone())
                 .await?;
             assert_eq!(&replaced_id, old_identifier);
 
-            let removed_id = self
-                .path_index
-                .remove_resource(&self.transaction, &old_path.into())
-                .await?;
+            let removed_id = self.path_index.remove_resource(&old_path.into()).await?;
             assert_eq!(&removed_id, old_identifier);
 
             self.path_index
-                .add_resource(
-                    &self.transaction,
-                    &new_path.into(),
-                    resource_identifier.clone(),
-                )
+                .add_resource(&new_path.into(), resource_identifier.clone())
                 .await?;
 
             // unwrite previous resource content from content-store
-            self.transaction.unwrite_resource(old_identifier).await?;
+            self.persistent_provider
+                .unwrite_resource(old_identifier)
+                .await?;
 
             #[cfg(feature = "verbose")]
             {
@@ -424,19 +434,15 @@ where
         path: &str,
     ) -> Result<ResourceIdentifier> {
         // remove from main index
-        let resource_id = self
-            .main_index
-            .remove_resource(&self.transaction, id)
-            .await?;
+        let resource_id = self.main_index.remove_resource(id).await?;
 
-        let removed_id = self
-            .path_index
-            .remove_resource(&self.transaction, &path.into())
-            .await?;
+        let removed_id = self.path_index.remove_resource(&path.into()).await?;
         assert_eq!(resource_id, removed_id);
 
         // unwrite resource from content-store
-        self.transaction.unwrite_resource(&resource_id).await?;
+        self.persistent_provider
+            .unwrite_resource(&resource_id)
+            .await?;
 
         #[cfg(feature = "verbose")]
         {
@@ -484,7 +490,7 @@ where
         let mut leaves = self
             .main_index
             .indexer()
-            .diff_leaves(&self.transaction, &commit_index_id, &main_index_id)
+            .diff_leaves(&self.volatile_provider, &commit_index_id, &main_index_id)
             .await?
             .map(|(side, index_key, leaf)| match leaf {
                 Ok(leaf) => match leaf {
@@ -595,15 +601,6 @@ where
     ///
     /// The commit id.
     pub async fn commit(&mut self, message: &str, behavior: CommitMode) -> Result<Commit> {
-        let transaction = std::mem::replace(&mut self.transaction, Provider::new_in_memory());
-        let provider = match transaction.commit_transaction().await {
-            Ok(provider) => provider,
-            Err((provider, e)) => {
-                error!("failed to commit to content-store: {}", e);
-                provider
-            }
-        };
-
         let current_branch = self.get_current_branch().await?;
         let mut branch = self.index.get_branch(&current_branch.name).await?;
         let commit = self.index.get_commit(current_branch.head).await?;
@@ -637,8 +634,6 @@ where
         } else {
             commit
         };
-
-        self.transaction = provider.begin_transaction_in_memory();
 
         Ok(commit)
     }

--- a/examples/animation/src/main.rs
+++ b/examples/animation/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
         &repository_name,
         "main",
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
     )
     .await
     .expect("failed to create a project");

--- a/examples/animation/src/main.rs
+++ b/examples/animation/src/main.rs
@@ -96,6 +96,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut asset_registry = AssetRegistryOptions::new().add_device_source_cas(
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
         project.source_manifest_id(),
     );
     lgn_graphics_data::offline::add_loaders(&mut asset_registry);

--- a/examples/physics/src/main.rs
+++ b/examples/physics/src/main.rs
@@ -87,6 +87,7 @@ async fn main() -> anyhow::Result<()> {
         &repository_name,
         "main",
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
     )
     .await
     .expect("failed to create a project");

--- a/examples/physics/src/main.rs
+++ b/examples/physics/src/main.rs
@@ -93,6 +93,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut asset_registry = AssetRegistryOptions::new().add_device_source_cas(
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
         project.source_manifest_id(),
     );
     lgn_graphics_data::offline::add_loaders(&mut asset_registry);

--- a/examples/pong/src/main.rs
+++ b/examples/pong/src/main.rs
@@ -84,6 +84,7 @@ async fn main() -> anyhow::Result<()> {
         &repository_name,
         "main",
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
     )
     .await
     .expect("failed to create a project");

--- a/examples/pong/src/main.rs
+++ b/examples/pong/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut asset_registry = AssetRegistryOptions::new().add_device_source_cas(
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
         project.source_manifest_id(),
     );
     lgn_graphics_data::offline::add_loaders(&mut asset_registry);

--- a/tests/sample-data-compiler/src/main/main.rs
+++ b/tests/sample-data-compiler/src/main/main.rs
@@ -107,6 +107,7 @@ async fn main() {
         &repository_name,
         branch_name,
         Arc::clone(&source_control_content_provider),
+        Arc::clone(&data_content_provider),
         true,
     )
     .await;

--- a/tests/sample-data-compiler/src/offline_compiler/mod.rs
+++ b/tests/sample-data-compiler/src/offline_compiler/mod.rs
@@ -118,7 +118,7 @@ pub async fn build(
         };
 
         let manifest_id = manifest
-            .into_rt_manifest(&data_content_provider, filter)
+            .into_rt_manifest(data_content_provider, filter)
             .await;
 
         let mut file = OpenOptions::new()

--- a/tests/sample-data-compiler/src/raw_loader/mod.rs
+++ b/tests/sample-data-compiler/src/raw_loader/mod.rs
@@ -34,6 +34,7 @@ pub async fn build_offline(
     repository_name: &RepositoryName,
     branch_name: &str,
     source_control_content_provider: Arc<Provider>,
+    data_content_provider: Arc<Provider>,
     incremental: bool,
 ) -> Project {
     let raw_dir = {
@@ -52,6 +53,7 @@ pub async fn build_offline(
         repository_name,
         branch_name,
         source_control_content_provider,
+        data_content_provider,
     )
     .await;
 
@@ -213,6 +215,7 @@ async fn setup_project(
     repository_name: &RepositoryName,
     branch_name: &str,
     source_control_content_provider: Arc<Provider>,
+    data_content_provider: Arc<Provider>,
 ) -> (Project, Arc<AssetRegistry>) {
     // create/load project
     let project = Project::new(
@@ -220,6 +223,7 @@ async fn setup_project(
         repository_name,
         branch_name,
         source_control_content_provider,
+        data_content_provider,
     )
     .await
     .unwrap();


### PR DESCRIPTION
* In the context of the source-control workspace, resources are stored in the persistent content-store, but all indices (trees) are now store in the volatile content-store
* source-control workspace no longer creates an in-memory "transaction" provider. Changes are written directly to providers. No longer needs to commit project for changes to be visible to compilers for example.
* ResourceIndex now holds a provider, simplifying its API