### PR TITLE
[telemetry] Add common telemetry types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5398,6 +5398,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lgn-telemetry"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "http",
+ "hyper",
+ "lgn-api-codegen",
+ "lgn-online",
+ "lgn-tracing",
+ "serde",
+ "serde_qs",
+]
+
+[[package]]
 name = "lgn-telemetry-proto"
 version = "0.1.0"
 dependencies = [

--- a/crates/lgn-telemetry/Cargo.toml
+++ b/crates/lgn-telemetry/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "lgn-telemetry"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lgn-online = { path = "../lgn-online", version = "0.1.0" }
+lgn-tracing = { path = "../lgn-tracing", version = "0.1.0" }
+async-trait = "0.1"
+axum = "0.5"
+http = "0.2"
+chrono = "0.4"
+hyper = { version = "0.14", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_qs = { version = "0.9", features = ["axum"] }
+
+[build-dependencies]
+lgn-api-codegen = { path = "../lgn-api-codegen", version = "0.1.0" }

--- a/crates/lgn-telemetry/apis/components.yaml
+++ b/crates/lgn-telemetry/apis/components.yaml
@@ -1,0 +1,204 @@
+openapi: 3.0.3
+info:
+  title: "Telemetry API components"
+  description: "The common telemetry API components"
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Block:
+      description: The block.
+      type: object
+      properties:
+        block_id:
+          type: string
+        stream_id:
+          type: string
+        begin_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        begin_ticks:
+          type: integer
+          format: int64
+        end_ticks:
+          type: integer
+          format: int64
+        nb_objects:
+          type: integer
+        payload:
+          $ref: "#/components/schemas/BlockPayload"
+      required:
+        - block_id
+        - stream_id
+        - begin_time
+        - end_time
+        - begin_ticks
+        - end_ticks
+        - nb_objects
+    BlockPayload:
+      description: The block payload.
+      type: object
+      properties:
+        dependencies:
+          type: string
+          format: byte
+        objects:
+          type: string
+          format: byte
+      required:
+        - dependencies
+        - objects
+    BlockMetadata:
+      description: The block metadata.
+      type: object
+      properties:
+        block_id:
+          type: string
+        stream_id:
+          type: string
+        begin_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+        begin_ticks:
+          type: integer
+          format: int64
+        end_ticks:
+          type: integer
+          format: int64
+        nb_objects:
+          type: integer
+        payload_size:
+          type: integer
+          format: int64
+      required:
+        - block_id
+        - stream_id
+        - begin_time
+        - end_time
+        - begin_ticks
+        - end_ticks
+        - nb_objects
+        - payload_size
+    Process:
+      description: The process.
+      type: object
+      properties:
+        process_id:
+          type: string
+        exe:
+          type: string
+        username:
+          type: string
+        realname:
+          type: string
+        computer:
+          type: string
+        distro:
+          type: string
+        cpu_brand:
+          type: string
+        tsc_frequency:
+          type: integer
+          format: int64
+          minimum: 0
+        start_time:
+          type: string
+          format: date-time
+        start_ticks:
+          type: integer
+          format: int64
+        parent_process_id:
+          type: string
+      required:
+        - process_id
+        - exe
+        - username
+        - realname
+        - computer
+        - distro
+        - cpu_brand
+        - tsc_frequency
+        - start_time
+        - start_ticks
+        - parent_process_id
+    Stream:
+      description: The stream.
+      type: object
+      properties:
+        stream_id:
+          type: string
+        process_id:
+          type: string
+        dependencies_metadata:
+          $ref: "#/components/schemas/ContainerMetadata"
+        objects_metadata:
+          $ref: "#/components/schemas/ContainerMetadata"
+        tags:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: string
+      required:
+        - stream_id
+        - process_id
+        - tags
+        - properties
+    ContainerMetadata:
+      description: The container metadata.
+      type: object
+      properties:
+        types:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserDefinedType"
+      required:
+        - types
+    UserDefinedType:
+      description: The user defined type.
+      type: object
+      properties:
+        name:
+          type: string
+        size:
+          type: integer
+          minimum: 0
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/UdtMember"
+        is_reference:
+          type: boolean
+      required:
+        - name
+        - size
+        - members
+        - is_reference
+    UdtMember:
+      description: The user defined type member.
+      type: object
+      properties:
+        name:
+          type: string
+        type_name:
+          type: string
+        offset:
+          type: integer
+          minimum: 0
+        size:
+          type: integer
+          minimum: 0
+        is_reference:
+          type: boolean
+      required:
+        - name
+        - type_name
+        - offset
+        - size
+        - is_reference

--- a/crates/lgn-telemetry/build.rs
+++ b/crates/lgn-telemetry/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let options = lgn_api_codegen::RustOptions::default();
+
+    lgn_api_codegen::generate!(
+        lgn_api_codegen::Language::Rust(options),
+        "apis",
+        ["components"]
+    );
+}

--- a/crates/lgn-telemetry/src/api.rs
+++ b/crates/lgn-telemetry/src/api.rs
@@ -1,0 +1,6 @@
+#![allow(dead_code)]
+#![allow(unused_mut)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
+lgn_online::include_api!();

--- a/crates/lgn-telemetry/src/lib.rs
+++ b/crates/lgn-telemetry/src/lib.rs
@@ -1,0 +1,3 @@
+//! telemetry api common components
+pub mod api;
+mod types;

--- a/crates/lgn-telemetry/src/types/block.rs
+++ b/crates/lgn-telemetry/src/types/block.rs
@@ -1,0 +1,107 @@
+#[derive(Clone, PartialEq)]
+pub struct Block {
+    pub block_id: String,
+    pub stream_id: String,
+    pub begin_time: chrono::DateTime<chrono::Utc>,
+    pub end_time: chrono::DateTime<chrono::Utc>,
+    pub begin_ticks: i64,
+    pub end_ticks: i64,
+    pub payload: Option<BlockPayload>,
+    pub nb_objects: i32,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct BlockPayload {
+    pub dependencies: Vec<u8>,
+    pub objects: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct BlockMetadata {
+    pub block_id: String,
+    pub stream_id: String,
+    pub begin_time: chrono::DateTime<chrono::Utc>,
+    pub end_time: chrono::DateTime<chrono::Utc>,
+    pub begin_ticks: i64,
+    pub end_ticks: i64,
+    pub nb_objects: i32,
+    pub payload_size: i64,
+}
+
+impl From<crate::api::components::Block> for Block {
+    fn from(block: crate::api::components::Block) -> Self {
+        Block {
+            block_id: block.block_id,
+            stream_id: block.stream_id,
+            begin_time: block.begin_time,
+            end_time: block.end_time,
+            begin_ticks: block.begin_ticks,
+            end_ticks: block.end_ticks,
+            payload: block.payload.map(Into::into),
+            nb_objects: block.nb_objects,
+        }
+    }
+}
+
+impl From<Block> for crate::api::components::Block {
+    fn from(block: Block) -> Self {
+        crate::api::components::Block {
+            block_id: block.block_id,
+            stream_id: block.stream_id,
+            begin_time: block.begin_time,
+            end_time: block.end_time,
+            begin_ticks: block.begin_ticks,
+            end_ticks: block.end_ticks,
+            payload: block.payload.map(Into::into),
+            nb_objects: block.nb_objects,
+        }
+    }
+}
+
+impl From<crate::api::components::BlockPayload> for BlockPayload {
+    fn from(payload: crate::api::components::BlockPayload) -> Self {
+        BlockPayload {
+            dependencies: payload.dependencies.into(),
+            objects: payload.objects.into(),
+        }
+    }
+}
+
+impl From<BlockPayload> for crate::api::components::BlockPayload {
+    fn from(payload: BlockPayload) -> Self {
+        crate::api::components::BlockPayload {
+            dependencies: payload.dependencies.into(),
+            objects: payload.objects.into(),
+        }
+    }
+}
+
+impl From<crate::api::components::BlockMetadata> for BlockMetadata {
+    fn from(metadata: crate::api::components::BlockMetadata) -> Self {
+        BlockMetadata {
+            block_id: metadata.block_id,
+            stream_id: metadata.stream_id,
+            begin_time: metadata.begin_time,
+            end_time: metadata.end_time,
+            begin_ticks: metadata.begin_ticks,
+            end_ticks: metadata.end_ticks,
+            nb_objects: metadata.nb_objects,
+            payload_size: metadata.payload_size,
+        }
+    }
+}
+
+impl From<BlockMetadata> for crate::api::components::BlockMetadata {
+    fn from(metadata: BlockMetadata) -> Self {
+        crate::api::components::BlockMetadata {
+            block_id: metadata.block_id,
+            stream_id: metadata.stream_id,
+            begin_time: metadata.begin_time,
+            end_time: metadata.end_time,
+            begin_ticks: metadata.begin_ticks,
+            end_ticks: metadata.end_ticks,
+            nb_objects: metadata.nb_objects,
+            payload_size: metadata.payload_size,
+        }
+    }
+}

--- a/crates/lgn-telemetry/src/types/mod.rs
+++ b/crates/lgn-telemetry/src/types/mod.rs
@@ -1,0 +1,7 @@
+mod block;
+mod process;
+mod stream;
+
+pub use block::{Block, BlockMetadata, BlockPayload};
+pub use process::Process;
+pub use stream::{ContainerMetadata, Stream, UdtMember, UserDefinedType};

--- a/crates/lgn-telemetry/src/types/process.rs
+++ b/crates/lgn-telemetry/src/types/process.rs
@@ -1,0 +1,50 @@
+#[derive(Clone, PartialEq)]
+pub struct Process {
+    pub process_id: String,
+    pub exe: String,
+    pub username: String,
+    pub realname: String,
+    pub computer: String,
+    pub distro: String,
+    pub cpu_brand: String,
+    pub tsc_frequency: u64,
+    pub start_time: chrono::DateTime<chrono::Utc>,
+    pub start_ticks: i64,
+    pub parent_process_id: String,
+}
+
+impl From<crate::api::components::Process> for Process {
+    fn from(process: crate::api::components::Process) -> Self {
+        Process {
+            process_id: process.process_id,
+            exe: process.exe,
+            username: process.username,
+            realname: process.realname,
+            computer: process.computer,
+            distro: process.distro,
+            cpu_brand: process.cpu_brand,
+            tsc_frequency: process.tsc_frequency,
+            start_time: process.start_time,
+            start_ticks: process.start_ticks,
+            parent_process_id: process.parent_process_id,
+        }
+    }
+}
+
+impl From<Process> for crate::api::components::Process {
+    fn from(process: Process) -> Self {
+        crate::api::components::Process {
+            process_id: process.process_id,
+            exe: process.exe,
+            username: process.username,
+            realname: process.realname,
+            computer: process.computer,
+            distro: process.distro,
+            cpu_brand: process.cpu_brand,
+            tsc_frequency: process.tsc_frequency,
+            start_time: process.start_time,
+            start_ticks: process.start_ticks,
+            parent_process_id: process.parent_process_id,
+        }
+    }
+}

--- a/crates/lgn-telemetry/src/types/stream.rs
+++ b/crates/lgn-telemetry/src/types/stream.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+
+#[derive(Clone, PartialEq)]
+pub struct Stream {
+    pub stream_id: String,
+    pub process_id: String,
+    pub dependencies_metadata: Option<ContainerMetadata>,
+    pub objects_metadata: Option<ContainerMetadata>,
+    pub tags: Vec<String>,
+    pub properties: BTreeMap<String, String>,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct ContainerMetadata {
+    pub types: Vec<UserDefinedType>,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UserDefinedType {
+    pub name: String,
+    pub size: u32,
+    pub members: Vec<UdtMember>,
+    pub is_reference: bool,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UdtMember {
+    pub name: String,
+    pub type_name: String,
+    pub offset: u32,
+    pub size: u32,
+    pub is_reference: bool,
+}
+
+impl From<crate::api::components::Stream> for Stream {
+    fn from(stream: crate::api::components::Stream) -> Self {
+        Self {
+            stream_id: stream.stream_id,
+            process_id: stream.process_id,
+            dependencies_metadata: stream.dependencies_metadata.map(Into::into),
+            objects_metadata: stream.objects_metadata.map(Into::into),
+            tags: stream.tags,
+            properties: stream.__additional_properties,
+        }
+    }
+}
+
+impl From<Stream> for crate::api::components::Stream {
+    fn from(stream: Stream) -> Self {
+        Self {
+            stream_id: stream.stream_id,
+            process_id: stream.process_id,
+            dependencies_metadata: stream.dependencies_metadata.map(Into::into),
+            objects_metadata: stream.objects_metadata.map(Into::into),
+            tags: stream.tags,
+            __additional_properties: stream.properties,
+        }
+    }
+}
+
+impl From<crate::api::components::ContainerMetadata> for ContainerMetadata {
+    fn from(metadata: crate::api::components::ContainerMetadata) -> Self {
+        Self {
+            types: metadata.types.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<ContainerMetadata> for crate::api::components::ContainerMetadata {
+    fn from(metadata: ContainerMetadata) -> Self {
+        Self {
+            types: metadata.types.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<crate::api::components::UserDefinedType> for UserDefinedType {
+    fn from(type_: crate::api::components::UserDefinedType) -> Self {
+        Self {
+            name: type_.name,
+            size: type_.size,
+            members: type_.members.into_iter().map(Into::into).collect(),
+            is_reference: type_.is_reference,
+        }
+    }
+}
+
+impl From<UserDefinedType> for crate::api::components::UserDefinedType {
+    fn from(type_: UserDefinedType) -> Self {
+        Self {
+            name: type_.name,
+            size: type_.size,
+            members: type_.members.into_iter().map(Into::into).collect(),
+            is_reference: type_.is_reference,
+        }
+    }
+}
+
+impl From<crate::api::components::UdtMember> for UdtMember {
+    fn from(member: crate::api::components::UdtMember) -> Self {
+        Self {
+            name: member.name,
+            type_name: member.type_name,
+            offset: member.offset,
+            size: member.size,
+            is_reference: member.is_reference,
+        }
+    }
+}
+
+impl From<UdtMember> for crate::api::components::UdtMember {
+    fn from(member: UdtMember) -> Self {
+        Self {
+            name: member.name,
+            type_name: member.type_name,
+            offset: member.offset,
+            size: member.size,
+            is_reference: member.is_reference,
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `lgn-telemetry` crate where the common types used by the analytics and ingestion servers live.