### PR TITLE
Camera refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,15 +2385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dolly"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ca62af80028e899eae554918f89106ae480104b1de01965b454601e1ad87de"
-dependencies = [
- "glam",
-]
-
-[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,7 +4903,6 @@ dependencies = [
  "bumpalo",
  "bumpalo-herd",
  "crossbeam-channel",
- "dolly",
  "egui",
  "lgn-app",
  "lgn-asset-registry",

--- a/crates/lgn-graphics-renderer/Cargo.toml
+++ b/crates/lgn-graphics-renderer/Cargo.toml
@@ -32,7 +32,6 @@ bit-set = "0.5"
 bumpalo = { version = "3.9.1", features = ["collections"] }
 bumpalo-herd = "0.1"
 crossbeam-channel = "0.5"
-dolly = "0.3.0"
 egui = "0.18.1"
 parking_lot = "0.12"
 paste = "1.0.6"

--- a/crates/lgn-graphics-renderer/src/components/camera_component.rs
+++ b/crates/lgn-graphics-renderer/src/components/camera_component.rs
@@ -1,9 +1,3 @@
-use std::marker::PhantomData;
-
-use dolly::driver::RigDriver;
-use dolly::prelude::{Handedness, Position, RightHanded, Smooth};
-use dolly::rig::{CameraRig, RigUpdateParams};
-use dolly::transform::Transform;
 use lgn_core::Time;
 use lgn_ecs::prelude::*;
 use lgn_graphics_data::runtime::CameraSetup;
@@ -15,84 +9,104 @@ use lgn_input::{
         Axis, GamepadAxis, GamepadAxisType, GamepadButton, Gamepads, Input, KeyCode, MouseButton,
     },
 };
-use lgn_math::{Angle, EulerRot, Mat3, Quat, Vec3};
+use lgn_math::{Angle, DMat4, EulerRot, Mat3, Quat, Vec3};
 use lgn_transform::components::GlobalTransform;
 use lgn_utils::HashMap;
 
 use crate::core::{PrimaryTableView, RenderCamera, RenderObjectId};
-use crate::UP_VECTOR;
 
-#[derive(Debug)]
-pub struct EulerRotator {
-    alpha: Angle,
-    beta: Angle,
-    gamma: Angle,
-
-    euler: EulerRot,
-}
-
-impl Default for EulerRotator {
-    fn default() -> Self {
-        Self::new(EulerRot::YZX)
-    }
-}
-
-impl EulerRotator {
-    pub fn new(euler: EulerRot) -> Self {
-        Self {
-            alpha: Angle::from_degrees(0.0),
-            beta: Angle::from_degrees(0.0),
-            gamma: Angle::from_degrees(0.0),
-            euler,
-        }
-    }
-
-    #[must_use]
-    pub fn rotation_quat(mut self, rotation: Quat) -> Self {
-        self.set_rotation_quat(rotation);
-        self
-    }
-
-    pub fn rotate(&mut self, alpha: Angle, beta: Angle, gamma: Angle) {
-        self.set_rotation_angles(self.alpha + alpha, self.beta + beta, self.gamma + gamma);
-    }
-
-    pub fn set_rotation_quat(&mut self, rotation: Quat) {
-        let (alpha, beta, gamma) = rotation.to_euler(self.euler);
-        self.set_rotation_angles(
-            Angle::from_radians(alpha),
-            Angle::from_radians(beta),
-            Angle::from_radians(gamma),
-        );
-    }
-
-    fn set_rotation_angles(&mut self, alpha: Angle, beta: Angle, gamma: Angle) {
-        self.alpha = Angle::from_radians(alpha.radians() % (std::f32::consts::TAU));
-        self.beta = Angle::from_radians(beta.radians() % (std::f32::consts::TAU));
-        self.gamma = Angle::from_radians(gamma.radians().clamp(-std::f32::consts::PI, 0.0));
-    }
-}
-
-impl<H: Handedness> RigDriver<H> for EulerRotator {
-    fn update(&mut self, params: RigUpdateParams<'_, H>) -> Transform<H> {
-        Transform {
-            position: params.parent.position,
-            rotation: Quat::from_euler(
-                self.euler,
-                self.alpha.radians(),
-                self.beta.radians(),
-                self.gamma.radians(),
-            ),
-            phantom: PhantomData,
-        }
-    }
-}
-#[derive(Component)]
-pub struct CameraComponent {
-    camera_rig: CameraRig,
+pub struct CameraOptions {
+    setup: CameraSetup,
     speed: f32,
     rotation_speed: Angle,
-    setup: CameraSetup,
+}
+
+impl CameraOptions {
+    fn new(
+        setup: &CameraSetup,
+        camera_transform: &mut GlobalTransform,
+        speed: f32,
+        rotation_speed: Angle,
+    ) -> Self {
+        let camera_options = Self {
+            setup: setup.clone(),
+            speed,
+            rotation_speed,
+        };
+        camera_options.setup_camera_transform(camera_transform);
+        camera_options
+
+        //let forward = (setup.look_at - setup.eye).normalize();
+        //
+        //let (yaw, pitch, _roll) = vector_to_euler(forward);
+        //
+        //assert!(yaw <= std::f32::consts::TAU);
+        //assert!(yaw >= 0.0);
+        //
+        //assert!(pitch <= std::f32::consts::PI);
+        //assert!(pitch >= -std::f32::consts::PI);
+        //
+        //CameraRig::builder()
+        //    .with(Position::new(setup.eye))
+        //    .with(
+        //        YawPitch::new()
+        //            .yaw_degrees(yaw.to_degrees())
+        //            .pitch_degrees(pitch.to_degrees()),
+        //    )
+        //    .with(Smooth::new_position_rotation(0.2, 0.2))
+        //    .build()
+    }
+
+    fn reset(&self, camera_transform: &mut GlobalTransform) {
+        self.setup_camera_transform(camera_transform);
+    }
+
+    pub fn view_transform(camera_transform: &GlobalTransform) -> GlobalTransform {
+        let eye = camera_transform.translation.as_dvec3();
+        let forward = camera_transform.forward().as_dvec3();
+
+        let world2view = DMat4::look_at_rh(eye, eye + forward, camera_transform.up().as_dvec3());
+        let (_scale, rotation, translation) = world2view.to_scale_rotation_translation();
+
+        let mut view_transform = GlobalTransform::identity();
+        view_transform.translation = translation.as_vec3();
+        view_transform.rotation = rotation.as_f32();
+
+        view_transform
+    }
+
+    fn setup_camera_transform(&self, camera_transform: &mut GlobalTransform) {
+        let forward = self.setup.look_at - self.setup.eye;
+        let (yaw, pitch) = dir_to_yaw_pitch(forward);
+        camera_transform.rotation = Quat::from_euler(EulerRot::YZX, 0.0, yaw, pitch);
+        camera_transform.translation = self.setup.eye;
+    }
+}
+
+impl Default for CameraOptions {
+    fn default() -> Self {
+        let setup = CameraSetup {
+            eye: Vec3::new(0.0, -2.0, 1.0),
+            look_at: Vec3::ZERO,
+        };
+
+        Self {
+            speed: 2.5,
+            rotation_speed: Angle::from_degrees(40.0),
+            setup,
+        }
+    }
+}
+
+fn dir_to_yaw_pitch(dir: Vec3) -> (f32, f32) {
+    let yaw = std::f32::consts::PI - (dir.x).atan2(-dir.y);
+    let dir_no_yaw = Mat3::from_rotation_z(yaw) * dir;
+    let pitch = (dir_no_yaw.y).atan2(-dir_no_yaw.z);
+    (yaw, pitch)
+}
+
+#[derive(Component)]
+pub struct CameraComponent {
     fov_y: Angle,
     z_near: f32,
     z_far: f32,
@@ -100,18 +114,6 @@ pub struct CameraComponent {
 }
 
 impl CameraComponent {
-    pub fn position(&self) -> Vec3 {
-        self.camera_rig.final_transform.position
-    }
-
-    pub fn rotation(&self) -> Quat {
-        self.camera_rig.final_transform.rotation
-    }
-
-    pub fn final_transform(&self) -> Transform<RightHanded> {
-        self.camera_rig.final_transform
-    }
-
     pub fn fov_y(&self) -> Angle {
         self.fov_y
     }
@@ -127,44 +129,11 @@ impl CameraComponent {
     pub fn render_object_id(&self) -> Option<RenderObjectId> {
         self.render_object_id
     }
-
-    fn build_rig(setup: &CameraSetup) -> CameraRig {
-        let forward = (setup.look_at - setup.eye).normalize();
-        let forward_dot = forward.dot(UP_VECTOR);
-        let right = if (forward_dot - 1.0).abs() < std::f32::EPSILON {
-            Vec3::new(-1.0, 0.0, 0.0)
-        } else if (forward_dot + 1.0).abs() < std::f32::EPSILON {
-            Vec3::new(1.0, 0.0, 0.0)
-        } else {
-            forward.cross(UP_VECTOR).normalize()
-        };
-        let up = right.cross(forward);
-        let rotation = Quat::from_mat3(&Mat3::from_cols(right, up, -forward));
-
-        CameraRig::builder()
-            .with(Position::new(setup.eye))
-            .with(EulerRotator::new(EulerRot::YZX).rotation_quat(rotation))
-            .with(Smooth::new_position_rotation(0.2, 0.2))
-            .build()
-    }
-
-    fn reset(&mut self) {
-        self.camera_rig = Self::build_rig(&self.setup);
-    }
 }
 
 impl Default for CameraComponent {
     fn default() -> Self {
-        let setup = CameraSetup {
-            eye: Vec3::new(0.0, 2.0, 1.0),
-            look_at: Vec3::ZERO,
-        };
-
         Self {
-            camera_rig: Self::build_rig(&setup),
-            speed: 2.5,
-            rotation_speed: Angle::from_degrees(40.0),
-            setup,
             fov_y: Angle::from_radians(std::f32::consts::FRAC_PI_4),
             z_near: 0.01,
             z_far: 100.0,
@@ -173,10 +142,15 @@ impl Default for CameraComponent {
     }
 }
 
-pub(crate) fn tmp_create_camera(mut commands: Commands<'_, '_>) {
+pub(crate) fn tmp_create_camera(
+    mut commands: Commands<'_, '_>,
+    camera_options: Res<'_, CameraOptions>,
+) {
+    let mut camera_transform = GlobalTransform::default();
+    camera_options.reset(&mut camera_transform);
     commands
         .spawn()
-        .insert_bundle((GlobalTransform::default(), CameraComponent::default()));
+        .insert_bundle((camera_transform, CameraComponent::default()));
 }
 
 #[derive(Component, Default)]
@@ -184,14 +158,14 @@ pub(crate) struct CameraSetupApplied(); // marker component
 
 pub(crate) fn apply_camera_setups(
     camera_setups: Query<'_, '_, (Entity, &CameraSetup), Without<CameraSetupApplied>>,
-    mut cameras: Query<'_, '_, &mut CameraComponent>,
+    mut cameras: Query<'_, '_, &mut GlobalTransform, With<CameraComponent>>,
     mut commands: Commands<'_, '_>,
+    mut camera_options: ResMut<'_, CameraOptions>,
 ) {
     for (entity, setup) in camera_setups.iter() {
-        if let Some(mut camera) = cameras.iter_mut().next() {
-            let camera = camera.as_mut();
-            camera.setup = setup.clone();
-            camera.reset();
+        if let Some(mut transform) = cameras.iter_mut().next() {
+            camera_options.setup = setup.clone();
+            camera_options.reset(transform.as_mut());
         }
         commands
             .entity(entity)
@@ -201,9 +175,32 @@ pub(crate) fn apply_camera_setups(
     drop(camera_setups);
 }
 
+pub struct CameraRotation {
+    pub yaw: f32,
+    pub pitch: f32,
+}
+
+impl CameraRotation {
+    pub fn rotate_yaw_pitch(&mut self, yaw: f32, pitch: f32) {
+        self.yaw += yaw;
+        self.pitch += pitch;
+        self.yaw = (self.yaw + yaw) % std::f32::consts::TAU;
+        self.pitch = (self.pitch + pitch).clamp(0.0, std::f32::consts::PI);
+    }
+}
+
+impl Default for CameraRotation {
+    fn default() -> Self {
+        CameraRotation {
+            yaw: std::f32::consts::PI,
+            pitch: std::f32::consts::FRAC_PI_2,
+        }
+    }
+}
+
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub(crate) fn camera_control(
-    mut cameras_query: Query<'_, '_, &mut CameraComponent>,
+    mut cameras_query: Query<'_, '_, &mut GlobalTransform, With<CameraComponent>>,
     mut mouse_motion_events: EventReader<'_, '_, MouseMotion>,
     mut mouse_wheel_events: EventReader<'_, '_, MouseWheel>,
     mouse_buttons: Res<'_, Input<MouseButton>>,
@@ -211,6 +208,8 @@ pub(crate) fn camera_control(
     gamepads: Res<'_, Gamepads>,
     gamepad_axes: Res<'_, Axis<GamepadAxis>>,
     gamepad_buttons: Res<'_, Input<GamepadButton>>,
+    mut camera_options: ResMut<'_, CameraOptions>,
+    mut camera_rotation: Local<'_, CameraRotation>,
 
     time: Res<'_, Time>,
 ) {
@@ -218,8 +217,8 @@ pub(crate) fn camera_control(
         return;
     }
     // Need to associate inputs with window/camera... we don''t have that for now
-    for mut camera in cameras_query.iter_mut() {
-        let camera = camera.as_mut();
+    for mut transform in cameras_query.iter_mut() {
+        let transform = transform.as_mut();
 
         if keys.pressed(KeyCode::Z)
             && !keys.any_pressed([
@@ -229,7 +228,7 @@ pub(crate) fn camera_control(
                 KeyCode::RControl,
             ])
         {
-            camera.reset();
+            camera_options.reset(transform);
             continue;
         }
 
@@ -255,34 +254,33 @@ pub(crate) fn camera_control(
             let mut camera_translation_change = Vec3::ZERO;
 
             if keys.pressed(KeyCode::W) {
-                camera_translation_change += camera.camera_rig.final_transform.forward();
+                camera_translation_change += transform.forward();
             }
             if keys.pressed(KeyCode::S) {
-                camera_translation_change -= camera.camera_rig.final_transform.forward();
+                camera_translation_change -= transform.forward();
             }
             if keys.pressed(KeyCode::A) {
-                camera_translation_change -= camera.camera_rig.final_transform.right();
+                camera_translation_change -= transform.right();
             }
             if keys.pressed(KeyCode::D) {
-                camera_translation_change += camera.camera_rig.final_transform.right();
+                camera_translation_change += transform.right();
             }
 
             if let Some(gamepad) = gamepad {
                 if let Some(left_x) =
                     gamepad_axes.get(GamepadAxis(gamepad, GamepadAxisType::LeftStickX))
                 {
-                    camera_translation_change += left_x * camera.camera_rig.final_transform.right();
+                    camera_translation_change += left_x * transform.right();
                 }
 
                 if let Some(left_y) =
                     gamepad_axes.get(GamepadAxis(gamepad, GamepadAxisType::LeftStickY))
                 {
-                    camera_translation_change +=
-                        left_y * camera.camera_rig.final_transform.forward();
+                    camera_translation_change += left_y * transform.forward();
                 }
             }
 
-            let mut speed = camera.speed.exp();
+            let mut speed = camera_options.speed.exp();
             if let Some(gamepad) = gamepad {
                 if gamepad_buttons.pressed(GamepadButton(gamepad, GamepadButtonType::RightTrigger2))
                 {
@@ -294,19 +292,23 @@ pub(crate) fn camera_control(
             }
             camera_translation_change *= speed * time.delta_seconds();
 
-            camera
-                .camera_rig
-                .driver_mut::<Position>()
-                .translate(camera_translation_change);
+            transform.translation += camera_translation_change;
 
-            let rotation_speed = camera.rotation_speed;
-            let camera_driver = camera.camera_rig.driver_mut::<EulerRotator>();
+            let rotation_speed = camera_options.rotation_speed;
             for mouse_motion_event in mouse_motion_events.iter() {
-                let rotation = (rotation_speed.degrees() * time.delta_seconds()).min(10.0); // clamping rotation speed for when it's laggy
-                camera_driver.rotate(
-                    Angle::from_degrees(0.0),
-                    Angle::from_degrees(mouse_motion_event.delta.x * rotation),
-                    Angle::from_degrees(-mouse_motion_event.delta.y * rotation),
+                let rotation = (rotation_speed.degrees() * time.delta_seconds())
+                    .min(10.0)
+                    .to_radians(); // clamping rotation speed for when it's laggy
+
+                camera_rotation.rotate_yaw_pitch(
+                    -mouse_motion_event.delta.x * rotation,
+                    -mouse_motion_event.delta.y * rotation,
+                );
+                transform.rotation = Quat::from_euler(
+                    EulerRot::YZX,
+                    0.0,
+                    camera_rotation.yaw,
+                    camera_rotation.pitch,
                 );
             }
             for mouse_wheel_event in mouse_wheel_events.iter() {
@@ -317,10 +319,9 @@ pub(crate) fn camera_control(
                     // Last time I tested one segment of a wheel would yield 250 pixels,
                     MouseScrollUnit::Pixel => -mouse_wheel_event.y / 1000.0,
                 };
-                camera.speed = (camera.speed + speed_change).clamp(0.0, 10.0);
+                camera_options.speed = (camera_options.speed + speed_change).clamp(0.0, 10.0);
             }
         }
-        camera.camera_rig.update(time.delta_seconds());
     }
 }
 
@@ -387,5 +388,31 @@ pub(crate) fn reflect_camera_components(
         for (e, visual) in queries.p1().iter() {
             map.insert(e, visual.render_object_id.unwrap());
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use lgn_math::{EulerRot, Mat3, Quat, Vec3};
+
+    use crate::{components::camera_component::dir_to_euler, DOWN_VECTOR};
+
+    #[test]
+    fn camera() {
+        let default_rotation = Quat::from_mat3(&Mat3::IDENTITY);
+        assert_eq!(default_rotation, Quat::from_xyzw(0.0, 0.0, 0.0, 1.0));
+        assert_eq!(default_rotation.to_euler(EulerRot::YXZ), (0.0, 0.0, 0.0));
+
+        let pitch_90 = Quat::from_mat3(&Mat3::from_cols_array(&[
+            1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0,
+        ]));
+        let (yaw, pitch, roll) = pitch_90.to_euler(EulerRot::YXZ);
+        assert!(yaw.abs() < f32::EPSILON);
+        assert!((pitch - std::f32::consts::FRAC_PI_2).abs() < 0.003); // It seems like to_euler() is not very precise so not using f32::EPSILON
+        assert!(roll.abs() < f32::EPSILON);
+
+        //let eye = Vec3::new(0.0, -2.0, 1.0);
+        //let look_at = Vec3::ZERO;
+        assert_eq!(dir_to_euler(DOWN_VECTOR), (0.0, 0.0, 0.0));
     }
 }

--- a/crates/lgn-graphics-renderer/src/components/camera_component.rs
+++ b/crates/lgn-graphics-renderer/src/components/camera_component.rs
@@ -37,7 +37,7 @@ impl CameraOptions {
 impl Default for CameraOptions {
     fn default() -> Self {
         let setup = CameraSetup {
-            eye: Vec3::new(0.0, 2.0, -1.0),
+            eye: Vec3::new(0.0, -2.0, 1.0),
             look_at: Vec3::ZERO,
         };
 
@@ -233,13 +233,6 @@ pub(crate) fn camera_control(
                 let yaw = (yaw - delta_yaw) % std::f32::consts::TAU;
                 let pitch = (pitch - delta_pitch)
                     .clamp(std::f32::EPSILON, std::f32::consts::PI - std::f32::EPSILON);
-                lgn_tracing::info!(
-                    "y_p: {:.2} {:.2}, dy: {:.2}, forward: {}",
-                    yaw.to_degrees(),
-                    pitch.to_degrees(),
-                    delta_yaw.to_degrees(),
-                    transform.forward()
-                );
                 transform.rotation = Quat::from_euler(EulerRot::YZX, 0.0, yaw, pitch);
             }
             for mouse_wheel_event in mouse_wheel_events.iter() {

--- a/crates/lgn-graphics-renderer/src/components/camera_component.rs
+++ b/crates/lgn-graphics-renderer/src/components/camera_component.rs
@@ -9,7 +9,7 @@ use lgn_input::{
         Axis, GamepadAxis, GamepadAxisType, GamepadButton, Gamepads, Input, KeyCode, MouseButton,
     },
 };
-use lgn_math::{Angle, DMat4, EulerRot, Mat3, Quat, Vec3};
+use lgn_math::{Angle, EulerRot, Mat3, Quat, Vec3};
 use lgn_transform::components::GlobalTransform;
 use lgn_utils::HashMap;
 
@@ -24,20 +24,6 @@ pub struct CameraOptions {
 impl CameraOptions {
     fn reset(&self, camera_transform: &mut GlobalTransform) {
         self.setup_camera_transform(camera_transform);
-    }
-
-    pub fn view_transform(camera_transform: &GlobalTransform) -> GlobalTransform {
-        let eye = camera_transform.translation.as_dvec3();
-        let forward = camera_transform.forward().as_dvec3();
-
-        let world2view = DMat4::look_at_rh(eye, eye + forward, camera_transform.up().as_dvec3());
-        let (_scale, rotation, translation) = world2view.to_scale_rotation_translation();
-
-        let mut view_transform = GlobalTransform::identity();
-        view_transform.translation = translation.as_vec3();
-        view_transform.rotation = rotation.as_f32();
-
-        view_transform
     }
 
     fn setup_camera_transform(&self, camera_transform: &mut GlobalTransform) {

--- a/crates/lgn-graphics-renderer/src/core/services/cameras.rs
+++ b/crates/lgn-graphics-renderer/src/core/services/cameras.rs
@@ -2,7 +2,7 @@ use lgn_graphics_cgen_runtime::Float4;
 use lgn_math::{Angle, DMat4, Mat4, Vec2, Vec4};
 use lgn_transform::prelude::GlobalTransform;
 
-use crate::{cgen, components::CameraComponent, UP_VECTOR};
+use crate::{cgen, components::CameraComponent};
 
 pub fn view_transform(camera_transform: &GlobalTransform) -> GlobalTransform {
     let eye = camera_transform.translation.as_dvec3();

--- a/crates/lgn-graphics-renderer/src/lib.rs
+++ b/crates/lgn-graphics-renderer/src/lib.rs
@@ -14,8 +14,8 @@ mod cgen {
 
 use crate::components::{
     reflect_camera_components, reflect_viewports, reflect_visual_components, tmp_create_camera,
-    tmp_debug_display_lights, EcsToRenderCamera, EcsToRenderLight, EcsToRenderViewport,
-    EcsToRenderVisual,
+    tmp_debug_display_lights, CameraOptions, EcsToRenderCamera, EcsToRenderLight,
+    EcsToRenderViewport, EcsToRenderVisual,
 };
 use crate::core::{
     RenderCamera, RenderCommandQueuePool, RenderFeatures, RenderFeaturesBuilder,
@@ -327,6 +327,7 @@ impl Plugin for RendererPlugin {
             .insert_resource(shared_resources_manager)
             .insert_resource(texture_manager)
             .insert_resource(RendererOptions::default())
+            .insert_resource(CameraOptions::default())
             .insert_resource(picking_manager.clone());
 
         // Init ecs

--- a/crates/lgn-graphics-renderer/src/picking/manipulator.rs
+++ b/crates/lgn-graphics-renderer/src/picking/manipulator.rs
@@ -112,13 +112,14 @@ fn intersect_ray_with_plane(
 
 pub(super) fn new_world_point_for_cursor(
     camera: &CameraComponent,
+    camera_transform: &GlobalTransform,
     screen_size: Vec2,
     mut cursor_pos: Vec2,
     plane_point: Vec3,
     plane_normal: Vec3,
 ) -> Vec3 {
     cursor_pos.y = screen_size.y - cursor_pos.y;
-    let camera_pos = camera.position();
+    let camera_pos = camera_transform.translation;
     let ray_point = camera_pos;
     let screen_offset = 2.0 * (cursor_pos / screen_size) - 1.0;
     let screen_pos = Vec4::new(screen_offset.x, screen_offset.y, 0.5, 1.0);
@@ -132,7 +133,7 @@ pub(super) fn new_world_point_for_cursor(
     let mut view_pos = projection_matrix.inverse().mul_vec4(screen_pos);
     view_pos /= view_pos.w;
 
-    let view_matrix = view_transform(&camera.final_transform()).compute_matrix();
+    let view_matrix = view_transform(camera_transform).compute_matrix();
     let world_pos = view_matrix.inverse().mul_vec4(view_pos);
 
     let ray_dir = (world_pos.xyz() - camera_pos).normalize();
@@ -143,10 +144,9 @@ pub(super) fn new_world_point_for_cursor(
 pub(super) fn plane_normal_for_camera_pos(
     component: AxisComponents,
     base_entity_transform: &GlobalTransform,
-    camera: &CameraComponent,
+    camera_pos: Vec3,
     rotation: Quat,
 ) -> Vec3 {
-    let camera_pos = camera.position();
     let dir_to_camera = (camera_pos - base_entity_transform.translation).normalize();
 
     let xy_plane_normal = rotation.mul_vec3(Vec3::Z);
@@ -270,6 +270,7 @@ impl ManipulatorManager {
         base_global_transform: &GlobalTransform,
         parent_global_transform: &GlobalTransform,
         camera: &CameraComponent,
+        camera_transform: &GlobalTransform,
         picked_pos: Vec2,
         screen_size: Vec2,
         cursor_pos: Vec2,
@@ -283,6 +284,7 @@ impl ManipulatorManager {
                 base_global_transform,
                 parent_global_transform,
                 camera,
+                camera_transform,
                 picked_pos,
                 screen_size,
                 cursor_pos,
@@ -293,6 +295,7 @@ impl ManipulatorManager {
                 base_global_transform,
                 parent_global_transform,
                 camera,
+                camera_transform,
                 picked_pos,
                 screen_size,
                 cursor_pos,
@@ -303,6 +306,7 @@ impl ManipulatorManager {
                 base_global_transform,
                 parent_global_transform,
                 camera,
+                camera_transform,
                 picked_pos,
                 screen_size,
                 cursor_pos,

--- a/crates/lgn-graphics-renderer/src/picking/picking_plugin.rs
+++ b/crates/lgn-graphics-renderer/src/picking/picking_plugin.rs
@@ -160,7 +160,7 @@ fn update_manipulator_component(
     q_cameras: Query<
         '_,
         '_,
-        &CameraComponent,
+        (&CameraComponent, &GlobalTransform),
         (Without<PickedComponent>, Without<ManipulatorComponent>),
     >,
     render_surfaces: Res<'_, RenderSurfaces>,
@@ -221,7 +221,9 @@ fn update_manipulator_component(
                 let (base_local_transform, base_global_transform) =
                     picking_manager.base_picking_transforms();
 
-                let q_cameras = q_cameras.iter().collect::<Vec<&CameraComponent>>();
+                let q_cameras = q_cameras
+                    .iter()
+                    .collect::<Vec<(&CameraComponent, &GlobalTransform)>>();
                 if !q_cameras.is_empty() {
                     for render_surface in render_surfaces.iter() {
                         let mut screen_rect = picking_manager.screen_rect();
@@ -244,7 +246,8 @@ fn update_manipulator_component(
                             &base_local_transform,
                             &base_global_transform,
                             &parent_global_transform,
-                            q_cameras[0],
+                            q_cameras[0].0,
+                            q_cameras[0].1,
                             picking_manager.picked_pos(),
                             screen_rect,
                             picking_manager.current_cursor_pos(),

--- a/crates/lgn-graphics-renderer/src/picking/position_manipulator.rs
+++ b/crates/lgn-graphics-renderer/src/picking/position_manipulator.rs
@@ -141,18 +141,35 @@ impl PositionManipulator {
         base_global_transform: &GlobalTransform,
         parent_global_transform: &GlobalTransform,
         camera: &CameraComponent,
+        camera_transform: &GlobalTransform,
         picked_pos: Vec2,
         screen_size: Vec2,
         cursor_pos: Vec2,
     ) -> Transform {
         let plane_point = base_global_transform.translation;
-        let plane_normal =
-            plane_normal_for_camera_pos(component, base_global_transform, camera, Quat::IDENTITY);
+        let plane_normal = plane_normal_for_camera_pos(
+            component,
+            base_global_transform,
+            camera_transform.translation,
+            Quat::IDENTITY,
+        );
 
-        let picked_world_point =
-            new_world_point_for_cursor(camera, screen_size, picked_pos, plane_point, plane_normal);
-        let new_world_point =
-            new_world_point_for_cursor(camera, screen_size, cursor_pos, plane_point, plane_normal);
+        let picked_world_point = new_world_point_for_cursor(
+            camera,
+            camera_transform,
+            screen_size,
+            picked_pos,
+            plane_point,
+            plane_normal,
+        );
+        let new_world_point = new_world_point_for_cursor(
+            camera,
+            camera_transform,
+            screen_size,
+            cursor_pos,
+            plane_point,
+            plane_normal,
+        );
 
         let delta = new_world_point - picked_world_point;
         let mut clamped_delta = match component {

--- a/crates/lgn-graphics-renderer/src/picking/rotation_manipulator.rs
+++ b/crates/lgn-graphics-renderer/src/picking/rotation_manipulator.rs
@@ -90,6 +90,7 @@ impl RotationManipulator {
         base_global_transform: &GlobalTransform,
         parent_global_transform: &GlobalTransform,
         camera: &CameraComponent,
+        camera_transform: &GlobalTransform,
         picked_pos: Vec2,
         screen_size: Vec2,
         cursor_pos: Vec2,
@@ -101,13 +102,25 @@ impl RotationManipulator {
             RotationComponents::ZAxis => Vec3::Z,
         };
 
-        let picked_world_point =
-            new_world_point_for_cursor(camera, screen_size, picked_pos, plane_point, plane_normal);
+        let picked_world_point = new_world_point_for_cursor(
+            camera,
+            camera_transform,
+            screen_size,
+            picked_pos,
+            plane_point,
+            plane_normal,
+        );
         let dir_to_picked_point =
             (picked_world_point - base_global_transform.translation).normalize();
 
-        let new_world_point =
-            new_world_point_for_cursor(camera, screen_size, cursor_pos, plane_point, plane_normal);
+        let new_world_point = new_world_point_for_cursor(
+            camera,
+            camera_transform,
+            screen_size,
+            cursor_pos,
+            plane_point,
+            plane_normal,
+        );
         let dir_to_new_point = (new_world_point - base_global_transform.translation).normalize();
 
         let initial_rotation = Mat3::from_quat(base_global_transform.rotation);

--- a/crates/lgn-graphics-renderer/src/picking/scale_manipulator.rs
+++ b/crates/lgn-graphics-renderer/src/picking/scale_manipulator.rs
@@ -141,6 +141,7 @@ impl ScaleManipulator {
         base_global_transform: &GlobalTransform,
         parent_global_transform: &GlobalTransform,
         camera: &CameraComponent,
+        camera_transform: &GlobalTransform,
         picked_pos: Vec2,
         screen_size: Vec2,
         cursor_pos: Vec2,
@@ -149,16 +150,32 @@ impl ScaleManipulator {
         let inv_entity_rotation = base_global_transform.rotation.inverse();
 
         let plane_point = base_global_transform.translation;
-        let plane_normal =
-            plane_normal_for_camera_pos(component, base_global_transform, camera, entity_rotation);
+        let plane_normal = plane_normal_for_camera_pos(
+            component,
+            base_global_transform,
+            camera_transform.translation,
+            entity_rotation,
+        );
 
-        let picked_world_point =
-            new_world_point_for_cursor(camera, screen_size, picked_pos, plane_point, plane_normal);
+        let picked_world_point = new_world_point_for_cursor(
+            camera,
+            camera_transform,
+            screen_size,
+            picked_pos,
+            plane_point,
+            plane_normal,
+        );
         let vec_to_picked_point =
             inv_entity_rotation.mul_vec3(picked_world_point - base_global_transform.translation);
 
-        let new_world_point =
-            new_world_point_for_cursor(camera, screen_size, cursor_pos, plane_point, plane_normal);
+        let new_world_point = new_world_point_for_cursor(
+            camera,
+            camera_transform,
+            screen_size,
+            cursor_pos,
+            plane_point,
+            plane_normal,
+        );
         let vec_to_new_point =
             inv_entity_rotation.mul_vec3(new_world_point - base_global_transform.translation);
 


### PR DESCRIPTION
Removed dependency on dolly. Transform is now taken from a GlobalTransform of the entity that has CameraComponent. CameraOptions resource is introduced that holds default camera setup and speed.

The camera movement is no longer smoothed.