### PR TITLE
Add in-memory transaction to source-control

### DIFF
--- a/crates/lgn-content-store/src/provider.rs
+++ b/crates/lgn-content-store/src/provider.rs
@@ -214,11 +214,13 @@ impl Provider {
     /// If the copy fails, an error is returned alongside the parent provider.
     pub async fn commit_and_restart_transaction(&self) -> Result<()> {
         if let Some(parent) = &self.parent {
-            let ids = self.referenced().await;
+            let mut refs = self.refs.lock().await; // maintain lock for duration of transfer to parent
+
+            let ids: Vec<Identifier> = refs.referenced().into_iter().cloned().collect();
 
             self.copy_all_to(ids, parent).await?;
 
-            self.clear_referenced().await;
+            refs.clear();
 
             Ok(())
         } else {

--- a/crates/lgn-content-store/src/provider.rs
+++ b/crates/lgn-content-store/src/provider.rs
@@ -203,6 +203,29 @@ impl Provider {
         }
     }
 
+    /// Commit a transaction, and immediately restart it with same parent.
+    ///
+    /// # Panics
+    ///
+    /// If the provider does not have a parent provider set.
+    ///
+    /// # Errors
+    ///
+    /// If the copy fails, an error is returned alongside the parent provider.
+    pub async fn commit_and_restart_transaction(&self) -> Result<()> {
+        if let Some(parent) = &self.parent {
+            let ids = self.referenced().await;
+
+            self.copy_all_to(ids, parent).await?;
+
+            self.clear_referenced().await;
+
+            Ok(())
+        } else {
+            panic!("no parent provider");
+        }
+    }
+
     /// Check whether a content exists.
     ///
     /// # Errors

--- a/crates/lgn-data-offline/src/resource/project.rs
+++ b/crates/lgn-data-offline/src/resource/project.rs
@@ -954,12 +954,12 @@ mod tests {
                 .await
                 .unwrap();
 
-            // assert_eq!(project.get_pending_changes().await.unwrap().len(), 1);
+            assert_eq!(project.get_pending_changes().await.unwrap().len(), 1);
         }
 
         project.commit("update actor").await.unwrap();
 
-        // assert_eq!(project.get_pending_changes().await.unwrap().len(), 0);
+        assert_eq!(project.get_pending_changes().await.unwrap().len(), 0);
     }
 
     #[tokio::test]

--- a/crates/lgn-source-control/src/error.rs
+++ b/crates/lgn-source-control/src/error.rs
@@ -85,6 +85,8 @@ pub enum Error {
     },
     #[error("{0}")]
     Unspecified(String),
+    #[error("content store: {0}")]
+    ContentStore(#[from] lgn_content_store::Error),
     #[error("content store indexing: {0}")]
     ContentStoreIndexing(#[from] lgn_content_store::indexing::Error),
     #[error("resource  `{id}` not found in content store")]

--- a/crates/lgn-source-control/src/workspace.rs
+++ b/crates/lgn-source-control/src/workspace.rs
@@ -391,9 +391,9 @@ where
                 );
                 self.dump_all_indices(Some(&resource_identifier)).await;
             }
-
-            self.commit_and_restart_transaction().await?;
         }
+
+        self.commit_and_restart_transaction().await?;
 
         Ok(resource_identifier)
     }
@@ -448,9 +448,9 @@ where
                 );
                 self.dump_all_indices(Some(&resource_identifier)).await;
             }
-
-            self.commit_and_restart_transaction().await?;
         }
+
+        self.commit_and_restart_transaction().await?;
 
         Ok(resource_identifier)
     }


### PR DESCRIPTION
Add a child in-memory provider (i.e. a transaction) in source-control workspace.
This transaction is automatically committed after each write operation (ex: delete / add / update resource).
This is done to protect the indices stored in the source-control database (commit tables), so that they won't be altered.

We had discussions regarding the use of a volatile provider (with persistent fallback), as a transaction.
However, since the same process may want to use the volatile provider *without* a persistent fallback, e.g. for derived resources, a short-lived in-memory transaction was chosen instead.