### PR TITLE
Remove useless Eq and Hash derives

### DIFF
--- a/crates/lgn-api-codegen/src/rust/filters.rs
+++ b/crates/lgn-api-codegen/src/rust/filters.rs
@@ -163,17 +163,6 @@ pub fn join_types(
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
-pub fn fmt_struct_derive(type_: &Option<Box<Type>>) -> ::askama::Result<String> {
-    Ok(match type_ {
-        Some(type_) if matches!(**type_, Type::Any) => {
-            "#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]"
-        }
-        _ => "#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]",
-    }
-    .to_string())
-}
-
 fn is_keyword(name: &str) -> bool {
     KEYWORDS.contains(&name)
 }

--- a/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
+++ b/crates/lgn-api-codegen/src/rust/snapshots/lgn_api_codegen__rust__tests__rust_generation.snap
@@ -10,7 +10,7 @@ pub mod cars {
 
     use lgn_online::codegen::Error;
 
-    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct TestAdditionalPropertiesCompositeAny200Response {
         #[serde(flatten)]
         pub __additional_properties: std::collections::BTreeMap<String, serde_json::Value>,
@@ -24,7 +24,7 @@ pub mod cars {
         pub time: Option<u32>,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct TestAdditionalPropertiesCompositeSchema200Response {
         #[serde(flatten)]
         pub __additional_properties: std::collections::BTreeMap<String, super::components::Pet>,
@@ -38,7 +38,7 @@ pub mod cars {
         pub time: Option<u32>,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub enum TestOneOf200Response {
         #[serde(rename = "option1")]
         Option1(super::components::Pet),
@@ -635,7 +635,7 @@ pub mod cars {
 
         // Request type.
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct TestHeadersRequest {
             pub x_string_header: Option<String>,
             pub x_bytes_header: Option<lgn_online::codegen::Bytes>,
@@ -814,7 +814,7 @@ pub mod cars {
             }
         }
 
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
         struct GetCarsQuery {
             #[serde(rename = "other_query")]
             other_query: String,
@@ -828,7 +828,7 @@ pub mod cars {
 
         // Request type.
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct GetCarsRequest {
             pub space_id: String,
             pub other_query: String,
@@ -885,7 +885,7 @@ pub mod cars {
 
         // Request type.
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct CreateCarRequest {
             pub space_id: String,
             pub span_id: Option<String>,
@@ -928,7 +928,7 @@ pub mod cars {
 
         // Request type.
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct GetCarRequest {
             pub space_id: String,
             pub car_id: i64,
@@ -993,7 +993,7 @@ pub mod cars {
 
         // Request type.
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct DeleteCarRequest {
             pub space_id: String,
             pub car_id: i64,
@@ -1045,7 +1045,7 @@ pub mod cars {
 
         // Request type.
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct TestBinaryRequest {
             pub space_id: String,
             pub body: lgn_online::codegen::Bytes,
@@ -2788,7 +2788,7 @@ pub mod cars {
             }
         }
 
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
         struct GetCarsQuery {
             #[serde(rename = "other_query")]
             other_query: String,
@@ -3659,14 +3659,14 @@ pub mod components {
 
     use lgn_online::codegen::Error;
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct Alpha {
         #[serde(rename = "beta")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub beta: Option<Beta>,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct Beta(pub Vec<Gamma>);
 
     impl From<Vec<Gamma>> for Beta {
@@ -3675,7 +3675,7 @@ pub mod components {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct Car {
         #[serde(rename = "code")]
         pub code: u32,
@@ -3698,7 +3698,7 @@ pub mod components {
     }
 
     /// The car color.
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub enum CarColor {
         #[serde(rename = "red")]
         Red,
@@ -3764,7 +3764,7 @@ pub mod components {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct Cars(pub Vec<Car>);
 
     impl From<Vec<Car>> for Cars {
@@ -3773,13 +3773,13 @@ pub mod components {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub enum Gamma {
         #[serde(rename = "option1")]
         Option1(Box<Alpha>),
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct Pet {
         #[serde(rename = "name")]
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/client.rs.jinja
@@ -6,7 +6,7 @@ use lgn_tracing::debug;
 {% for (path, routes) in api.paths %}
     {% for route in routes %}
         {% if !route.parameters.query.is_empty() -%}
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             struct {{ route.name|pascal_case }}Query {
                 {% for parameter in route.parameters.query -%}
                     #[serde(rename = "{{ parameter.name }}")]
@@ -25,7 +25,7 @@ use lgn_tracing::debug;
         // Request type.
         {% let request_type = "{}Request"|format(route.name|pascal_case) %}
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq)]
         pub struct {{ request_type }} {
             {% for parameter in route.parameters -%}
                 {%- if parameter.required -%}
@@ -46,7 +46,7 @@ use lgn_tracing::debug;
 
         // Response type.
         {% let response_type = "{}Response"|format(route.name|pascal_case) %}
-        
+
         #[derive(Debug)]
         pub enum {{ response_type }} {
             {% for (status_code, response) in route.responses -%}

--- a/crates/lgn-api-codegen/src/rust/templates/models.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/models.rs.jinja
@@ -4,7 +4,7 @@ use lgn_online::codegen::Error;
     {% if let Some(description) = model.description %}/// {{ description }}{% endif -%}
     {% match model.type_ %}
         {% when Type::Enum with { variants } %}
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             pub enum {{ model|fmt_model_name(ctx) }}
             {
                 {%- for variant in variants -%}
@@ -63,7 +63,7 @@ use lgn_online::codegen::Error;
                 }
             }
         {% when Type::OneOf with { types } %}
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             pub enum {{ model|fmt_model_name(ctx) }}
             {
                 {%- for type_ in types -%}
@@ -72,7 +72,7 @@ use lgn_online::codegen::Error;
                 {%- endfor -%}
             }
         {% when Type::Struct with { fields, map } %}
-            {{ map|fmt_struct_derive }}
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             pub struct {{ model|fmt_model_name(ctx) }} {
                 {% match map %}
                 {% when Some with (map) %}
@@ -92,7 +92,7 @@ use lgn_online::codegen::Error;
                 {% endfor %}
             }
         {% when t %}
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             pub struct {{ model|fmt_model_name(ctx) }}(pub {{ t|fmt_type(ctx, module_path) }});
 
             impl From<{{ t|fmt_type(ctx, module_path) }}> for {{ model|fmt_model_name(ctx) }} {

--- a/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
+++ b/crates/lgn-api-codegen/src/rust/templates/server.rs.jinja
@@ -18,7 +18,7 @@ use lgn_tracing::error;
 {% for (path, routes) in api.paths %}
     {% for route in routes %}
         {% if !route.parameters.query.is_empty() -%}
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             struct {{ route.name|pascal_case }}Query {
                 {% for parameter in route.parameters.query -%}
                     #[serde(rename = "{{ parameter.name }}")]


### PR DESCRIPTION
This PR removes the useless `Eq` and `Hash` from the api codegen.